### PR TITLE
add Forward boolean to Jet DataFormat

### DIFF
--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -18,13 +18,16 @@ namespace l1t {
        int pt=0,
        int eta=0,
        int phi=0,
-       int qual=0);
+       int qual=0,
+       bool forward=false);
   Jet( const PolarLorentzVector& p4,
        int pt=0,
        int eta=0,
        int phi=0,
-       int qual=0);
+       int qual=0,
+       bool forward=false);
 
+  bool forward() const;
 
   ~Jet();
 
@@ -32,6 +35,7 @@ namespace l1t {
 
   // additional hardware quantities common to L1 global jet
   // there are currently none
+  bool forward_;
 
   };
 

--- a/DataFormats/L1Trigger/src/Jet.cc
+++ b/DataFormats/L1Trigger/src/Jet.cc
@@ -5,23 +5,28 @@ l1t::Jet::Jet( const LorentzVector& p4,
 	       int pt,
 	       int eta,
 	       int phi,
-	       int qual )
-  : L1Candidate(p4, pt, eta, phi, qual, 0)
+	       int qual,
+	       bool forward)
+  : L1Candidate(p4, pt, eta, phi, qual, 0), forward_(forward)
 {
-
 }
 
 l1t::Jet::Jet( const PolarLorentzVector& p4,
 	       int pt,
 	       int eta,
 	       int phi,
-	       int qual )
-  : L1Candidate(p4, pt, eta, phi, qual, 0)
+	       int qual,
+	       bool forward)
+  : L1Candidate(p4, pt, eta, phi, qual, 0), forward_(forward)
 {
-
 }
 
 l1t::Jet::~Jet()
 {
 
+}
+
+bool l1t::Jet::forward() const
+{
+  return forward_;
 }

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -5,8 +5,8 @@
   <class name="l1t::L1CandidateBxCollection"/>
   <class name="edm::Wrapper<l1t::L1CandidateBxCollection>"/>
 
-  <class name="l1t::Jet" ClassVersion="10">
-   <version ClassVersion="10" checksum="4108627301"/>
+  <class name="l1t::Jet" ClassVersion="11">
+   <version ClassVersion="11" checksum="375640457"/>
   </class>
   <class name="l1t::JetBxCollection"/>
   <class name="edm::Wrapper<l1t::JetBxCollection>"/>

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -158,7 +158,7 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
     int cenCount = 0; //max 4
     for(l1t::JetBxCollection::const_iterator itJet = Jet->begin(itBX);
 	itJet != Jet->end(itBX); ++itJet){
-      bool forward=(itJet->hwEta() <= 4 || itJet->hwEta() >= 17);
+      bool forward= itJet->forward();
       //int hackPt = itJet->hwPt()/8; //hack convert from LSB 0.5GeV for regions to LSB 4GeV jets
       double hackPt = static_cast<double>(itJet->hwPt()) * jetScale->linearLsb();
       hackPt = jetScale->rank(hackPt);

--- a/L1Trigger/L1TCalorimeter/plugins/PhysicalEtAdder.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/PhysicalEtAdder.cc
@@ -122,11 +122,12 @@ l1t::PhysicalEtAdder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       const double pt = itJet->hwPt() * emScale->linearLsb();
       const double eta = getPhysicalEta(itJet->hwEta());
       const double phi = getPhysicalPhi(itJet->hwPhi());
+      const bool forward = itJet->forward();
       math::PtEtaPhiMLorentzVector *p4 = new math::PtEtaPhiMLorentzVector(pt, eta, phi, 0);
 
       l1t::Jet *jet = new l1t::Jet(*p4, itJet->hwPt(),
 				   itJet->hwEta(), itJet->hwPhi(),
-				   itJet->hwQual());
+				   itJet->hwQual(), forward);
       new_jets->push_back(bx, *jet);
 
     }

--- a/L1Trigger/L1TCalorimeter/src/JetFinderMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/JetFinderMethods.cc
@@ -29,7 +29,7 @@ namespace l1t {
 
   bool compareJets (l1t::Jet i, l1t::Jet j){
     return (i.hwPt() < j.hwPt() );
-  } 
+  }
 
   void slidingWindowJetFinder(const int jetSeedThreshold, const std::vector<l1t::CaloRegion> * regions,
 			      std::vector<l1t::Jet> * jets)
