### PR TITLE
EMTF Fix ME1/1a flag in data

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/PrimitiveConverter.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PrimitiveConverter.h
@@ -34,6 +34,9 @@ std::vector<ConvertedHit> PrimConv(std::vector<TriggerPrimitive> TriggPrim, int 
 	int station = Det.station(), chamber = Det.chamber(), ring = Det.ring(), wire = C3.getCSCData().keywire, sector = Det.triggerSector(), strip = C3.getCSCData().strip; 
 	int pattern = C3.getPattern(), Id = C3.Id(), quality = C3.getCSCData().quality, BX = C3.getCSCData().bx, endcap = Det.endcap();
 	
+	if(station == 1 && ring == 1 && strip > 127)
+		ring = 4;
+	
 	if(ring == 4){Id += 9;}
 
 	//if(endcap == 1 && sector == 1)//
@@ -158,7 +161,7 @@ std::vector<ConvertedHit> PrimConv(std::vector<TriggerPrimitive> TriggPrim, int 
 	
 		eightstrip = (eightstrip>>1);
 		patcor = (patcor>>1);
-		//if(ring == 4) eightstrip -= 512;
+		if(ring == 4 && strip > 127) eightstrip -= 512;
 	}	
 	
 	if(clctpatsign) patcor = -patcor;

--- a/L1Trigger/L1TMuonEndCap/interface/PrimitiveConverter.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PrimitiveConverter.h
@@ -34,9 +34,10 @@ std::vector<ConvertedHit> PrimConv(std::vector<TriggerPrimitive> TriggPrim, int 
 	int station = Det.station(), chamber = Det.chamber(), ring = Det.ring(), wire = C3.getCSCData().keywire, sector = Det.triggerSector(), strip = C3.getCSCData().strip; 
 	int pattern = C3.getPattern(), Id = C3.Id(), quality = C3.getCSCData().quality, BX = C3.getCSCData().bx, endcap = Det.endcap();
 	
-	if(station == 1 && ring == 1 && strip > 127)
-		ring = 4;
 	
+	if(station == 1 && ring == 1 && strip > 127)
+	  ring = 4;
+		
 	if(ring == 4){Id += 9;}
 
 	//if(endcap == 1 && sector == 1)//
@@ -278,10 +279,6 @@ std::vector<ConvertedHit> PrimConv(std::vector<TriggerPrimitive> TriggPrim, int 
 	////////////////////////////////////////////////////
 	
 	
-	if(Id > 9){
-		Id -= 9;strip += 128;
-	}
-	
 	
 	int zhit = -99, pz = -99;
 	std::vector<int> zonecontribution; //Each hit could go in more than one zone so we make a vector which stores all the zones for which this hit will contribute
@@ -313,7 +310,10 @@ std::vector<ConvertedHit> PrimConv(std::vector<TriggerPrimitive> TriggPrim, int 
 	/////////   Converted TP's around code   //////////////
 	///////////////////////////////////////////////////////
 	
-	//if(verbose) std::cout<<"Phi = "<<fph<<" and Theta = "<<th<<std::endl;
+	
+	if(Id > 9 && strip < 128){
+		Id -= 9;strip += 128;
+	}
 	
 	ConvertedHit Hit;
 

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -48,9 +48,6 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 
   //bool verbose = false;
 
-
-  //std::cout<<"Start Upgraded Track Finder Producer::::: event = "<<ev.id().event()<<"\n\n";
-
   //fprintf (write,"12345\n"); //<-- part of printing text file to send verilog code, not needed if George's package is included
 
 
@@ -77,6 +74,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     auto digi = (*chamber).second.first;
     auto dend = (*chamber).second.second;
     for( ; digi != dend; ++digi ) {
+	
       out.push_back(TriggerPrimitive((*chamber).first,*digi));
     }
   }
@@ -101,7 +99,6 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 
 		tester.push_back(*tp);
 
-		//std::cout<<"\ntrigger prim found station:"<<tp->detId<CSCDetId>().station()<<std::endl;
       }
 
      }
@@ -334,7 +331,7 @@ for(int SectIndex=0;SectIndex<NUM_SECTORS;SectIndex++){//perform TF on all 12 se
         //int bx = 0;
 		float theta_angle = (AllTracks[fbest].theta*0.2851562 + 8.5)*(3.14159265359/180);
 		float eta = (-1)*log(tan(theta_angle/2));
-		std::pair<int,l1t::RegionalMuonCand> outPair(sebx,outCand);
+		std::pair<int,l1t::RegionalMuonCand> outPair(ebx,outCand);
 		
 		if(!ME13 && fabs(eta) > 1.1)
 			holder.push_back(outPair);


### PR DESCRIPTION
This fixes the ME1/1a flag to behave properly in MC with simCscTriggerPrimitiveDigis and in data with csctfDigis. Overall EMTF track assignment is updated to reflect FW exactly.
