### PR TITLE
muon unpacker debugging

### DIFF
--- a/DataFormats/L1TMuon/interface/RegionalMuonCand.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCand.h
@@ -53,7 +53,7 @@ class RegionalMuonCand {
     // this is left to still be compatible with OMTF
     void setLink(int link);
     // Set the 64 bit word from two 32 words. bits 0-31->lsbs, bits 32-63->msbs
-    void setDataword(int msbs, int lsbs) { m_dataword = (((uint64_t)msbs) << 32) + lsbs; };
+    void setDataword(uint32_t msbs, uint32_t lsbs) { m_dataword = (((uint64_t)msbs) << 32) + lsbs; };
     // Set the 64 bit word coming from HW directly
     void setDataword(uint64_t bits) { m_dataword = bits; };
     /// Set a part of the muon candidates track address; specialised for BMTF
@@ -93,9 +93,9 @@ class RegionalMuonCand {
     /// Get 64 bit data word
     const uint64_t dataword() const { return m_dataword; };
     /// Get 32 MSBs of data word
-    const int dataword32Msb() const { return (int)((m_dataword >> 32) & 0xFFFFFFFF); };
+    const uint32_t dataword32Msb() const { return (uint32_t)((m_dataword >> 32) & 0xFFFFFFFF); };
     /// Get 32 LSBs of data word
-    const int dataword32Lsb() const { return (int)(m_dataword & 0xFFFFFFFF); };
+    const uint32_t dataword32Lsb() const { return (uint32_t)(m_dataword & 0xFFFFFFFF); };
     /// Get the track address (identifies track primitives used for reconstruction)
     const std::map<int, int>& trackAddress() const {
         return m_trackAddress;

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MuonUnpacker.cc
@@ -25,9 +25,9 @@ namespace l1t {
 
          auto payload = block.payload();
 
-         int nwords = 6; // every link transmits 6 words (3 muons) per bx
+         unsigned int nWords = 6; // every link transmits 6 words (3 muons) per bx
          int nBX, firstBX, lastBX;
-         nBX = int(ceil(block.header().getSize() / nwords));
+         nBX = int(ceil(block.header().getSize() / nWords));
          getBXRange(nBX, firstBX, lastBX);
          // only use central BX for now
          //firstBX = 0;
@@ -44,12 +44,13 @@ namespace l1t {
 
          // Loop over multiple BX and then number of muons filling muon collection
          for (int bx = firstBX; bx <= lastBX; ++bx) {
-            for (unsigned nWord = 0; nWord < block.header().getSize(); nWord += 2) {
+            for (unsigned nWord = 0; nWord < nWords; nWord += 2) {
                uint32_t raw_data_00_31 = payload[i++];
                uint32_t raw_data_32_63 = payload[i++];        
                LogDebug("L1T|Muon") << "raw_data_00_31 = 0x" << hex << raw_data_00_31 << " raw_data_32_63 = 0x" << raw_data_32_63;
-               // skip empty muons (all 64 bits 0)
-               if (raw_data_00_31 == 0 && raw_data_32_63 == 0) {
+               // skip empty muons
+               // the msb are reserved for global information
+               if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
                   LogDebug("L1T|Muon") << "Raw data is zero. Skip.";
                   continue;
                }

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MuonUnpacker.cc
@@ -25,7 +25,7 @@ namespace l1t {
 
          auto payload = block.payload();
 
-         int nwords = 2; // every link transmits 2 words per event
+         int nwords = 6; // every link transmits 6 words (3 muons) per bx
          int nBX, firstBX, lastBX;
          nBX = int(ceil(block.header().getSize() / nwords));
          getBXRange(nBX, firstBX, lastBX);

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -25,7 +25,7 @@ namespace l1t {
 
          auto payload = block.payload();
 
-         int nwords = 2; // every link transmits 2 words per event
+         int nwords = 6; // every link transmits 6 words (3 muons) per bx
          int nBX, firstBX, lastBX;
          nBX = int(ceil(block.header().getSize() / nwords));
          getBXRange(nBX, firstBX, lastBX);

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -25,9 +25,9 @@ namespace l1t {
 
          auto payload = block.payload();
 
-         int nwords = 6; // every link transmits 6 words (3 muons) per bx
+         unsigned int nWords = 6; // every link transmits 6 words (3 muons) per bx
          int nBX, firstBX, lastBX;
-         nBX = int(ceil(block.header().getSize() / nwords));
+         nBX = int(ceil(block.header().getSize() / nWords));
          getBXRange(nBX, firstBX, lastBX);
          // only use central BX for now
          //firstBX = 0;
@@ -74,12 +74,13 @@ namespace l1t {
 
          // Loop over multiple BX and then number of muons filling muon collection
          for (int bx = firstBX; bx <= lastBX; ++bx) {
-            for (unsigned nWord = 0; nWord < block.header().getSize(); nWord += 2) {
+            for (unsigned nWord = 0; nWord < nWords; nWord += 2) {
                uint32_t raw_data_00_31 = payload[i++];
                uint32_t raw_data_32_63 = payload[i++];        
                LogDebug("L1T|Muon") << "raw_data_00_31 = 0x" << hex << raw_data_00_31 << " raw_data_32_63 = 0x" << raw_data_32_63;
-               // skip empty muons (all 64 bits 0)
-               if (raw_data_00_31 == 0 && raw_data_32_63 == 0) {
+               // skip empty muons
+               // the msb are reserved for global information
+               if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
                   LogDebug("L1T|Muon") << "Raw data is zero. Skip.";
                   continue;
                }


### PR DESCRIPTION
Some debugging for the uGMT unpackers. fixing wrong bx lengths.
Fixing dataword setter RegionalMuonCand.
