### PR TITLE
bmtf wheel number change in RegionalMuonCand

### DIFF
--- a/DataFormats/L1TMuon/interface/RegionalMuonCand.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCand.h
@@ -9,7 +9,7 @@ class RegionalMuonCand {
   public:
     /// Enum to identify the individual parts of the BMTF track address
     enum bmtfAddress {
-        kWheelSide=0, kWheelNum=1, kStat1=2, kStat2=3, kStat3=4, kStat4=5
+        kWheelSide=0, kWheelNum=1, kStat1=2, kStat2=3, kStat3=4, kStat4=5, kSegSelStat1=6, kSegSelStat2=7, kSegSelStat3=8, kSegSelStat4=9
     };
     /// Enum to identify the individual parts of the EMTF track address
     enum emtfAddress {

--- a/DataFormats/L1TMuon/interface/RegionalMuonCand.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCand.h
@@ -51,7 +51,7 @@ class RegionalMuonCand {
     /// Set the processor ID, track-finder type. From these two, the link is set
     void setTFIdentifiers(int processor, tftype trackFinder);
     // this is left to still be compatible with OMTF
-    void setLink(int link);
+    void setLink(int link) {m_link = link; };
     // Set the 64 bit word from two 32 words. bits 0-31->lsbs, bits 32-63->msbs
     void setDataword(uint32_t msbs, uint32_t lsbs) { m_dataword = (((uint64_t)msbs) << 32) + lsbs; };
     // Set the 64 bit word coming from HW directly
@@ -84,7 +84,7 @@ class RegionalMuonCand {
     const int hwQual() const { return m_hwQuality; };
     /// Get link on which the MicroGMT receives the candidate
     const int link() const { return m_link; };
-    /// Get processor ID on which the candidate was found (1..6 for OMTF/EMTF; 1..12 for BMTF)
+    /// Get processor ID on which the candidate was found (0..5 for OMTF/EMTF; 0..11 for BMTF)
     const int processor() const { return m_processor; };
     /// Get track-finder which found the muon (bmtf, emtf_pos/emtf_neg or omtf_pos/omtf_neg)
     const tftype trackFinderType() const { return m_trackFinder; };

--- a/DataFormats/L1TMuon/interface/RegionalMuonCand.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCand.h
@@ -9,7 +9,7 @@ class RegionalMuonCand {
   public:
     /// Enum to identify the individual parts of the BMTF track address
     enum bmtfAddress {
-        kWheel=0, kStat1=1, kStat2=2, kStat3=3, kStat4=4
+        kWheelSide=0, kWheelNum=1, kStat1=2, kStat2=3, kStat3=4, kStat4=5
     };
     /// Enum to identify the individual parts of the EMTF track address
     enum emtfAddress {

--- a/L1Trigger/L1TMuon/src/MicroGMTCancelOutUnit.cc
+++ b/L1Trigger/L1TMuon/src/MicroGMTCancelOutUnit.cc
@@ -186,49 +186,43 @@ MicroGMTCancelOutUnit::getTrackAddrCancelBits(std::vector<std::shared_ptr<GMTInt
   if ((*coll1.begin())->trackFinderType() == tftype::bmtf && (*coll2.begin())->trackFinderType() == tftype::bmtf) {
     for (auto mu_w1 = coll1.begin(); mu_w1 != coll1.end(); ++mu_w1) {
       std::map<int, int> trkAddr_w1 = (*mu_w1)->origin().trackAddress();
-      int wheel_w1 = trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kWheel];
+      int wheelNum_w1 = trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kWheelNum];
+      int wheelSide_w1 = trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kWheelSide];
       std::vector<int> stations_w1;
       stations_w1.push_back(trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kStat1]);
       stations_w1.push_back(trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kStat2]);
       stations_w1.push_back(trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kStat3]);
       stations_w1.push_back(trkAddr_w1[l1t::RegionalMuonCand::bmtfAddress::kStat4]);
-      //std::cout << "Track address 1: wheel: " << wheel_w1 << ", stations1234: 0x" << hex << stations_w1[0] << stations_w1[1] << stations_w1[2] << stations_w1[3] << dec << std::endl;
+      //std::cout << "Track address 1: wheelSide (1 == negative side): " << wheelSide_w1 << ", wheelNum: " << wheelNum_w1 << ", stations1234: 0x" << hex << stations_w1[0] << stations_w1[1] << stations_w1[2] << stations_w1[3] << dec << std::endl;
 
       for (auto mu_w2 = coll2.begin(); mu_w2 != coll2.end(); ++mu_w2) {
         std::map<int, int> trkAddr_w2 = (*mu_w2)->origin().trackAddress();
-        int wheel_w2 = trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kWheel];
+        int wheelNum_w2 = trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kWheelNum];
+        int wheelSide_w2 = trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kWheelSide];
         std::vector<int> stations_w2;
         stations_w2.push_back(trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kStat1]);
         stations_w2.push_back(trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kStat2]);
         stations_w2.push_back(trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kStat3]);
         stations_w2.push_back(trkAddr_w2[l1t::RegionalMuonCand::bmtfAddress::kStat4]);
