### PR TITLE
Fix uGMT muon pt scales and adding TwinMux emulator

### DIFF
--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -73,7 +73,8 @@
   <class name="edm::reftobase::RefHolder<L1TMuon::CSCTrackRef>"/>
   <class name="edm::reftobase::RefHolder<L1TMuon::InternalTrackRef>"/>
 
- <class name="BMTrackCand" ClassVersion="22">
+ <class name="BMTrackCand" ClassVersion="23">
+  <version ClassVersion="23" checksum="1616896838"/>
   <version ClassVersion="22" checksum="612222572"/>
   <version ClassVersion="21" checksum="1616896838"/>
   <version ClassVersion="20" checksum="612222572"/>

--- a/L1Trigger/L1TMuon/plugins/L1TBMTFConverter.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TBMTFConverter.cc
@@ -76,8 +76,9 @@ class L1TBMTFConverter : public edm::EDProducer {
 //
 // constructors and destructor
 //
-L1TBMTFConverter::L1TBMTFConverter(const edm::ParameterSet& iConfig) : m_barrelTfInputTag("bmtfEmulator", "BM")
+L1TBMTFConverter::L1TBMTFConverter(const edm::ParameterSet& iConfig)
 {
+  m_barrelTfInputTag = iConfig.getParameter<edm::InputTag>("barrelTFInput");
   m_barrelTfInputToken = consumes<RegionalMuonCandBxCollection>(m_barrelTfInputTag);
   //register your products
   produces<RegionalMuonCandBxCollection>("ConvBMTFMuons");

--- a/L1Trigger/L1TMuon/plugins/L1TMicroGMTProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMicroGMTProducer.cc
@@ -260,7 +260,7 @@ L1TMicroGMTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   // copy muons to output collection...
   for (const auto& mu : internalMuons) {
     if (mu->hwPt() > 0) {
-      math::PtEtaPhiMLorentzVector vec{mu->hwPt()*0.5, mu->hwEta()*0.010875, mu->hwGlobalPhi()*0.010908, 0.0};
+      math::PtEtaPhiMLorentzVector vec{(mu->hwPt()-1)*0.5, mu->hwEta()*0.010875, mu->hwGlobalPhi()*0.010908, 0.0};
       int iso = mu->hwAbsIso() + (mu->hwRelIso() << 1);
       Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), mu->hwQual(), mu->hwSign(), mu->hwSignValid(), iso, 0, true, mu->hwIsoSum(), mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
       m_debugOut << mu->hwCaloPhi() << " " << mu->hwCaloEta() << std::endl;
@@ -338,7 +338,7 @@ L1TMicroGMTProducer::addMuonsToCollections(MicroGMTConfiguration::InterMuonList&
 {
   for (auto& mu : coll) {
     interout.push_back(mu);
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > vec{};
+    math::PtEtaPhiMLorentzVector vec{(mu->hwPt()-1)*0.5, mu->hwEta()*0.010875, mu->hwGlobalPhi()*0.010908, 0.0};
     // FIXME: once we debugged the change global -> local: Change hwLocalPhi -> hwGlobalPhi to test offsets
     Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), mu->hwQual(), mu->hwSign(), mu->hwSignValid(), -1, 0, true, -1, mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
 

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -23,7 +23,7 @@ l1t::MuonRawDigiTranslator::fillMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t
   mu.setHwChargeValid((raw_data_32_63 >> chargeValidShift_) & 0x1);
 
   if (mu.hwPt() > 0) {
-    math::PtEtaPhiMLorentzVector vec{mu.hwPt()*0.5, mu.hwEta()*0.010875, mu.hwPhi()*0.010908, 0.0};
+    math::PtEtaPhiMLorentzVector vec{(mu.hwPt()-1)*0.5, mu.hwEta()*0.010875, mu.hwPhi()*0.010908, 0.0};
     mu.setP4(vec);
   }
 }

--- a/L1Trigger/L1TMuon/test/microgmt_from_tfinputs_cfg.py
+++ b/L1Trigger/L1TMuon/test/microgmt_from_tfinputs_cfg.py
@@ -11,7 +11,7 @@ VERBOSE = False
 SAMPLE = "zmumu"  # "relval"##"minbias"
 EDM_OUT = True
 # min bias: 23635 => 3477 passed L1TMuonFilter (~6.7%), zmumu ~84%
-NEVENTS = 5
+NEVENTS = 50
 if VERBOSE:
     process.MessageLogger = cms.Service("MessageLogger",
                                         suppressInfo=cms.untracked.vstring('AfterSource', 'PostModule'),
@@ -57,9 +57,12 @@ fnames = ['/store/relval/CMSSW_7_5_0_pre1/RelValSingleMuPt10_UP15/GEN-SIM-DIGI-R
           '/store/relval/CMSSW_7_5_0_pre1/RelValSingleMuPt10_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/MCRUN2_74_V7-v1/00000/8E6F7913-83E3-E411-B72F-0025905A48BB.root']
 
 if SAMPLE == "zmumu":
-    fnames = ['root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/20000/B61E1FCD-A077-E311-8B65-001E673974EA.root',
-              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/0023D81B-2980-E311-85A1-001E67398C0F.root',
-              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/248FB042-3080-E311-A346-001E67397D00.root']
+#    fnames = ['root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/20000/B61E1FCD-A077-E311-8B65-001E673974EA.root',
+#              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/0023D81B-2980-E311-85A1-001E67398C0F.root',
+#              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/248FB042-3080-E311-A346-001E67397D00.root']
+    fnames = ['/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/PU20bx25_tsg_castor_PHYS14_25_V1-v1/10000/044B58B4-9D75-E411-AB6C-002590A83218.root',
+              '/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/PU20bx25_tsg_castor_PHYS14_25_V1-v1/10000/045570BC-9175-E411-A06A-002590A887F0.root',
+              '/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/PU20bx25_tsg_castor_PHYS14_25_V1-v1/10000/0C8C76BC-9775-E411-882E-002481E0DCD8.root',]
 elif SAMPLE == "minbias":
     fnames = ['root://xrootd.unl.edu//store/mc/Fall13dr/Neutrino_Pt-2to20_gun/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/00000/00276D94-AA88-E311-9C90-0025905A6060.root',
               'root://xrootd.unl.edu//store/mc/Fall13dr/Neutrino_Pt-2to20_gun/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/00000/004F8058-6F88-E311-B971-0025905A6094.root',
@@ -90,7 +93,7 @@ process.load('L1Trigger.L1TMuonTrackFinderEndCap.L1TMuonTriggerPrimitiveProducer
 
 path = "L1Trigger/L1TMuonTrackFinderOverlap/data/"
 # OMTF emulator configuration
-process.load('L1Trigger.L1TMuonTrackFinderOverlap.OMTFProducer_cfi')
+process.load('L1Trigger.L1TMuonTrackFinderOverlap.OMTFProducer_cff')
 
 process.L1TMuonEndcapTrackFinder = cms.EDProducer(
     'L1TMuonUpgradedTrackFinder',
@@ -101,24 +104,25 @@ process.L1TMuonEndcapTrackFinder = cms.EDProducer(
     ),
 )
 
-# BMTF Emulator
-process.bmtfEmulator = cms.EDProducer("BMTrackFinder",
-                                      CSCStub_Source=cms.InputTag("simCsctfTrackDigis"),
-                                      DTDigi_Source=cms.InputTag("simDtTriggerPrimitiveDigis"),
-                                      Debug=cms.untracked.int32(0)
+# TwinMux Emulator
+process.load('L1Trigger.L1TMuonTrackFinderBarrel.L1TTwinMuxProducer_cfi')
 
-                                      )
+# BMTF Emulator
+process.load('L1Trigger.L1TMuonTrackFinderBarrel.bmtfDigis_cfi')
+process.bmtfDigis.DTDigi_Source=cms.InputTag("L1TTwinMuxProducer")
 
 process.MicroGMTCaloInputProducer = cms.EDProducer("L1TMicroGMTCaloInputProducer",
                                                caloStage2Layer2Label=cms.InputTag("caloStage2Layer1Digis"),
 )
 # WORKAROUNDS FOR WRONG SCALES / MISSING COLLECTIONS:
-process.bmtfConverter = cms.EDProducer("L1TBMTFConverter",)
+process.bmtfConverter = cms.EDProducer("L1TBMTFConverter",
+                                       barrelTFInput = cms.InputTag("bmtfDigis", "BM"))
 
 # Adjust input tags if running on GEN-SIM-RAW (have to re-digi)
 if SAMPLE == "zmumu" or SAMPLE == "minbias":
     process.L1TMuonTriggerPrimitives.CSC.src = cms.InputTag('simCscTriggerPrimitiveDigis')
 
+# uGMT emulator
 process.load("L1Trigger.L1TMuon.l1tmicrogmtproducer_cfi")
 
 process.microGMTEmulator.overlapTFInput = cms.InputTag("omtfEmulator", "OMTF")
@@ -140,7 +144,7 @@ process = customise_csc_PostLS1(process)
 # upgrade calo stage 2
 process.load('L1Trigger.L1TCalorimeter.L1TCaloStage2_PPFromRaw_cff')
 
-# test L1TMicroGMTESProducer
+# L1TMicroGMTESProducer
 process.load('L1Trigger.L1TMuon.l1tmicrogmtparamsesproducer_cfi')
 # reset LUT paths to trigger CMSSW internal LUT generation
 #process.l1tGMTParamsESProducer.AbsIsoCheckMemLUTPath = cms.string('')
@@ -172,11 +176,19 @@ process.esTest = cms.EDAnalyzer("EventSetupRecordDataGetter",
    verbose = cms.untracked.bool(True)
 )
 
+process.L1ReEmulSeq = cms.Sequence(process.SimL1Emulator
+                                   + process.ecalDigis
+                                   #+ process.hcalDigis
+                                   #+ process.gtDigis
+                                   #+ process.gtEvmDigis
+                                   #+ process.csctfDigis
+                                   #+ process.dttfDigis
+                                   )
+
 process.L1TMuonSeq = cms.Sequence(
-    process.SimL1Emulator
-    + process.ecalDigis
-    + process.L1TMuonTriggerPrimitives
-    + process.bmtfEmulator
+    process.L1TMuonTriggerPrimitives
+    + process.L1TTwinMuxProducer
+    + process.bmtfDigis
     + process.bmtfConverter
     + process.omtfEmulator
     + process.L1TMuonEndcapTrackFinder
@@ -190,7 +202,7 @@ process.L1TMuonSeq = cms.Sequence(
 process.MuonFilter = cms.Sequence()
 
 
-process.L1TMuonPath = cms.Path(process.L1TMuonSeq)
+process.L1TMuonPath = cms.Path(process.L1ReEmulSeq + process.L1TMuonSeq)
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands=cms.untracked.vstring(),

--- a/L1Trigger/L1TMuon/test/produce_l1upgradentuple_cfg.py
+++ b/L1Trigger/L1TMuon/test/produce_l1upgradentuple_cfg.py
@@ -57,9 +57,12 @@ fnames = ['/store/relval/CMSSW_7_5_0_pre1/RelValSingleMuPt10_UP15/GEN-SIM-DIGI-R
           '/store/relval/CMSSW_7_5_0_pre1/RelValSingleMuPt10_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/MCRUN2_74_V7-v1/00000/8E6F7913-83E3-E411-B72F-0025905A48BB.root']
 
 if SAMPLE == "zmumu":
-    fnames = ['root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/20000/B61E1FCD-A077-E311-8B65-001E673974EA.root',
-              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/0023D81B-2980-E311-85A1-001E67398C0F.root',
-              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/248FB042-3080-E311-A346-001E67397D00.root']
+#    fnames = ['root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/20000/B61E1FCD-A077-E311-8B65-001E673974EA.root',
+#              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/0023D81B-2980-E311-85A1-001E67398C0F.root',
+#              'root://xrootd.unl.edu//store/mc/Fall13dr/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/10000/248FB042-3080-E311-A346-001E67397D00.root']
+    fnames = ['/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/PU20bx25_tsg_castor_PHYS14_25_V1-v1/10000/044B58B4-9D75-E411-AB6C-002590A83218.root',
+              '/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/PU20bx25_tsg_castor_PHYS14_25_V1-v1/10000/045570BC-9175-E411-A06A-002590A887F0.root',
+              '/store/mc/Phys14DR/DYToMuMu_M-50_Tune4C_13TeV-pythia8/GEN-SIM-RAW/PU20bx25_tsg_castor_PHYS14_25_V1-v1/10000/0C8C76BC-9775-E411-882E-002481E0DCD8.root',]
 elif SAMPLE == "minbias":
     fnames = ['root://xrootd.unl.edu//store/mc/Fall13dr/Neutrino_Pt-2to20_gun/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/00000/00276D94-AA88-E311-9C90-0025905A6060.root',
               'root://xrootd.unl.edu//store/mc/Fall13dr/Neutrino_Pt-2to20_gun/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/00000/004F8058-6F88-E311-B971-0025905A6094.root',
@@ -87,8 +90,7 @@ process.load('L1Trigger.L1TMuonTrackFinderEndCap.L1TMuonTriggerPrimitiveProducer
 
 path = "L1Trigger/L1TMuonTrackFinderOverlap/data/"
 # OMTF emulator configuration
-# OMTF emulator configuration
-process.load('L1Trigger.L1TMuonTrackFinderOverlap.OMTFProducer_cfi')
+process.load('L1Trigger.L1TMuonTrackFinderOverlap.OMTFProducer_cff')
 
 process.L1TMuonEndcapTrackFinder = cms.EDProducer(
     'L1TMuonUpgradedTrackFinder',
@@ -99,19 +101,19 @@ process.L1TMuonEndcapTrackFinder = cms.EDProducer(
     ),
 )
 
-# BMTF Emulator
-process.bmtfEmulator = cms.EDProducer("BMTrackFinder",
-                                      CSCStub_Source=cms.InputTag("simCsctfTrackDigis"),
-                                      DTDigi_Source=cms.InputTag("simDtTriggerPrimitiveDigis"),
-                                      Debug=cms.untracked.int32(0)
+# TwinMux Emulator
+process.load('L1Trigger.L1TMuonTrackFinderBarrel.L1TTwinMuxProducer_cfi')
 
-                                      )
+# BMTF Emulator
+process.load('L1Trigger.L1TMuonTrackFinderBarrel.bmtfDigis_cfi')
+process.bmtfDigis.DTDigi_Source=cms.InputTag("L1TTwinMuxProducer")
 
 process.MicroGMTCaloInputProducer = cms.EDProducer("L1TMicroGMTCaloInputProducer",
                                                caloStage2Layer2Label=cms.InputTag("caloStage2Layer1Digis"),
 )
 # WORKAROUNDS FOR WRONG SCALES / MISSING COLLECTIONS:
-process.bmtfConverter = cms.EDProducer("L1TBMTFConverter",)
+process.bmtfConverter = cms.EDProducer("L1TBMTFConverter",
+                                       barrelTFInput = cms.InputTag("bmtfDigis", "BM"))
 
 # Adjust input tags if running on GEN-SIM-RAW (have to re-digi)
 if SAMPLE == "zmumu" or SAMPLE == "minbias":
@@ -126,6 +128,7 @@ process.load("L1TriggerDPG.L1Ntuples.l1ExtraTreeProducer_cfi")
 process.load("L1TriggerDPG.L1Ntuples.l1MuonRecoTreeProducer_cfi")
 process.load("L1TriggerDPG.L1Ntuples.l1MuonUpgradeTreeProducer_cfi")
 
+# uGMT emulator
 process.load("L1Trigger.L1TMuon.l1tmicrogmtproducer_cfi")
 
 process.microGMTEmulator.overlapTFInput = cms.InputTag("omtfEmulator", "OMTF")
@@ -137,20 +140,12 @@ process.l1MuonUpgradeTreeProducer.bmtfTag = cms.InputTag("bmtfConverter", "ConvB
 process.microGMTEmulator.triggerTowerInput = cms.InputTag("MicroGMTCaloInputProducer", "TriggerTowerSums")
 process.l1MuonUpgradeTreeProducer.calo2x2Tag = cms.InputTag("MicroGMTCaloInputProducer", "TriggerTower2x2s")
 process.l1MuonUpgradeTreeProducer.caloTag = cms.InputTag("caloStage2Layer1Digis")
-
-# disable pre-loaded cancel-out lookup tables (they currently contain only 0)
-process.microGMTEmulator.OvlNegSingleMatchQualLUTSettings.filename = cms.string("")
-process.microGMTEmulator.OvlPosSingleMatchQualLUTSettings.filename = cms.string("")
-process.microGMTEmulator.FOPosMatchQualLUTSettings.filename = cms.string("")
-process.microGMTEmulator.FONegMatchQualLUTSettings.filename = cms.string("")
-process.microGMTEmulator.BrlSingleMatchQualLUTSettings.filename = cms.string("")
-process.microGMTEmulator.BOPosMatchQualLUTSettings.filename = cms.string("")
-process.microGMTEmulator.BONegMatchQualLUTSettings.filename = cms.string("")
+process.l1MuonUpgradeTreeProducer.caloRecoTag = cms.InputTag("none")
 
 # output file
 process.TFileService = cms.Service("TFileService",
                                    fileName=cms.string(
-                                       '/afs/cern.ch/work/j/jlingema/private/l1ntuples_upgrade/l1ntuple_{sample}_n.root'.format(sample=SAMPLE))
+                                       '/afs/cern.ch/work/t/treis/private/l1ntuples_upgrade/l1ntuple_{sample}_n.root'.format(sample=SAMPLE))
                                    )
 
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
@@ -160,6 +155,38 @@ process = customise_csc_PostLS1(process)
 
 # upgrade calo stage 2
 process.load('L1Trigger.L1TCalorimeter.L1TCaloStage2_PPFromRaw_cff')
+
+# L1TMicroGMTESProducer
+process.load('L1Trigger.L1TMuon.l1tmicrogmtparamsesproducer_cfi')
+# reset LUT paths to trigger CMSSW internal LUT generation
+#process.l1tGMTParamsESProducer.AbsIsoCheckMemLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.RelIsoCheckMemLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.IdxSelMemPhiLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.IdxSelMemEtaLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.BrlSingleMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.FwdPosSingleMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.FwdNegSingleMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.OvlPosSingleMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.OvlNegSingleMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.BOPosMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.BONegMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.FOPosMatchQualLUTPath = cms.string('')
+process.l1tGMTParamsESProducer.FONegMatchQualLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.BPhiExtrapolationLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.OPhiExtrapolationLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.FPhiExtrapolationLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.BEtaExtrapolationLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.OEtaExtrapolationLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.FEtaExtrapolationLUTPath = cms.string('')
+#process.l1tGMTParamsESProducer.SortRankLUTPath = cms.string('')
+
+process.esTest = cms.EDAnalyzer("EventSetupRecordDataGetter",
+   toGet = cms.VPSet(
+      cms.PSet(record = cms.string('L1TGMTParamsRcd'),
+               data = cms.vstring('L1TGMTParams'))
+                    ),
+   verbose = cms.untracked.bool(True)
+)
 
 # analysis
 process.l1NtupleProducer.hltSource = cms.InputTag("none")
@@ -177,7 +204,7 @@ process.l1NtupleProducer.ecalSource = cms.InputTag("none")
 process.l1NtupleProducer.hcalSource = cms.InputTag("none")
 process.l1NtupleProducer.csctfTrkSource = cms.InputTag("none")
 process.l1NtupleProducer.csctfLCTSource = cms.InputTag("none")
-process.l1NtupleProducer.csctfLCTSource = cms.InputTag("none")
+process.l1NtupleProducer.csctfStatusSource = cms.InputTag("none")
 process.l1NtupleProducer.generatorSource = cms.InputTag("genParticles")
 process.l1NtupleProducer.csctfDTStubsSource = cms.InputTag("none")
 
@@ -201,7 +228,8 @@ process.L1NtupleSeq = cms.Sequence(process.l1NtupleProducer + process.l1MuonUpgr
 
 process.L1TMuonSeq = cms.Sequence(
     process.L1TMuonTriggerPrimitives
-    + process.bmtfEmulator
+    + process.L1TTwinMuxProducer
+    + process.bmtfDigis
     + process.bmtfConverter
     + process.omtfEmulator
     + process.L1TMuonEndcapTrackFinder


### PR DESCRIPTION
Fix uGMT muon pt scales. 
Add TwinMux to emulator chain for testing. 
Increased class version for BMTrackCand to 23.
