### PR TITLE
Add uGMT input TF muon index variable to l1t::Muon data format

### DIFF
--- a/DataFormats/L1Trigger/interface/Muon.h
+++ b/DataFormats/L1Trigger/interface/Muon.h
@@ -22,6 +22,7 @@ namespace l1t {
       int charge=0,
       int chargeValid=0,
       int iso=0,
+      int tfMuonIndex=-1,
       int tag=0, 
       bool debug = false,
       int isoSum = 0,
@@ -37,6 +38,7 @@ namespace l1t {
       int charge=0,
       int chargeValid=0,
       int iso=0,
+      int tfMuonIndex=-1,
       int tag=0, 
       bool debug = false,
       int isoSum = 0,
@@ -49,6 +51,7 @@ namespace l1t {
     // set integer values
     void setHwCharge(int charge);
     void setHwChargeValid(int valid);
+    void setTfMuonIndex(int index);
     void setHwTag(int tag);
     
     void setHwIsoSum(int isoSum);
@@ -61,6 +64,7 @@ namespace l1t {
     // methods to retrieve integer values
     int hwCharge() const;
     int hwChargeValid() const;
+    int tfMuonIndex() const;
     int hwTag() const;
 
     int hwIsoSum() const;
@@ -75,6 +79,7 @@ namespace l1t {
     // additional hardware quantities common to L1 global jet
     int hwCharge_;
     int hwChargeValid_;
+    int tfMuonIndex_;
     int hwTag_;
 
     // additional hardware quantities only available if debug flag is set

--- a/DataFormats/L1Trigger/src/Muon.cc
+++ b/DataFormats/L1Trigger/src/Muon.cc
@@ -5,6 +5,7 @@ l1t::Muon::Muon()
   : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
     hwCharge_(0),
     hwChargeValid_(0),
+    tfMuonIndex_(-1),
     hwTag_(0),
     debug_(false),
     hwIsoSum_(0),
@@ -23,6 +24,7 @@ l1t::Muon::Muon( const LorentzVector& p4,
     int charge,
     int chargeValid,
     int iso,
+    int tfMuonIndex,
     int tag,
     bool debug,
     int isoSum,
@@ -32,6 +34,7 @@ l1t::Muon::Muon( const LorentzVector& p4,
   : L1Candidate(p4, pt, eta, phi, qual, iso),
     hwCharge_(charge),
     hwChargeValid_(chargeValid),
+    tfMuonIndex_(tfMuonIndex),
     hwTag_(tag),
     debug_(debug),
     hwIsoSum_(isoSum),
@@ -50,6 +53,7 @@ l1t::Muon::Muon( const PolarLorentzVector& p4,
     int charge,
     int chargeValid,
     int iso,
+    int tfMuonIndex,
     int tag,
     bool debug,
     int isoSum,
@@ -59,6 +63,7 @@ l1t::Muon::Muon( const PolarLorentzVector& p4,
   : L1Candidate(p4, pt, eta, phi, qual, iso),
     hwCharge_(charge),
     hwChargeValid_(chargeValid),
+    tfMuonIndex_(tfMuonIndex),
     hwTag_(tag),
     debug_(debug),
     hwIsoSum_(isoSum),
@@ -90,6 +95,12 @@ void
 l1t::Muon::setHwTag(int tag)
 {
   hwTag_ = tag;
+}
+
+void 
+l1t::Muon::setTfMuonIndex(int index)
+{
+  tfMuonIndex_ = index;
 }
 
 void 
@@ -138,6 +149,12 @@ int
 l1t::Muon::hwTag() const
 {
   return hwTag_;
+}
+
+int 
+l1t::Muon::tfMuonIndex() const
+{
+  return tfMuonIndex_;
 }
 
 int 

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -40,7 +40,8 @@
   <class name="l1t::TauBxCollection"/>
   <class name="edm::Wrapper<l1t::TauBxCollection>"/>
 
-  <class name="l1t::Muon" ClassVersion="13">
+  <class name="l1t::Muon" ClassVersion="14">
+   <version ClassVersion="14" checksum="1302394108"/>
    <version ClassVersion="13" checksum="957467775"/>
    <version ClassVersion="12" checksum="2662600115"/>
    <version ClassVersion="11" checksum="2449295419"/>

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -22,6 +22,8 @@ namespace l1t {
       static const unsigned phiShift_ = 0;
       static const unsigned chargeShift_ = 2;
       static const unsigned chargeValidShift_ = 3;
+      static const unsigned tfMuonIndexMask_ = 0x7F;
+      static const unsigned tfMuonIndexShift_ = 4;
       static const unsigned isoMask_ = 0x3;
       static const unsigned isoShift_ = 0;
   };

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -268,7 +268,7 @@ L1TMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (mu->hwPt() > 0) {
         math::PtEtaPhiMLorentzVector vec{(mu->hwPt()-1)*0.5, mu->hwEta()*0.010875, mu->hwGlobalPhi()*0.010908, 0.0};
         int iso = mu->hwAbsIso() + (mu->hwRelIso() << 1);
-        Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), mu->hwQual(), mu->hwSign(), mu->hwSignValid(), iso, 0, true, mu->hwIsoSum(), mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
+        Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), mu->hwQual(), mu->hwSign(), mu->hwSignValid(), iso, -1, 0, true, mu->hwIsoSum(), mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
         if (mu->hwSignValid()) {
           outMu.setCharge(1 - 2 * mu->hwSign());
         } else {
@@ -351,7 +351,8 @@ L1TMuonProducer::addMuonsToCollections(MicroGMTConfiguration::InterMuonList& col
     interout.push_back(mu);
     math::PtEtaPhiMLorentzVector vec{(mu->hwPt()-1)*0.5, mu->hwEta()*0.010875, mu->hwGlobalPhi()*0.010908, 0.0};
     // FIXME: once we debugged the change global -> local: Change hwLocalPhi -> hwGlobalPhi to test offsets
-    Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), mu->hwQual(), mu->hwSign(), mu->hwSignValid(), -1, 0, true, -1, mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
+    // FIXME: set tfMuonIndex to actual index
+    Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), mu->hwQual(), mu->hwSign(), mu->hwSignValid(), -1, -1, 0, true, -1, mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
     if (mu->hwSignValid()) {
       outMu.setCharge(1 - 2 * mu->hwSign());
     } else {

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -20,6 +20,7 @@ l1t::MuonRawDigiTranslator::fillMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t
   // charge is coded as -1^chargeBit
   mu.setHwCharge((raw_data_32_63 >> chargeShift_) & 0x1);
   mu.setHwChargeValid((raw_data_32_63 >> chargeValidShift_) & 0x1);
+  mu.setTfMuonIndex((raw_data_32_63 >> tfMuonIndexShift_) & tfMuonIndexMask_);
 
   if (mu.hwPt() > 0) {
     math::PtEtaPhiMLorentzVector vec{(mu.hwPt()-1)*0.5, mu.hwEta()*0.010875, mu.hwPhi()*0.010908, 0.0};
@@ -53,6 +54,7 @@ l1t::MuonRawDigiTranslator::generatePackedDataWords(const Muon& mu, uint32_t &ra
 
   raw_data_32_63 = mu.hwCharge() << chargeShift_
                  | mu.hwChargeValid() << chargeValidShift_
+                 | (mu.tfMuonIndex() & tfMuonIndexMask_) << tfMuonIndexShift_
                  | (mu.hwIso() & isoMask_) << isoShift_;
 }
 


### PR DESCRIPTION
Add a variable to the uGMT output muons that gives the index of the input muon (0 to 107). This is coded on bits 36-42 of the data  word.
Fill a dummy value in L1TMuonProducer for now. A later implementation will not change the data format anymore.