-        //std::cout << "Track address 2: wheel: " << wheel_w2 << ", stations1234: 0x" << hex << stations_w2[0] << stations_w2[1] << stations_w2[2] << stations_w2[3] << dec << std::endl;
+        //std::cout << "Track address 2: wheelSide (1 == negative side): " << wheelSide_w2 << ", wheelNum: " << wheelNum_w2 << ", stations1234: 0x" << hex << stations_w2[0] << stations_w2[1] << stations_w2[2] << stations_w2[3] << dec << std::endl;
 
         int nMatchedStations = 0;
         // search for duplicates in stations 2-4
         for (int i = 1; i < 4; ++i) {
-          if (wheel_w1 == wheel_w2) { // both tracks have the same reference wheel on the same detector side
-            if ((stations_w1[i] == 0x0 && stations_w2[i] == 0x2) ||
-                (stations_w1[i] == 0x1 && stations_w2[i] == 0x3) ||
-                (stations_w1[i] == 0x4 && stations_w2[i] == 0x0) ||
-                (stations_w1[i] == 0x5 && stations_w2[i] == 0x1) ||
-                (stations_w1[i] == 0x8 && stations_w2[i] == 0xA) ||
-                (stations_w1[i] == 0x9 && stations_w2[i] == 0xB) ||
-                (stations_w1[i] == 0xC && stations_w2[i] == 0x8) ||
-                (stations_w1[i] == 0xD && stations_w2[i] == 0x9))
-            {
-              ++nMatchedStations;
-            }
-          } else if (wheel_w1 * wheel_w2 == -1) { // both tracks are on either side of the central wheel (+1 and -1)
-            if ((stations_w1[i] == 0x8 && stations_w2[i] == 0xA) ||
-                (stations_w1[i] == 0x9 && stations_w2[i] == 0xB) ||
-                (stations_w1[i] == 0xC && stations_w2[i] == 0x8) ||
-                (stations_w1[i] == 0xD && stations_w2[i] == 0x9))
-            {
-              ++nMatchedStations;
-            }
-          } else if (wheel_w1 * wheel_w2 > 0) {
-            if (abs(wheel_w1) == abs(wheel_w2) - 1) { // track 2 is one wheel higher than track 1 on the same detector side
+          if (wheelSide_w1 == wheelSide_w2) { // both tracks are on the same detector side
+            if (wheelNum_w1 == wheelNum_w2) { // both tracks have the same reference wheel
+              if ((stations_w1[i] == 0x0 && stations_w2[i] == 0x2) ||
+                  (stations_w1[i] == 0x1 && stations_w2[i] == 0x3) ||
+                  (stations_w1[i] == 0x4 && stations_w2[i] == 0x0) ||
+                  (stations_w1[i] == 0x5 && stations_w2[i] == 0x1) ||
+                  (stations_w1[i] == 0x8 && stations_w2[i] == 0xA) ||
+                  (stations_w1[i] == 0x9 && stations_w2[i] == 0xB) ||
+                  (stations_w1[i] == 0xC && stations_w2[i] == 0x8) ||
+                  (stations_w1[i] == 0xD && stations_w2[i] == 0x9))
+              {
+                ++nMatchedStations;
+              }
+            } else if (wheelNum_w1 == wheelNum_w2 - 1) { // track 2 is one wheel higher than track 1
               if ((stations_w1[i] == 0x0 && stations_w2[i] == 0xA) ||
                   (stations_w1[i] == 0x1 && stations_w2[i] == 0xB) ||
                   (stations_w1[i] == 0x4 && stations_w2[i] == 0x8) ||
@@ -236,11 +230,21 @@ MicroGMTCancelOutUnit::getTrackAddrCancelBits(std::vector<std::shared_ptr<GMTInt
               {
                 ++nMatchedStations;
               }
-            } else if (abs(wheel_w1) == abs(wheel_w2) + 1) { // track 2 is one wheel lower than track 1 on the same detector side
+            } else if (wheelNum_w1 == wheelNum_w2 + 1) { // track 2 is one wheel lower than track 1
               if ((stations_w1[i] == 0x8 && stations_w2[i] == 0x2) ||
                   (stations_w1[i] == 0x9 && stations_w2[i] == 0x3) ||
                   (stations_w1[i] == 0xC && stations_w2[i] == 0x0) ||
                   (stations_w1[i] == 0xD && stations_w2[i] == 0x1))
+              {
+                ++nMatchedStations;
+              }
+            }
+          } else {
+            if (wheelNum_w1 == 0 && wheelNum_w2 == 0) { // both tracks are on either side of the central wheel (+0 and -0)
+              if ((stations_w1[i] == 0x8 && stations_w2[i] == 0xA) ||
+                  (stations_w1[i] == 0x9 && stations_w2[i] == 0xB) ||
+                  (stations_w1[i] == 0xC && stations_w2[i] == 0x8) ||
+                  (stations_w1[i] == 0xD && stations_w2[i] == 0x9))
               {
                 ++nMatchedStations;
               }

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -33,7 +33,7 @@ l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& mu, u
   if (tf == bmtf) {
     int segSel = (rawTrackAddress >> bmtfTrAddrSegSelShift_) & bmtfTrAddrSegSelMask_;
     int detSide = (rawTrackAddress >> bmtfTrAddrDetSideShift_) & 0x1;
-    int wheel = (1 - 2*detSide) * ((rawTrackAddress >> bmtfTrAddrWheelShift_) & bmtfTrAddrWheelMask_);
+    int wheelNum = (rawTrackAddress >> bmtfTrAddrWheelShift_) & bmtfTrAddrWheelMask_;
     int statAddr1 = ((rawTrackAddress >> bmtfTrAddrStat1Shift_) & bmtfTrAddrStat1Mask_)
                   | ((segSel & 0x1) << 2);
     int statAddr2 = ((rawTrackAddress >> bmtfTrAddrStat2Shift_) & bmtfTrAddrStat2Mask_)
@@ -42,7 +42,8 @@ l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& mu, u
                   | ((segSel & 0x4) << 2);
     int statAddr4 = ((rawTrackAddress >> bmtfTrAddrStat4Shift_) & bmtfTrAddrStat4Mask_)
                   | ((segSel & 0x8) << 1);
-    mu.setTrackSubAddress(RegionalMuonCand::kWheel, wheel);
+    mu.setTrackSubAddress(RegionalMuonCand::kWheelSide, detSide);
+    mu.setTrackSubAddress(RegionalMuonCand::kWheelNum, wheelNum);
     mu.setTrackSubAddress(RegionalMuonCand::kStat1, statAddr1);
     mu.setTrackSubAddress(RegionalMuonCand::kStat2, statAddr2);
     mu.setTrackSubAddress(RegionalMuonCand::kStat3, statAddr3);
@@ -90,7 +91,8 @@ l1t::RegionalMuonRawDigiTranslator::generatePackedDataWords(const RegionalMuonCa
   int tf = mu.trackFinderType();
   int rawTrkAddr = 0;
   if (tf == bmtf) {
-    int wheel = mu.trackSubAddress(RegionalMuonCand::kWheel);
+    int detSide = mu.trackSubAddress(RegionalMuonCand::kWheelSide);
+    int wheelNum = mu.trackSubAddress(RegionalMuonCand::kWheelNum);
     int stat1 = mu.trackSubAddress(RegionalMuonCand::kStat1);
     int stat2 = mu.trackSubAddress(RegionalMuonCand::kStat2);
     int stat3 = mu.trackSubAddress(RegionalMuonCand::kStat3);
@@ -102,8 +104,8 @@ l1t::RegionalMuonRawDigiTranslator::generatePackedDataWords(const RegionalMuonCa
                | (stat4 & 0x10) >> 1;
 
     rawTrkAddr = (segSel & bmtfTrAddrSegSelMask_) << bmtfTrAddrSegSelShift_
-               | (wheel < 0) << bmtfTrAddrDetSideShift_
-               | (abs(wheel) & bmtfTrAddrWheelMask_) << bmtfTrAddrWheelShift_
+               | (detSide & 0x1) << bmtfTrAddrDetSideShift_
+               | (wheelNum & bmtfTrAddrWheelMask_) << bmtfTrAddrWheelShift_
                | (stat1 & bmtfTrAddrStat1Mask_) << bmtfTrAddrStat1Shift_
                | (stat2 & bmtfTrAddrStat2Mask_) << bmtfTrAddrStat2Shift_
                | (stat3 & bmtfTrAddrStat3Mask_) << bmtfTrAddrStat3Shift_

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -48,6 +48,10 @@ l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& mu, u
     mu.setTrackSubAddress(RegionalMuonCand::kStat2, statAddr2);
     mu.setTrackSubAddress(RegionalMuonCand::kStat3, statAddr3);
     mu.setTrackSubAddress(RegionalMuonCand::kStat4, statAddr4);
+    mu.setTrackSubAddress(RegionalMuonCand::kSegSelStat1, segSel & 0x1);
+    mu.setTrackSubAddress(RegionalMuonCand::kSegSelStat2, segSel & 0x2);
+    mu.setTrackSubAddress(RegionalMuonCand::kSegSelStat3, segSel & 0x4);
+    mu.setTrackSubAddress(RegionalMuonCand::kSegSelStat4, segSel & 0x8);
   } else if (tf == emtf_neg || tf == emtf_pos) {
     int me12 = (rawTrackAddress >> emtfTrAddrMe12Shift_) & emtfTrAddrMe12Mask_;
     int me22 = (rawTrackAddress >> emtfTrAddrMe22Shift_) & emtfTrAddrMe22Mask_;
@@ -98,10 +102,10 @@ l1t::RegionalMuonRawDigiTranslator::generatePackedDataWords(const RegionalMuonCa
     int stat3 = mu.trackSubAddress(RegionalMuonCand::kStat3);
     int stat4 = mu.trackSubAddress(RegionalMuonCand::kStat4);
 
-    int segSel = (stat1 & 0x4) >> 2
-               | (stat2 & 0x10) >> 3
-               | (stat3 & 0x10) >> 2
-               | (stat4 & 0x10) >> 1;
+    int segSel = mu.trackSubAddress(RegionalMuonCand::kSegSelStat1)
+               | (mu.trackSubAddress(RegionalMuonCand::kSegSelStat2)) >> 1
+               | (mu.trackSubAddress(RegionalMuonCand::kSegSelStat3)) >> 2
+               | (mu.trackSubAddress(RegionalMuonCand::kSegSelStat4)) >> 3;
 
     rawTrkAddr = (segSel & bmtfTrAddrSegSelMask_) << bmtfTrAddrSegSelShift_
                | (detSide & 0x1) << bmtfTrAddrDetSideShift_

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc
@@ -227,7 +227,8 @@ void L1MuBMTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
             int abs_add_3 = setAdd(3,cand->address(3));
             int abs_add_4 = setAdd(4,cand->address(4));
 
-            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheel, cand->spid().wheel()); // this has to be set!
+            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheelSide, cand->spid().wheel() < 0); // this has to be set!
+            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheelNum, abs(cand->spid().wheel()) - 1); // this has to be set!
             rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat1, abs_add_1);
             rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat2, abs_add_2);
             rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat3, abs_add_3);
@@ -268,7 +269,8 @@ void L1MuBMTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
         int abs_add_3 = setAdd(3,(*iter)->address(3));
         int abs_add_4 = setAdd(4,(*iter)->address(4));
 
-        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheel, (*iter)->spid().wheel()); // this has to be set!
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheelSide, (*iter)->spid().wheel() < 0); // this has to be set!
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheelNum, abs((*iter)->spid().wheel()) - 1); // this has to be set!
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat1, abs_add_1);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat2, abs_add_2);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat3, abs_add_3);
@@ -312,7 +314,8 @@ void L1MuBMTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
         int abs_add_3 = setAdd(3,(*iter)->address(3));
         int abs_add_4 = setAdd(4,(*iter)->address(4));
 
