### PR TITLE
Updated L1TStage2uGT DQM module

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGT.h
@@ -66,14 +66,35 @@ private:
    std::string histFolder_; // histogram folder for L1 uGT plots
    
    // Booking of histograms for the module
-   MonitorElement* algoBits_;
-   MonitorElement* algoBits_corr_;
-   MonitorElement* algoBits_bx_global_;
-   MonitorElement* algoBits_bx_inEvt_;
-   MonitorElement* algoBits_lumi_;
+   
+   // Algorithm bits
+   MonitorElement* algoBits_after_bxomask_;
+   MonitorElement* algoBits_after_prescaler_;
+   MonitorElement* algoBits_after_mask_;
   
-   MonitorElement* prescaleFactorSet_;
+   // Algorithm bits correlation
+   MonitorElement* algoBits_after_bxomask_corr_;
+   MonitorElement* algoBits_after_prescaler_corr_;
+   MonitorElement* algoBits_after_mask_corr_;
  
+   // Algorithm bits vs global BX number
+   MonitorElement* algoBits_after_bxomask_bx_global_;
+   MonitorElement* algoBits_after_prescaler_bx_global_;
+   MonitorElement* algoBits_after_mask_bx_global_;
+  
+   // Algorithm bits vs BX number in event
+   MonitorElement* algoBits_after_bxomask_bx_inEvt_;
+   MonitorElement* algoBits_after_prescaler_bx_inEvt_;
+   MonitorElement* algoBits_after_mask_bx_inEvt_;
+
+   // Algorithm bits vs LS
+   MonitorElement* algoBits_after_bxomask_lumi_;
+   MonitorElement* algoBits_after_prescaler_lumi_;
+   MonitorElement* algoBits_after_mask_lumi_;
+ 
+   // Prescale factor index 
+   MonitorElement* prescaleFactorSet_;
+
 };
 
 #endif

