### PR TITLE
Add TF muon index variable to upgrade muon ntuple

### DIFF
--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -73,6 +73,7 @@ namespace L1Analysis
       muonChg.clear();
       muonIso.clear();
       muonQual.clear();
+      muonTfMuonIdx.clear();
       muonBx.clear();
 
       nSums = 0;
@@ -124,6 +125,7 @@ namespace L1Analysis
     std::vector<short int>      muonChg;
     std::vector<unsigned short int> muonIso;
     std::vector<unsigned short int> muonQual;
+    std::vector<unsigned short int> muonTfMuonIdx;
     std::vector<short int>      muonBx;
 
     

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -79,9 +79,10 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuon(const edm::Handle<l1t::MuonBxColle
 	l1upgrade_.muonIEt .push_back(it->hwPt());
 	l1upgrade_.muonIEta.push_back(it->hwEta());
 	l1upgrade_.muonIPhi.push_back(it->hwPhi());
-	l1upgrade_.muonChg.push_back(0); //it->charge());
+	l1upgrade_.muonChg.push_back(it->charge());
 	l1upgrade_.muonIso.push_back(it->hwIso());
 	l1upgrade_.muonQual.push_back(it->hwQual());
+	l1upgrade_.muonTfMuonIdx.push_back(it->tfMuonIndex());
 	l1upgrade_.muonBx .push_back(ibx);
 	l1upgrade_.nMuons++;
       }


### PR DESCRIPTION
Add the TF muon index variable to the upgrade muon ntuple. It contains the link index on which the muon was received at the uGMT input and, thus, from which TF the muon comes.
Set muonChg variable to the muon charge.