-        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheel, (*iter)->spid().wheel()); // this has to be set!
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheelSide, (*iter)->spid().wheel() < 0); // this has to be set!
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kWheelNum, abs((*iter)->spid().wheel()) - 1); // this has to be set!
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat1, abs_add_1);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat2, abs_add_2);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat3, abs_add_3);

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc
@@ -233,6 +233,10 @@ void L1MuBMTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
             rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat2, abs_add_2);
             rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat3, abs_add_3);
             rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat4, abs_add_4);
+            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat1, 0);
+            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat2, 0);
+            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat3, 0);
+            rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat4, 0);
 
             rmc.setHwPhi(cand->hwPhi());
             rmc.setHwSign(cand->hwSign() == 1 ? 0 : 1 );
@@ -275,6 +279,10 @@ void L1MuBMTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat2, abs_add_2);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat3, abs_add_3);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat4, abs_add_4);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat1, 0);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat2, 0);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat3, 0);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat4, 0);
 
 
         rmc.setHwPhi((*iter)->hwPhi());
@@ -320,6 +328,10 @@ void L1MuBMTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat2, abs_add_2);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat3, abs_add_3);
         rmc.setTrackSubAddress(l1t::RegionalMuonCand::kStat4, abs_add_4);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat1, 0);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat2, 0);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat3, 0);
+        rmc.setTrackSubAddress(l1t::RegionalMuonCand::kSegSelStat4, 0);
 
 
         rmc.setHwPhi((*iter)->hwPhi());


### PR DESCRIPTION
Implementing changes discussed in https://github.com/cms-l1t-offline/cmssw/issues/126

Adding also the segment selector bits necessary for a future extension to four segments sent from TwinMux to the BMTF.
