### PR TITLE
Drop muons from unpacking already if only pt == 0

### DIFF
--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MuonUnpacker.cc
@@ -48,10 +48,9 @@ namespace l1t {
                uint32_t raw_data_00_31 = payload[i++];
                uint32_t raw_data_32_63 = payload[i++];        
                LogDebug("L1T|Muon") << "raw_data_00_31 = 0x" << hex << raw_data_00_31 << " raw_data_32_63 = 0x" << raw_data_32_63;
-               // skip empty muons
-               // the msb are reserved for global information
-               if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
-                  LogDebug("L1T|Muon") << "Raw data is zero. Skip.";
+               // skip empty muons (hwPt == 0)
+               if (((raw_data_00_31 >> l1t::MuonRawDigiTranslator::ptShift_) & l1t::MuonRawDigiTranslator::ptMask_) == 0) {
+                  LogDebug("L1T|Muon") << "Muon hwPt zero. Skip.";
                   continue;
                }
 

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -78,10 +78,11 @@ namespace l1t {
                uint32_t raw_data_00_31 = payload[i++];
                uint32_t raw_data_32_63 = payload[i++];        
                LogDebug("L1T|Muon") << "raw_data_00_31 = 0x" << hex << raw_data_00_31 << " raw_data_32_63 = 0x" << raw_data_32_63;
-               // skip empty muons
-               // the msb are reserved for global information
-               if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
-                  LogDebug("L1T|Muon") << "Raw data is zero. Skip.";
+               // skip empty muons (hwPt == 0)
+               //// the msb are reserved for global information
+               //if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
+               if (((raw_data_00_31 >> l1t::RegionalMuonRawDigiTranslator::ptShift_) & l1t::RegionalMuonRawDigiTranslator::ptMask_) == 0) {
+                  LogDebug("L1T|Muon") << "Muon hwPt zero. Skip.";
                   continue;
                }
  

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -11,19 +11,18 @@ namespace l1t {
       static void generatePackedDataWords(const Muon&, uint32_t&, uint32_t&);
       static uint64_t generate64bitDataWord(const Muon&);
 
-    private:
-      static const unsigned ptWidth_ = 0x1FF;
+      static const unsigned ptMask_ = 0x1FF;
       static const unsigned ptShift_ = 10;
-      static const unsigned qualWidth_ = 0xF;
+      static const unsigned qualMask_ = 0xF;
       static const unsigned qualShift_ = 19;
-      static const unsigned absEtaWidth_ = 0xFF;
+      static const unsigned absEtaMask_ = 0xFF;
       static const unsigned absEtaShift_ = 23;
       static const unsigned etaSignShift_ = 31;
-      static const unsigned phiWidth_ = 0x3FF;
+      static const unsigned phiMask_ = 0x3FF;
       static const unsigned phiShift_ = 0;
       static const unsigned chargeShift_ = 2;
       static const unsigned chargeValidShift_ = 3;
-      static const unsigned isoWidth_ = 0x3;
+      static const unsigned isoMask_ = 0x3;
       static const unsigned isoShift_ = 0;
   };
 }

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -11,7 +11,6 @@ namespace l1t {
       static void generatePackedDataWords(const RegionalMuonCand&, uint32_t&, uint32_t&);
       static uint64_t generate64bitDataWord(const RegionalMuonCand&);
 
-    private:
       static const unsigned ptMask_ = 0x1FF;
       static const unsigned ptShift_ = 0;
       static const unsigned qualMask_ = 0xF;

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -4,19 +4,19 @@
 void
 l1t::MuonRawDigiTranslator::fillMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63)
 {
-  mu.setHwPt((raw_data_00_31 >> ptShift_) & ptWidth_);
-  mu.setHwQual((raw_data_00_31 >> qualShift_) & qualWidth_);
+  mu.setHwPt((raw_data_00_31 >> ptShift_) & ptMask_);
+  mu.setHwQual((raw_data_00_31 >> qualShift_) & qualMask_);
   
   // eta is coded as two's complement
-  int abs_eta = (raw_data_00_31 >> absEtaShift_) & absEtaWidth_;
+  int abs_eta = (raw_data_00_31 >> absEtaShift_) & absEtaMask_;
   if ((raw_data_00_31 >> etaSignShift_) & 0x1) {
      mu.setHwEta(abs_eta - (1 << (etaSignShift_ - absEtaShift_)));
   } else {
      mu.setHwEta(abs_eta);
   }
 
-  mu.setHwPhi((raw_data_00_31 >> phiShift_) & phiWidth_);
-  mu.setHwIso((raw_data_32_63 >> isoShift_) & isoWidth_); 
+  mu.setHwPhi((raw_data_00_31 >> phiShift_) & phiMask_);
+  mu.setHwIso((raw_data_32_63 >> isoShift_) & isoMask_); 
   // charge is coded as -1^chargeBit
   int chargeBit = (raw_data_32_63 >> chargeShift_) & 0x1;
   mu.setHwCharge(1 - 2*chargeBit);
@@ -41,15 +41,15 @@ l1t::MuonRawDigiTranslator::generatePackedDataWords(const Muon& mu, uint32_t &ra
   if (abs_eta < 0) {
     abs_eta += (1 << (etaSignShift_ - absEtaShift_));
   }
-  raw_data_00_31 = (mu.hwPt() & ptWidth_) << ptShift_
-                 | (mu.hwQual() & qualWidth_) << qualShift_
-                 | (abs_eta & absEtaWidth_) << absEtaShift_
+  raw_data_00_31 = (mu.hwPt() & ptMask_) << ptShift_
+                 | (mu.hwQual() & qualMask_) << qualShift_
+                 | (abs_eta & absEtaMask_) << absEtaShift_
                  | (mu.hwEta() < 0) << etaSignShift_
-                 | (mu.hwPhi() & phiWidth_) << phiShift_;
+                 | (mu.hwPhi() & phiMask_) << phiShift_;
 
   raw_data_32_63 = (mu.hwCharge() < 0) << chargeShift_
                  | mu.hwChargeValid() << chargeValidShift_
-                 | (mu.hwIso() & isoWidth_) << isoShift_;
+                 | (mu.hwIso() & isoMask_) << isoShift_;
 }
 
 uint64_t 


### PR DESCRIPTION
Instead of ignoring 32 bit words if they are entirely 0, ignore already if just the pt bits are 0.