@@ -139,9 +139,249 @@ namespace l1t {
 	  assert(false);
 	}
 
+	bool forward = (jetEta < 4 || jetEta > 17);
+
 	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > *jetLorentz =
 	  new ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >();
-	l1t::Jet theJet(*jetLorentz, jetET, jetEta, jetPhi);
+	l1t::Jet theJet(*jetLorentz, jetET, jetEta, jetPhi,0,forward);
+	//l1t::Jet theJet(0, jetET, jetEta, jetPhi);
+
+	jets->push_back(theJet);
+      }
+    }
+
+    // separate loops for the central jets at the edges of HF, composed of 6 regions only.
+    for(std::vector<CaloRegion>::const_iterator region = regions->begin(); region != regions->end(); region++) {
+      double regionET = region->hwPt();
+      // look at only the left eta wall
+      if (region->hwEta() != 4) continue;
+      if (regionET  < jetSeedThreshold) continue;
+      double neighborN_et = 0;
+      double neighborS_et = 0;
+      double neighborE_et = 0;
+      //double neighborW_et = 0;
+      double neighborNE_et = 0;
+      //double neighborSW_et = 0;
+      //double neighborNW_et = 0;
+      double neighborSE_et = 0;
+      unsigned int nNeighbors = 0;
+      for(std::vector<CaloRegion>::const_iterator neighbor = regions->begin(); neighbor != regions->end(); neighbor++) {
+
+	double neighborET = neighbor->hwPt(); //regionPhysicalEt(*neighbor);
+	if(deltaGctPhi(*region, *neighbor) == 1 &&
+	   (region->hwEta()    ) == neighbor->hwEta()) {
+	  neighborN_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	else if(deltaGctPhi(*region, *neighbor) == -1 &&
+		(region->hwEta()    ) == neighbor->hwEta()) {
+	  neighborS_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	else if(deltaGctPhi(*region, *neighbor) == 0 &&
+		(region->hwEta() + 1) == neighbor->hwEta()) {
+	  neighborE_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	// else if(deltaGctPhi(*region, *neighbor) == 0 &&
+	// 	(region->hwEta() - 1) == neighbor->hwEta()) {
+	//   neighborW_et = neighborET;
+	//   nNeighbors++;
+	//   continue;
+	// }
+	else if(deltaGctPhi(*region, *neighbor) == 1 &&
+		(region->hwEta() + 1) == neighbor->hwEta()) {
+	  neighborNE_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	// else if(deltaGctPhi(*region, *neighbor) == -1 &&
+	// 	(region->hwEta() - 1) == neighbor->hwEta()) {
+	//   neighborSW_et = neighborET;
+	//   nNeighbors++;
+	//   continue;
+	// }
+	// else if(deltaGctPhi(*region, *neighbor) == 1 &&
+	// 	(region->hwEta() - 1) == neighbor->hwEta()) {
+	//   neighborNW_et = neighborET;
+	//   nNeighbors++;
+	//   continue;
+	// }
+	else if(deltaGctPhi(*region, *neighbor) == -1 &&
+		(region->hwEta() + 1) == neighbor->hwEta()) {
+	  neighborSE_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+      }
+      if(regionET > neighborN_et &&
+	 //regionET > neighborNW_et &&
+	 //regionET > neighborW_et &&
+	 //regionET > neighborSW_et &&
+	 regionET >= neighborNE_et &&
+	 regionET >= neighborE_et &&
+	 regionET >= neighborSE_et &&
+	 regionET >= neighborS_et) {
+	unsigned int jetET = regionET +
+	  neighborN_et + neighborS_et + neighborE_et + /*neighborW_et +*/
+	  neighborNE_et + /*neighborSW_et +*/ neighborSE_et;// + neighborNW_et;
+	/*
+	  int jetPhi = region->hwPhi() * 4 +
+	  ( - 2 * (neighborS_et + neighborSE_et + neighborSW_et)
+	  + 2 * (neighborN_et + neighborNE_et + neighborNW_et) ) / jetET;
+	  if(jetPhi < 0) {
+
+	  }
+	  else if(jetPhi >= ((int) N_JET_PHI)) {
+	  jetPhi -= N_JET_PHI;
+	  }
+	  int jetEta = region->hwEta() * 4 +
+	  ( - 2 * (neighborW_et + neighborNW_et + neighborSW_et)
+	  + 2 * (neighborE_et + neighborNE_et + neighborSE_et) ) / jetET;
+	  if(jetEta < 0) jetEta = 0;
+	  if(jetEta >= ((int) N_JET_ETA)) jetEta = N_JET_ETA - 1;
+	*/
+	// Temporarily use the region granularity -- we will try to improve as above when code is debugged
+	int jetPhi = region->hwPhi();
+	int jetEta = region->hwEta();
+
+	bool neighborCheck = (nNeighbors == 5);
+	// On the eta edge we only expect 5 neighbors
+	// if (!neighborCheck && (jetEta == 0 || jetEta == 21) && nNeighbors == 5)
+	//   neighborCheck = true;
+
+	if (!neighborCheck) {
+	  std::cout << "phi: " << jetPhi << " eta: " << jetEta << " n: " << nNeighbors << std::endl;
+	  assert(false);
+	}
+
+	bool forward = false; //by definition
+
+	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > *jetLorentz =
+	  new ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >();
+	l1t::Jet theJet(*jetLorentz, jetET, jetEta, jetPhi,0,forward);
+	//l1t::Jet theJet(0, jetET, jetEta, jetPhi);
+
+	jets->push_back(theJet);
+      }
+    }
+
+    // separate loops for the central jets at the edges of HF, composed of 6 regions only.
+    for(std::vector<CaloRegion>::const_iterator region = regions->begin(); region != regions->end(); region++) {
+      double regionET = region->hwPt();
+      // look at only the right eta wall
+      if (region->hwEta() != 17) continue;
+      if (regionET  < jetSeedThreshold) continue;
+      double neighborN_et = 0;
+      double neighborS_et = 0;
+      //double neighborE_et = 0;
+      double neighborW_et = 0;
+      //double neighborNE_et = 0;
+      double neighborSW_et = 0;
+      double neighborNW_et = 0;
+      //double neighborSE_et = 0;
+      unsigned int nNeighbors = 0;
+      for(std::vector<CaloRegion>::const_iterator neighbor = regions->begin(); neighbor != regions->end(); neighbor++) {
+
+	double neighborET = neighbor->hwPt(); //regionPhysicalEt(*neighbor);
+	if(deltaGctPhi(*region, *neighbor) == 1 &&
+	   (region->hwEta()    ) == neighbor->hwEta()) {
+	  neighborN_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	else if(deltaGctPhi(*region, *neighbor) == -1 &&
+		(region->hwEta()    ) == neighbor->hwEta()) {
+	  neighborS_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	// else if(deltaGctPhi(*region, *neighbor) == 0 &&
+	// 	(region->hwEta() + 1) == neighbor->hwEta()) {
+	//   neighborE_et = neighborET;
+	//   nNeighbors++;
+	//   continue;
+	// }
+	else if(deltaGctPhi(*region, *neighbor) == 0 &&
+		(region->hwEta() - 1) == neighbor->hwEta()) {
+	  neighborW_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	// else if(deltaGctPhi(*region, *neighbor) == 1 &&
+	// 	(region->hwEta() + 1) == neighbor->hwEta()) {
+	//   neighborNE_et = neighborET;
+	//   nNeighbors++;
+	//   continue;
+	// }
+	else if(deltaGctPhi(*region, *neighbor) == -1 &&
+		(region->hwEta() - 1) == neighbor->hwEta()) {
+	  neighborSW_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	else if(deltaGctPhi(*region, *neighbor) == 1 &&
+		(region->hwEta() - 1) == neighbor->hwEta()) {
+	  neighborNW_et = neighborET;
+	  nNeighbors++;
+	  continue;
+	}
+	// else if(deltaGctPhi(*region, *neighbor) == -1 &&
+	// 	(region->hwEta() + 1) == neighbor->hwEta()) {
+	//   neighborSE_et = neighborET;
+	//   nNeighbors++;
+	//   continue;
+	// }
+      }
+      if(//regionET > neighborN_et &&
+	 regionET > neighborNW_et &&
+	 regionET > neighborW_et &&
+	 regionET > neighborSW_et &&
+	 //regionET >= neighborNE_et &&
+	 //regionET >= neighborE_et &&
+	 //regionET >= neighborSE_et &&
+	 regionET >= neighborS_et) {
+	unsigned int jetET = regionET +
+	  neighborN_et + neighborS_et + /*neighborE_et + */neighborW_et +
+	  /*neighborNE_et +*/ neighborSW_et + /*neighborSE_et + */neighborNW_et;
+	/*
+	  int jetPhi = region->hwPhi() * 4 +
+	  ( - 2 * (neighborS_et + neighborSE_et + neighborSW_et)
+	  + 2 * (neighborN_et + neighborNE_et + neighborNW_et) ) / jetET;
+	  if(jetPhi < 0) {
+
+	  }
+	  else if(jetPhi >= ((int) N_JET_PHI)) {
+	  jetPhi -= N_JET_PHI;
+	  }
+	  int jetEta = region->hwEta() * 4 +
+	  ( - 2 * (neighborW_et + neighborNW_et + neighborSW_et)
+	  + 2 * (neighborE_et + neighborNE_et + neighborSE_et) ) / jetET;
+	  if(jetEta < 0) jetEta = 0;
+	  if(jetEta >= ((int) N_JET_ETA)) jetEta = N_JET_ETA - 1;
+	*/
+	// Temporarily use the region granularity -- we will try to improve as above when code is debugged
+	int jetPhi = region->hwPhi();
+	int jetEta = region->hwEta();
+
+	bool neighborCheck = (nNeighbors == 5);
+	// On the eta edge we only expect 5 neighbors
+	// if (!neighborCheck && (jetEta == 0 || jetEta == 21) && nNeighbors == 5)
+	//   neighborCheck = true;
+
+	if (!neighborCheck) {
+	  std::cout << "phi: " << jetPhi << " eta: " << jetEta << " n: " << nNeighbors << std::endl;
+	  assert(false);
+	}
+
+	bool forward = false; // by definition
+
+	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > *jetLorentz =
+	  new ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >();
+	l1t::Jet theJet(*jetLorentz, jetET, jetEta, jetPhi,0,forward);
 	//l1t::Jet theJet(0, jetET, jetEta, jetPhi);
 
 	jets->push_back(theJet);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpHI.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpHI.cc
@@ -22,8 +22,8 @@ using namespace l1t;
 
 Stage1Layer2JetAlgorithmImpHI::Stage1Layer2JetAlgorithmImpHI(CaloParams* params) : params_(params)
 {
-  double jetScale=params_->jetScale();
-  jetSeedThreshold= floor( params_->jetSeedThreshold()/jetScale + 0.5);
+  //double jetScale=params_->jetScale();
+  //jetSeedThreshold= floor( params_->jetSeedThreshold()/jetScale + 0.5);
 }
 //: regionLSB_(0.5) {}
 
@@ -35,7 +35,7 @@ void Stage1Layer2JetAlgorithmImpHI::processEvent(const std::vector<l1t::CaloRegi
 
   std::vector<l1t::CaloRegion> *subRegions = new std::vector<l1t::CaloRegion>();
   HICaloRingSubtraction(regions, subRegions);
-  slidingWindowJetFinder(jetSeedThreshold, subRegions, jets);
+  slidingWindowJetFinder(0, subRegions, jets);
 
   delete subRegions;
 }


### PR DESCRIPTION
@mulhearn @jimbrooke @kalanand @apana 
Stage1Layer2 would like to change our jet finder to make sure that central jets have no HF energy. This means that we need to deal with the possibility of two jets at the same eta-phi position, one including HF (a forward jet) and one not including HF (a central jet). 

I think the simplest method for handling this extra required info in our algos is to add a forward member to the l1t::Jet class, which I have done here. This is build and run-tested. Previous uses of the constructor should still be fine.

Is there any reason not to merge this? I had to edit classes_def.xml, wasn't sure what the procedure with that was.

Thanks,
Alex
