### PR TITLE
Make emulator output match unpacker/GT expectation

### DIFF
--- a/CondFormats/L1TObjects/interface/CaloParams.h
+++ b/CondFormats/L1TObjects/interface/CaloParams.h
@@ -4,7 +4,7 @@
 /// Description: Placeholder for calorimeter trigger parameters
 ///
 /// Implementation:
-///    
+///
 ///
 /// \author: Jim Brooke
 ///
@@ -14,15 +14,21 @@
 
 #include "CondFormats/L1TObjects/interface/LUT.h"
 
+#include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
+#include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1HtMissScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1HfRingEtScaleRcd.h"
+
 #include <memory>
 #include <iostream>
 #include <vector>
 #include <cmath>
 
 namespace l1t {
-  
+
   class CaloParams {
-    
+
   public:
 
     CaloParams() {}
@@ -73,7 +79,7 @@ namespace l1t {
     double egMaxHcalEt() const { return egMaxHcalEt_; }
     int egEtToRemoveHECutHw() const {return floor(egEtToRemoveHECut_/egLsb_);}
     double egEtToRemoveHECut() const {return egEtToRemoveHECut_;}
-    double egMaxHOverE() const { return egMaxHOverE_; } 
+    double egMaxHOverE() const { return egMaxHOverE_; }
     double egRelativeJetIsolationCut() const { return egRelativeJetIsolationCut_; }
     unsigned egIsoAreaNrTowersEta()const{return egIsoAreaNrTowersEta_;}
     unsigned egIsoAreaNrTowersPhi()const{return egIsoAreaNrTowersPhi_;}
@@ -85,7 +91,7 @@ namespace l1t {
     l1t::LUT* egIsolationLUT() { return egIsolationLUT_.get(); }
     std::string egCalibrationType() const { return egCalibrationType_; }
     std::vector<double> egCalibrationParams() { return egCalibrationParams_; }
-
+    L1CaloEtScale emScale() { return emScale_; }
 
     void setEgLsb(double lsb) { egLsb_ = lsb; }
     void setEgSeedThreshold(double thresh) { egSeedThreshold_ = thresh; }
@@ -94,7 +100,7 @@ namespace l1t {
     void setEgEtToRemoveHECut(double thresh) { egEtToRemoveHECut_ = thresh;}
     void setEgMaxHOverE(double cut) { egMaxHOverE_ = cut; }
     void setEgRelativeJetIsolationCut(double cutValue) { egRelativeJetIsolationCut_ = cutValue; }
-   
+
     void setEgIsoAreaNrTowersEta(unsigned iEgIsoAreaNrTowersEta){egIsoAreaNrTowersEta_=iEgIsoAreaNrTowersEta;}
     void setEgIsoAreaNrTowersPhi(unsigned iEgIsoAreaNrTowersPhi){egIsoAreaNrTowersPhi_=iEgIsoAreaNrTowersPhi;}
     void setEgIsoVetoNrTowersPhi(unsigned iEgIsoVetoNrTowersPhi){egIsoVetoNrTowersPhi_=iEgIsoVetoNrTowersPhi;}
@@ -105,6 +111,7 @@ namespace l1t {
     void setEgIsolationLUT(std::shared_ptr<LUT> lut) { egIsolationLUT_ = lut; }
     void setEgCalibrationType(std::string type) { egCalibrationType_ = type; }
     void setEgCalibrationParams(std::vector<double> params) { egCalibrationParams_ = params; }
+    void setEmScale(L1CaloEtScale emScale) { emScale_ = emScale; }
 
 
     // tau
@@ -138,6 +145,7 @@ namespace l1t {
     std::vector<double> jetPUSParams() { return jetPUSParams_; }
     std::string jetCalibrationType() const { return jetCalibrationType_; }
     std::vector<double> jetCalibrationParams() { return jetCalibrationParams_; }
+    L1CaloEtScale jetScale() { return jetScale_; }
 
     void setJetLsb(double lsb) { jetLsb_ = lsb; }
     void setJetSeedThreshold(double thresh) { jetSeedThreshold_ = thresh; }
@@ -146,19 +154,24 @@ namespace l1t {
     void setJetPUSParams(std::vector<double> params) { jetPUSParams_ = params; }
     void setJetCalibrationType(std::string type) { jetCalibrationType_ = type; }
     void setJetCalibrationParams(std::vector<double> params) { jetCalibrationParams_ = params; }
+    void setJetScale(L1CaloEtScale jetScale) { jetScale_ = jetScale; }
 
-    
+
     // sums
     double etSumLsb() const { return etSumLsb_; }
     int etSumEtaMin(unsigned isum) const;
     int etSumEtaMax(unsigned isum) const;
     int etSumEtThresholdHw(unsigned isum) const { return floor(etSumEtThreshold(isum)/etSumLsb_); }
     double etSumEtThreshold(unsigned isum) const;
-    
+    L1CaloEtScale HtMissScale() {return HtMissScale_;}
+    L1CaloEtScale HfRingScale() {return HfRingScale_;}
+
     void setEtSumLsb(double lsb) { etSumLsb_ = lsb; }
     void setEtSumEtaMin(unsigned isum, int eta);
     void setEtSumEtaMax(unsigned isum, int eta);
-    void setEtSumEtThreshold(unsigned isum, double thresh);    
+    void setEtSumEtThreshold(unsigned isum, double thresh);
+    void setHtMissScale(L1CaloEtScale HtMissScale){HtMissScale_ = HtMissScale;}
+    void setHfRingScale(L1CaloEtScale HfRingScale){HfRingScale_ = HfRingScale;}
 
     // print parameters to stream:
     void print(std::ostream&) const;
@@ -214,7 +227,7 @@ namespace l1t {
 
     // bitmask for storing ECAL/HCAL ratio in tower object
     int towerMaskRatio_;
-    
+
     // turn encoding on/off
     bool towerDoEncoding_;
 
@@ -249,7 +262,7 @@ namespace l1t {
 
     // Et threshold to remove the H/E cut from the EGammas
     double egEtToRemoveHECut_;
-    
+
     // EG maximum value of H/E
     double egMaxHOverE_;
 
@@ -257,16 +270,16 @@ namespace l1t {
     double egRelativeJetIsolationCut_;
 
     // isolation area in eta is seed tower +/- <=egIsoAreaNrTowersPhi
-    unsigned egIsoAreaNrTowersEta_; 
+    unsigned egIsoAreaNrTowersEta_;
 
     // isolation area in phi is seed tower +/- <=egIsoAreaNrTowersPhi
-    unsigned egIsoAreaNrTowersPhi_; 
+    unsigned egIsoAreaNrTowersPhi_;
 
     // veto region is seed tower +/- <=egIsoVetoNrTowersPhi
-    unsigned egIsoVetoNrTowersPhi_; 
-    
+    unsigned egIsoVetoNrTowersPhi_;
+
     // for # towers based PU estimator, estimator is #towers/egIsoPUEstTowerGranularity_
-    unsigned egIsoPUEstTowerGranularity_; 
+    unsigned egIsoPUEstTowerGranularity_;
 
     // eta range over which # towers is estimated
     unsigned egIsoMaxEtaAbsForTowerSum_;
@@ -279,14 +292,16 @@ namespace l1t {
 
     // EG calibration coefficients
     std::vector<double> egCalibrationParams_;
-    
+
     // EG isolation PUS
     std::string egIsoPUSType_;
 
     // EG isolation LUT (indexed by eta, Et ?)
     std::shared_ptr<l1t::LUT> egIsolationLUT_;
 
- 
+    L1CaloEtScale emScale_;
+
+
 
     /* Tau */
 
@@ -298,7 +313,7 @@ namespace l1t {
 
     // Et threshold on tau neighbour towers
     double tauNeighbourThreshold_;
-    
+
     // Relative jet isolation cut for Taus (Stage1Layer2)
     double tauRelativeJetIsolationCut_;
     // Tau isolation PUS
@@ -327,7 +342,7 @@ namespace l1t {
     double jetNeighbourThreshold_;
 
     // jet PUS scheme ("None" means no PU)
-    std::string jetPUSType_;                    
+    std::string jetPUSType_;
 
     // jet PU params
     std::vector<double> jetPUSParams_;
@@ -337,6 +352,8 @@ namespace l1t {
 
     // jet calibration coefficients
     std::vector<double> jetCalibrationParams_;
+
+    L1CaloEtScale jetScale_;
 
 
 
@@ -360,6 +377,9 @@ namespace l1t {
     unsigned regionETCutForMET_;
     int minGctEtaForSums_;
     int maxGctEtaForSums_;
+
+    L1CaloEtScale HtMissScale_;
+    L1CaloEtScale HfRingScale_;
 
   };
 

--- a/L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h
@@ -1,0 +1,40 @@
+// legacyGtHelper.h
+// Authors: Alex Barbieri
+//
+// This is a collection of helper methods to make sure that
+// the objects passed to the legacy GT are using the proper
+// Et scales and eta coordinates.
+
+#ifndef LEGACYGTHELPER_H
+#define LEGACYGTHELPER_H
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "CondFormats/L1TObjects/interface/CaloParams.h"
+
+#include <vector>
+
+namespace l1t {
+
+void JetToGtScales(CaloParams *params,
+		     const std::vector<l1t::Jet> * input,
+		     std::vector<l1t::Jet> *output);
+
+void EGammaToGtScales(CaloParams *params,
+			const std::vector<l1t::EGamma> * input,
+			std::vector<l1t::EGamma> *output);
+
+void TauToGtScales(CaloParams *params,
+		     const std::vector<l1t::Tau> * input,
+		     std::vector<l1t::Tau> *output);
+
+void EtSumToGtScales(CaloParams *params,
+		       const std::vector<l1t::EtSum> * input,
+		       std::vector<l1t::EtSum> *output);
+
+
+}
+
+#endif

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -172,13 +172,7 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
 	itJet != Jet->end(itBX); ++itJet){
       // use 2nd quality bit to define forward
       const bool forward = ((itJet->hwQual() & 0x2) != 0);
-      const uint16_t rankPt = jetScale->rank((uint16_t)itJet->hwPt());
-      
-      unsigned iEta = itJet->hwEta();
-      unsigned rctEta = (iEta<11 ? 10-iEta : iEta-11);
-      unsigned gtEta=(((rctEta % 7) & 0x7) | (iEta<11 ? 0x8 : 0));
-
-      L1GctJetCand JetCand(rankPt, itJet->hwPhi(), gtEta,
+      L1GctJetCand JetCand(itJet->hwPt(), itJet->hwPhi(), itJet->hwEta(),
 			   false, forward,0, 0, itBX);
       //L1GctJetCand(unsigned rank, unsigned phi, unsigned eta,
       //             bool isTau, bool isFor, uint16_t block, uint16_t index, int16_t bx);
@@ -216,28 +210,6 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
       }
     }
   }
-
-
-
-  //*isoEmResult =
-  //this->ConvertToNonIsoEmCand(EGamma);
-  //  DataFormatter.ConvertToNonIsoEmCand(*EGamma, nonIsoEmResult);
-  //  DataFormatter.ConvertToCenJetCand(*Jet, cenJetResult);
-  //  DataFormatter.ConvertToForJetCand(*Jet, forJetResult);
-  //  DataFormatter.ConvertToTauJetCand(*Tau, tauJetResult);
-
-  //  DataFormatter.ConvertToEtTotal(EtSum, etTotResult);
-  // DataFormatter.ConvertToEtHad(EtSum,etHadResult);
-  // DataFormatter.ConvertToEtMiss(EtSum,etMissResult);
-  // DataFormatter.ConvertToHtMiss(EtSum,htMissResult);
-  // DataFormatter.ConvertToHFBitCounts(EtSum,hfBitCountResult);
-  // DataFormatter.ConvertToHFRingEtSums(EtSum, hfRingEtSumResult);
-
-  //  DataFormatter.ConvertToIntJet(Jet, internalJetResult);
-  //  DataFormatter.ConvertToIntEtSum(EtSum,internalEtSumResult);
-  //  DataFormatter.ConvertToIntHtMiss(EtSum,internalHtMissResult);
-
-
 
   e.put(isoEmResult,"isoEm");
   e.put(nonIsoEmResult,"nonIsoEm");

--- a/L1Trigger/L1TCalorimeter/plugins/Stage1Layer2Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/Stage1Layer2Producer.cc
@@ -27,6 +27,8 @@
 #include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
 #include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
 #include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1HtMissScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1HfRingEtScaleRcd.h"
 
 #include <vector>
 #include "DataFormats/L1Trigger/interface/BXVector.h"
@@ -262,8 +264,8 @@ Stage1Layer2Producer::endJob() {
 
 void Stage1Layer2Producer::beginRun(Run const&iR, EventSetup const&iE){
 
-  unsigned long long id = iE.get<L1TCaloParamsRcd>().cacheIdentifier();  
-  
+  unsigned long long id = iE.get<L1TCaloParamsRcd>().cacheIdentifier();
+
   if (id != m_paramsCacheId) {
 
     m_paramsCacheId = id;
@@ -274,11 +276,11 @@ void Stage1Layer2Producer::beginRun(Run const&iR, EventSetup const&iE){
     // replace our local copy of the parameters with a new one using placement new
     m_params->~CaloParams();
     m_params = new (m_params) CaloParams(*paramsHandle.product());
-    
+
     LogDebug("L1TDebug") << *m_params << std::endl;
 
     if (! m_params){
-      edm::LogError("l1t|caloStage1") << "Could not retrieve params from Event Setup" << std::endl;            
+      edm::LogError("l1t|caloStage1") << "Could not retrieve params from Event Setup" << std::endl;
     }
 
   }
@@ -290,16 +292,26 @@ void Stage1Layer2Producer::beginRun(Run const&iR, EventSetup const&iE){
   m_params->setMaxGctEtaForSums(maxGctEtaForSums);
   m_params->setEgRelativeJetIsolationCut(egRelativeJetIsolationCut);
   m_params->setTauRelativeJetIsolationCut(tauRelativeJetIsolationCut);
-    
+
   LogDebug("l1t|stage 1 jets") << "Stage1Layer2Producer::beginRun function called...\n";
 
-  //get the proper scales for conversion to physical et
-  //right now just set them in the Params cfi, rename them egLsb, jetLsb
-  //edm::ESHandle< L1CaloEtScale > emScale ;
-  //iE.get< L1EmEtScaleRcd >().get( emScale ) ;
+  //get the proper scales for conversion to physical et AND gt scales
+  edm::ESHandle< L1CaloEtScale > emScale ;
+  iE.get< L1EmEtScaleRcd >().get( emScale ) ;
+  m_params->setEmScale(*emScale);
 
-  //edm::ESHandle< L1CaloEtScale > jetScale ;
-  //iE.get< L1JetEtScaleRcd >().get( jetScale ) ;
+  edm::ESHandle< L1CaloEtScale > jetScale ;
+  iE.get< L1JetEtScaleRcd >().get( jetScale ) ;
+  m_params->setJetScale(*jetScale);
+
+  edm::ESHandle< L1CaloEtScale > HtMissScale;
+  iE.get< L1HtMissScaleRcd >().get( HtMissScale ) ;
+  m_params->setHtMissScale(*HtMissScale);
+
+  //not sure if I need this one
+  edm::ESHandle< L1CaloEtScale > HfRingScale;
+  iE.get< L1HfRingEtScaleRcd >().get( HfRingScale );
+  m_params->setHfRingScale(*HfRingScale);
 
 
   //m_params->setEgLsb(emScale->linearLsb());

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpHI.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpHI.cc
@@ -10,6 +10,7 @@
 #include "L1Trigger/L1TCalorimeter/interface/Stage1Layer2JetAlgorithmImp.h"
 #include "L1Trigger/L1TCalorimeter/interface/JetFinderMethods.h"
 #include "L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h"
+#include "L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h"
 
 // Taken from UCT code. Might not be appropriate. Refers to legacy L1 objects.
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h"
@@ -22,7 +23,6 @@ using namespace l1t;
 
 Stage1Layer2JetAlgorithmImpHI::Stage1Layer2JetAlgorithmImpHI(CaloParams* params) : params_(params)
 {
-  double jetLsb=params_->jetLsb();
   jetSeedThreshold= floor( params_->jetSeedThreshold()/jetLsb + 0.5);
 }
 //: regionLSB_(0.5) {}
@@ -34,8 +34,12 @@ void Stage1Layer2JetAlgorithmImpHI::processEvent(const std::vector<l1t::CaloRegi
 					       std::vector<l1t::Jet> * jets){
 
   std::vector<l1t::CaloRegion> *subRegions = new std::vector<l1t::CaloRegion>();
+  std::vector<l1t::Jet> *preGtJets = new std::vector<l1t::Jet>();
+
   HICaloRingSubtraction(regions, subRegions);
-  slidingWindowJetFinder(jetSeedThreshold, subRegions, jets);
+  slidingWindowJetFinder(jetSeedThreshold, subRegions, preGtJets);
+  JetToGtScales(params_, preGtJets, jets);
 
   delete subRegions;
+  delete preGtJets;
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpPP.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpPP.cc
@@ -11,6 +11,7 @@
 #include "L1Trigger/L1TCalorimeter/interface/JetFinderMethods.h"
 #include "L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h"
 #include "L1Trigger/L1TCalorimeter/interface/JetCalibrationMethods.h"
+#include "L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h"
 
 // Taken from UCT code. Might not be appropriate. Refers to legacy L1 objects.
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h"
@@ -41,22 +42,26 @@ void Stage1Layer2JetAlgorithmImpPP::processEvent(const std::vector<l1t::CaloRegi
 
   std::vector<l1t::CaloRegion> * subRegions = new std::vector<l1t::CaloRegion>();
   std::vector<l1t::Jet> * uncalibjets = new std::vector<l1t::Jet>();
+  std::vector<l1t::Jet> * preGtJets = new std::vector<l1t::Jet>();
 
-  
-  //Region Correction will return uncorrected subregions 
+
+  //Region Correction will return uncorrected subregions
   //if regionPUSType is set to None in the config
   RegionCorrection(regions, EMCands, subRegions, regionPUSParams, regionPUSType);
-  
-  
+
+
   slidingWindowJetFinder(jetSeedThreshold, subRegions, uncalibjets);
 
   //will return jets with no response corrections
   //if jetCalibrationType is set to None in the config
-  JetCalibration(uncalibjets, jetCalibrationParams, jets, jetCalibrationType, jetLsb);
+  JetCalibration(uncalibjets, jetCalibrationParams, preGtJets, jetCalibrationType, jetLsb);
 
+  // takes input jets (using region scales/eta) and outputs jets using Gt scales/eta
+  JetToGtScales(params_, preGtJets, jets);
 
   delete subRegions;
   delete uncalibjets;
+  delete preGtJets;
 
   // std::vector<l1t::CaloRegion>::const_iterator incell;
   // for (incell = regions.begin(); incell != regions.end(); ++incell){
@@ -64,4 +69,3 @@ void Stage1Layer2JetAlgorithmImpPP::processEvent(const std::vector<l1t::CaloRegi
   // }
 
 }
-

--- a/L1Trigger/L1TCalorimeter/src/legacyGtHelper.cc
+++ b/L1Trigger/L1TCalorimeter/src/legacyGtHelper.cc
@@ -1,0 +1,65 @@
+// legacyGtHelper.cc
+// Authors: Alex Barbieri
+//
+// This is a collection of helper methods to make sure that
+// the objects passed to the legacy GT are using the proper
+// Et scales and eta coordinates.
+
+#include "L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h"
+
+const unsigned int gtEta(const unsigned int iEta);
+
+namespace l1t {
+
+  void JetToGtScales(CaloParams *params,
+		     const std::vector<l1t::Jet> * input,
+		     std::vector<l1t::Jet> *output){
+
+    for(std::vector<l1t::Jet>::const_iterator itJet = input->begin();
+	itJet != input->end(); ++itJet){
+      const unsigned newEta = gtEta(itJet->hwEta());
+      const uint16_t rankPt = params->jetScale().rank((uint16_t)itJet->hwPt());
+
+      ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > *jetLorentz =
+	  new ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >();
+
+      l1t::Jet gtJet(*jetLorentz, rankPt, newEta, itJet->hwPhi(), itJet->hwQual());
+      output->push_back(gtJet);
+    }
+  }
+
+  void EGammaToGtScales(CaloParams *params,
+			const std::vector<l1t::EGamma> * input,
+			std::vector<l1t::EGamma> *output){
+  }
+
+  void TauToGtScales(CaloParams *params,
+		     const std::vector<l1t::Tau> * input,
+		     std::vector<l1t::Tau> *output){
+    for(std::vector<l1t::Tau>::const_iterator itTau = input->begin();
+	itTau != input->end(); ++itTau){
+      const unsigned newEta = gtEta(itTau->hwEta());
+      const uint16_t rankPt = params->jetScale().rank((uint16_t)itTau->hwPt());
+
+      ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > *tauLorentz =
+	  new ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >();
+
+      l1t::Tau gtTau(*tauLorentz, rankPt, newEta, itTau->hwPhi(), itTau->hwQual());
+      output->push_back(gtTau);
+    }
+
+  }
+
+  void EtSumToGtScales(CaloParams *params,
+		       const std::vector<l1t::EtSum> * input,
+		       std::vector<l1t::EtSum> *output){
+  }
+
+
+}
+
+const unsigned int gtEta(const unsigned int iEta)
+{
+  unsigned rctEta = (iEta<11 ? 10-iEta : iEta-11);
+  return (((rctEta % 7) & 0x7) | (iEta<11 ? 0x8 : 0));
+}


### PR DESCRIPTION
I'm using this pull request to track my work on changing the output of the emulator so that the eta coordinates and et scales match the GT expectations (as the unpacker output will use). It definitely shouldn't be merged until I've at least got the hardware parts working - the PhysicalEtAdder parts are secondary.

So far I've added the needed conversion scales to the CaloParams object (maybe not a good idea) and changed both jet algorithms to using the conversion code in legacyGtHelper.{cc,h}. Suggestions welcome.
