### PR TITLE
Set eta value of DT hits to 0.9. This is only temporary setting.

### DIFF
--- a/L1Trigger/L1TMuonTrackFinderOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonTrackFinderOverlap/src/OMTFinputMaker.cc
@@ -107,8 +107,7 @@ bool  OMTFinputMaker::acceptDigi(uint32_t rawId,
     break;
   }
   case MuonSubdetId::CSC: {
-    CSCDetId csc(rawId);
-    
+    CSCDetId csc(rawId);    
     if(type==l1t::tftype::omtf_pos &&
        (csc.endcap()==2 || csc.ring()==1 || csc.station()==4)) return false;
     if(type==l1t::tftype::omtf_neg &&
@@ -225,8 +224,6 @@ void OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
 	       unsigned int iProcessor,
 	       l1t::tftype type){
 
-  //std::cout<<"DT size: "<<dtPhDigis->getContainer()->size()<<std::endl;
-
   if(!dtPhDigis) return;
 
   for (const auto digiIt: *dtPhDigis->getContainer()) {
@@ -243,7 +240,7 @@ void OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
     
     unsigned int iLayer = OMTFConfiguration::hwToLogicLayer[hwNumber];   
     int iPhi =  katownik->getGlobalPhi(detid.rawId(), digiIt);
-    int iEta =  0;//TEST
+    int iEta =  0.9;//Temporary value.
     unsigned int iInput= getInputNumber(detid.rawId(), iProcessor, type);
 
     myInput->addLayerHit(iLayer,iInput,iPhi,iEta);
@@ -261,7 +258,7 @@ void OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDigis,
   
   auto chamber = cscDigis->begin();
   auto chend  = cscDigis->end();
-  for( ; chamber != chend; ++chamber ) {   
+  for( ; chamber != chend; ++chamber ) {    
     unsigned int rawid = (*chamber).first;
     ///Check it the data fits into given processor input range
     if(!acceptDigi(rawid, iProcessor, type)) continue;
@@ -271,7 +268,7 @@ void OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDigis,
     for( ; digi != dend; ++digi ) {
 
       ///Check Trigger primitive quality.
-      ///CSC central BX is 6 for some reason. 
+      ///CSC central BX is 6 for some reason.
       if (abs(digi->getBX()- 6)>0) continue;
       
       unsigned int hwNumber = OMTFConfiguration::getLayerNumber(rawid);

--- a/L1Trigger/L1TMuonTrackFinderOverlap/test/runOMTFProducer.py
+++ b/L1Trigger/L1TMuonTrackFinderOverlap/test/runOMTFProducer.py
@@ -64,7 +64,8 @@ process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 process.source = cms.Source(
     'PoolSource',
     #fileNames = cms.untracked.vstring('file:/home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/SingleMuFullEtaTestSample/720_FullEta_v1/data/SingleMu_16_p_1_2_TWz.root')
-    fileNames = cms.untracked.vstring('file:/home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/JPsi_21kEvents.root')
+    #fileNames = cms.untracked.vstring('file:/home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/JPsi_21kEvents.root')
+    fileNames = cms.untracked.vstring('file:/home/akalinow/scratch/CMS/OverlapTrackFinder/Prod/test/test.root')
     )
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100))
@@ -77,14 +78,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
-###OMTF CondFormats ESProducer. ESSetup is filled from XML file
-#process.load('L1Trigger.L1TMuonTrackFinderOverlap.omtfParams_cfi')
-
 ###OMTF emulator configuration
 process.load('L1Trigger.L1TMuonTrackFinderOverlap.OMTFProducer_cff')
-
-
-#process.load('L1Trigger.L1TMuonTrackFinderOverlap.OMTFProducer_cfi')
 ##Load configuration directly from XML
 #process.omtfEmulator.omtf.configFromXML = cms.bool(True)
 ##Dump event to XML file


### PR DESCRIPTION
After removing MuonTriggerPrimitive I have to rewrite code matching DT phi and eta digis to be in agreement with HW implementation. Before I finish it DT seeded candidates have assigned a constant eta value of 0.9 (it was 0.0 in previous commith which is a bas value for performacne studies).