--- a/DQM/L1TMonitor/src/L1TStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGT.cc
@@ -35,32 +35,76 @@ void L1TStage2uGT::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const
 void L1TStage2uGT::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const& evtSetup) {
    
    // Book histograms
-   const int numLS = 1000;
+   const int numLS = 2000;
    const double numLS_d = static_cast<double>(numLS);
    const int numAlgs = 512; // FIXME: Take number of algorithms from EventSetup
    const double numAlgs_d = static_cast<double>(numAlgs)-0.5;
 
    ibooker.setCurrentFolder(histFolder_);
-    
-   algoBits_ = ibooker.book1D("algoBits", "uGT: Algorithm Trigger Bits", numAlgs, -0.5, numAlgs_d);
-   algoBits_->setAxisTitle("Algorithm Trigger Bits", 1);
    
-   algoBits_corr_ = ibooker.book2D("algoBits_corr","uGT: Algorithm Trigger Bit Correlation", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
-   algoBits_corr_->setAxisTitle("Algorithm Trigger Bits", 1);
-   algoBits_corr_->setAxisTitle("Algorithm Trigger Bits", 2);
+   // Algorithm bits 
+   algoBits_after_bxomask_ = ibooker.book1D("algoBits_after_bxomask", "uGT: Algorithm Trigger Bits (after BX mask, before prescale)", numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 1);
    
-   algoBits_bx_global_ = ibooker.book2D("algoBits_bx_global", "uGT: Algorithm Trigger Bits vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
-   algoBits_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
-   algoBits_bx_global_->setAxisTitle("Algorithm Trigger Bits", 2);
+   algoBits_after_prescaler_ = ibooker.book1D("algoBits_after_prescaler", "uGT: Algorithm Trigger Bits (after prescale)", numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 1);
    
-   algoBits_bx_inEvt_ = ibooker.book2D("algoBits_bx_inEvt", "uGT: Algorithm Trigger Bits vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
-   algoBits_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
-   algoBits_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits", 2);
+   algoBits_after_mask_ = ibooker.book1D("algoBits_after_mask", "uGT: Algorithm Trigger Bits (after mask)", numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_->setAxisTitle("Algorithm Trigger Bits (after mask)", 1);
+  
+   // Algorithm bits correlation 
+   algoBits_after_bxomask_corr_ = ibooker.book2D("algoBits_after_bxomask_corr","uGT: Algorithm Trigger Bit Correlation (after BX mask, before prescale)", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_corr_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 1);
+   algoBits_after_bxomask_corr_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
    
-   algoBits_lumi_ = ibooker.book2D("algoBits_lumi","uGT: Algorithm Trigger Bits vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
-   algoBits_lumi_->setAxisTitle("Luminosity Segment", 1);
-   algoBits_lumi_->setAxisTitle("Algorithm Trigger Bits", 2);
- 
+   algoBits_after_prescaler_corr_ = ibooker.book2D("algoBits_after_prescaler_corr","uGT: Algorithm Trigger Bit Correlation (after prescale)", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_corr_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 1);
+   algoBits_after_prescaler_corr_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
+   
+   algoBits_after_mask_corr_ = ibooker.book2D("algoBits_after_mask_corr","uGT: Algorithm Trigger Bit Correlation (after mask)", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_corr_->setAxisTitle("Algorithm Trigger Bits (after mask)", 1);
+   algoBits_after_mask_corr_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
+  
+   // Algorithm bits vs global BX number
+   algoBits_after_bxomask_bx_global_ = ibooker.book2D("algoBits_after_bxomask_bx_global", "uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
+   algoBits_after_bxomask_bx_global_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
+   
+   algoBits_after_prescaler_bx_global_ = ibooker.book2D("algoBits_after_prescaler_bx_global", "uGT: Algorithm Trigger Bits (after prescale) vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
+   algoBits_after_prescaler_bx_global_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
+   
+   algoBits_after_mask_bx_global_ = ibooker.book2D("algoBits_after_mask_bx_global", "uGT: Algorithm Trigger Bits (after mask) vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
+   algoBits_after_mask_bx_global_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
+  
+   // Algorithm bits vs BX number in event
+   algoBits_after_bxomask_bx_inEvt_ = ibooker.book2D("algoBits_after_bxomask_bx_inEvt", "uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
+   algoBits_after_bxomask_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
+   
+   algoBits_after_prescaler_bx_inEvt_ = ibooker.book2D("algoBits_after_prescaler_bx_inEvt", "uGT: Algorithm Trigger Bits (after prescale) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
+   algoBits_after_prescaler_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
+   
+   algoBits_after_mask_bx_inEvt_ = ibooker.book2D("algoBits_after_mask_bx_inEvt", "uGT: Algorithm Trigger Bits (after mask) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
+   algoBits_after_mask_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
+  
+   // Algorithm bits vs LS
+   algoBits_after_bxomask_lumi_ = ibooker.book2D("algoBits_after_bxomask_lumi","uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_lumi_->setAxisTitle("Luminosity Segment", 1);
+   algoBits_after_bxomask_lumi_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
+   
+   algoBits_after_prescaler_lumi_ = ibooker.book2D("algoBits_after_prescaler_lumi","uGT: Algorithm Trigger Bits (after prescale) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_lumi_->setAxisTitle("Luminosity Segment", 1);
+   algoBits_after_prescaler_lumi_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
+  
+   algoBits_after_mask_lumi_ = ibooker.book2D("algoBits_after_mask_lumi","uGT: Algorithm Trigger Bits (after mask) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_lumi_->setAxisTitle("Luminosity Segment", 1);
+   algoBits_after_mask_lumi_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
+
+   // Prescale factor index 
    prescaleFactorSet_ = ibooker.book2D("prescaleFactorSet", "uGT: Index of Prescale Factor Set vs. LS", numLS, 0., numLS_d, 25, 0., 25.);
    prescaleFactorSet_->setAxisTitle("Luminosity Segment", 1);
    prescaleFactorSet_->setAxisTitle("Prescale Factor Set Index", 2);
@@ -98,15 +142,45 @@ void L1TStage2uGT::analyze(const edm::Event& evt, const edm::EventSetup& evtSetu
              
             // Fills algorithm bits histograms
             for(int algoBit = 0; algoBit < numAlgs; ++algoBit) {
+              
+               // Algorithm bits after BX mask, before prescale 
+               if(itr->getAlgoDecisionInitial(algoBit)) {
+                  algoBits_after_bxomask_->Fill(algoBit);
+                  algoBits_after_bxomask_lumi_->Fill(lumi, algoBit);
+                  algoBits_after_bxomask_bx_global_->Fill(bx, algoBit);
+                  algoBits_after_bxomask_bx_inEvt_->Fill(ibx, algoBit); // FIXME: or itr->getbxInEventNr()/getbxNr()?
+                  
+                  for(int algoBit2 = 0; algoBit2 < numAlgs; ++algoBit2) {
+                     if(itr->getAlgoDecisionInitial(algoBit2)) {
+                        algoBits_after_bxomask_corr_->Fill(algoBit, algoBit2);
+                     }
+                  }
+               }  
+               
+               // Algorithm bits after prescale 
+               if(itr->getAlgoDecisionPreScaled(algoBit)) {
+                  algoBits_after_prescaler_->Fill(algoBit);
+                  algoBits_after_prescaler_lumi_->Fill(lumi, algoBit);
+                  algoBits_after_prescaler_bx_global_->Fill(bx, algoBit);
+                  algoBits_after_prescaler_bx_inEvt_->Fill(ibx, algoBit); // FIXME: or itr->getbxInEventNr()/getbxNr()?
+                  
+                  for(int algoBit2 = 0; algoBit2 < numAlgs; ++algoBit2) {
+                     if(itr->getAlgoDecisionPreScaled(algoBit2)) {
+                        algoBits_after_prescaler_corr_->Fill(algoBit, algoBit2);
+                     }
+                  }
+               }  
+               
+               // Algorithm bits after mask 
                if(itr->getAlgoDecisionFinal(algoBit)) {
-                  algoBits_->Fill(algoBit);
-                  algoBits_lumi_->Fill(lumi, algoBit);
-                  algoBits_bx_global_->Fill(bx, algoBit);
-                  algoBits_bx_inEvt_->Fill(ibx, algoBit); // FIXME: or itr->getbxInEventNr()/getbxNr()?
+                  algoBits_after_mask_->Fill(algoBit);
+                  algoBits_after_mask_lumi_->Fill(lumi, algoBit);
+                  algoBits_after_mask_bx_global_->Fill(bx, algoBit);
+                  algoBits_after_mask_bx_inEvt_->Fill(ibx, algoBit); // FIXME: or itr->getbxInEventNr()/getbxNr()?
                   
                   for(int algoBit2 = 0; algoBit2 < numAlgs; ++algoBit2) {
                      if(itr->getAlgoDecisionFinal(algoBit2)) {
-                        algoBits_corr_->Fill(algoBit, algoBit2);
+                        algoBits_after_mask_corr_->Fill(algoBit, algoBit2);
                      }
                   }
                }  

--- a/DQM/L1TMonitor/src/L1TStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGT.cc
@@ -38,69 +38,71 @@ void L1TStage2uGT::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, e
    const int numLS = 2000;
    const double numLS_d = static_cast<double>(numLS);
    const int numAlgs = 512; // FIXME: Take number of algorithms from EventSetup
-   const double numAlgs_d = static_cast<double>(numAlgs)-0.5;
+   const double numAlgs_d = static_cast<double>(numAlgs);
+   const int numBx = 3564; 
+   const double numBx_d = static_cast<double>(numBx);
 
    ibooker.setCurrentFolder(histFolder_);
    
    // Algorithm bits 
-   algoBits_after_bxomask_ = ibooker.book1D("algoBits_after_bxomask", "uGT: Algorithm Trigger Bits (after BX mask, before prescale)", numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_ = ibooker.book1D("algoBits_after_bxomask", "uGT: Algorithm Trigger Bits (after BX mask, before prescale)", numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_bxomask_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 1);
    
-   algoBits_after_prescaler_ = ibooker.book1D("algoBits_after_prescaler", "uGT: Algorithm Trigger Bits (after prescale)", numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_ = ibooker.book1D("algoBits_after_prescaler", "uGT: Algorithm Trigger Bits (after prescale)", numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_prescaler_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 1);
    
-   algoBits_after_mask_ = ibooker.book1D("algoBits_after_mask", "uGT: Algorithm Trigger Bits (after mask)", numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_ = ibooker.book1D("algoBits_after_mask", "uGT: Algorithm Trigger Bits (after mask)", numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_mask_->setAxisTitle("Algorithm Trigger Bits (after mask)", 1);
   
    // Algorithm bits correlation 
-   algoBits_after_bxomask_corr_ = ibooker.book2D("algoBits_after_bxomask_corr","uGT: Algorithm Trigger Bit Correlation (after BX mask, before prescale)", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_corr_ = ibooker.book2D("algoBits_after_bxomask_corr","uGT: Algorithm Trigger Bit Correlation (after BX mask, before prescale)", numAlgs, -0.5, numAlgs_d-0.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_bxomask_corr_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 1);
    algoBits_after_bxomask_corr_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
    
-   algoBits_after_prescaler_corr_ = ibooker.book2D("algoBits_after_prescaler_corr","uGT: Algorithm Trigger Bit Correlation (after prescale)", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_corr_ = ibooker.book2D("algoBits_after_prescaler_corr","uGT: Algorithm Trigger Bit Correlation (after prescale)", numAlgs, -0.5, numAlgs_d-0.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_prescaler_corr_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 1);
    algoBits_after_prescaler_corr_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
    
-   algoBits_after_mask_corr_ = ibooker.book2D("algoBits_after_mask_corr","uGT: Algorithm Trigger Bit Correlation (after mask)", numAlgs, -0.5, numAlgs_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_corr_ = ibooker.book2D("algoBits_after_mask_corr","uGT: Algorithm Trigger Bit Correlation (after mask)", numAlgs, -0.5, numAlgs_d-0.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_mask_corr_->setAxisTitle("Algorithm Trigger Bits (after mask)", 1);
    algoBits_after_mask_corr_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
   
    // Algorithm bits vs global BX number
-   algoBits_after_bxomask_bx_global_ = ibooker.book2D("algoBits_after_bxomask_bx_global", "uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_bx_global_ = ibooker.book2D("algoBits_after_bxomask_bx_global", "uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. Global BX Number", numBx, 0.5, numBx_d + 0.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_bxomask_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
    algoBits_after_bxomask_bx_global_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
    
-   algoBits_after_prescaler_bx_global_ = ibooker.book2D("algoBits_after_prescaler_bx_global", "uGT: Algorithm Trigger Bits (after prescale) vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_bx_global_ = ibooker.book2D("algoBits_after_prescaler_bx_global", "uGT: Algorithm Trigger Bits (after prescale) vs. Global BX Number", numBx, 0.5, numBx_d + 0.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_prescaler_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
    algoBits_after_prescaler_bx_global_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
    
-   algoBits_after_mask_bx_global_ = ibooker.book2D("algoBits_after_mask_bx_global", "uGT: Algorithm Trigger Bits (after mask) vs. Global BX Number", 3600, -0.5, 3599.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_bx_global_ = ibooker.book2D("algoBits_after_mask_bx_global", "uGT: Algorithm Trigger Bits (after mask) vs. Global BX Number", numBx, 0.5, numBx_d + 0.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_mask_bx_global_->setAxisTitle("Global Bunch Crossing Number", 1); 
    algoBits_after_mask_bx_global_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
   
    // Algorithm bits vs BX number in event
-   algoBits_after_bxomask_bx_inEvt_ = ibooker.book2D("algoBits_after_bxomask_bx_inEvt", "uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_bx_inEvt_ = ibooker.book2D("algoBits_after_bxomask_bx_inEvt", "uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_bxomask_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
    algoBits_after_bxomask_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
    
-   algoBits_after_prescaler_bx_inEvt_ = ibooker.book2D("algoBits_after_prescaler_bx_inEvt", "uGT: Algorithm Trigger Bits (after prescale) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_bx_inEvt_ = ibooker.book2D("algoBits_after_prescaler_bx_inEvt", "uGT: Algorithm Trigger Bits (after prescale) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_prescaler_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
    algoBits_after_prescaler_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
    
-   algoBits_after_mask_bx_inEvt_ = ibooker.book2D("algoBits_after_mask_bx_inEvt", "uGT: Algorithm Trigger Bits (after mask) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_bx_inEvt_ = ibooker.book2D("algoBits_after_mask_bx_inEvt", "uGT: Algorithm Trigger Bits (after mask) vs. BX Number in Event", 5, -2.5, 2.5, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_mask_bx_inEvt_->setAxisTitle("Bunch Crossing Number in Event", 1);
    algoBits_after_mask_bx_inEvt_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
   
    // Algorithm bits vs LS
-   algoBits_after_bxomask_lumi_ = ibooker.book2D("algoBits_after_bxomask_lumi","uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_bxomask_lumi_ = ibooker.book2D("algoBits_after_bxomask_lumi","uGT: Algorithm Trigger Bits (after BX mask, before prescale) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_bxomask_lumi_->setAxisTitle("Luminosity Segment", 1);
    algoBits_after_bxomask_lumi_->setAxisTitle("Algorithm Trigger Bits (after BX mask, before prescale)", 2);
    
-   algoBits_after_prescaler_lumi_ = ibooker.book2D("algoBits_after_prescaler_lumi","uGT: Algorithm Trigger Bits (after prescale) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_prescaler_lumi_ = ibooker.book2D("algoBits_after_prescaler_lumi","uGT: Algorithm Trigger Bits (after prescale) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_prescaler_lumi_->setAxisTitle("Luminosity Segment", 1);
    algoBits_after_prescaler_lumi_->setAxisTitle("Algorithm Trigger Bits (after prescale)", 2);
   
-   algoBits_after_mask_lumi_ = ibooker.book2D("algoBits_after_mask_lumi","uGT: Algorithm Trigger Bits (after mask) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d);
+   algoBits_after_mask_lumi_ = ibooker.book2D("algoBits_after_mask_lumi","uGT: Algorithm Trigger Bits (after mask) vs. LS", numLS, 0., numLS_d, numAlgs, -0.5, numAlgs_d-0.5);
    algoBits_after_mask_lumi_->setAxisTitle("Luminosity Segment", 1);
    algoBits_after_mask_lumi_->setAxisTitle("Algorithm Trigger Bits (after mask)", 2);
 


### PR DESCRIPTION
In the L1TStage2uGT DQM module, added histograms which fill to algorithm bits '_after BX mask, before prescale_' and '_after prescale_'. This is on top of the existing ones which only had the final '_after mask_' algorithm bit decisions plotted. Very important for uGT monitoring.

Also, global BX range updated to [1, 3564].
