### PR TITLE
Minor Changes to EMTF Module and Unpacker

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("DQM")
+process = cms.Process("L1TStage2DQM")
 
 #--------------------------------------------------
 # Event Source and Condition
@@ -25,10 +25,7 @@ process.dqmEnv.subSystemFolder = "L1T2016"
 process.dqmSaver.tag = "L1T2016"
 process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/l1t_reference.root"
 
-process.dqmEndPath = cms.EndPath(
-    process.dqmEnv *
-    process.dqmSaver
-)
+process.dqmEndPath = cms.EndPath(process.dqmEnv * process.dqmSaver)
 
 #--------------------------------------------------
 # Standard Unpacking Path
@@ -37,50 +34,38 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 
 process.rawToDigiPath = cms.Path(process.RawToDigi)
 
-# For GCT, unpack all five samples.
-process.gctDigis.numberOfGctSamplesToUnpack = cms.uint32(5)
-
-process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
+# Remove Unpacker Modules
+process.rawToDigiPath.remove(process.siStripDigis)
+process.rawToDigiPath.remove(process.gtDigis)
+process.rawToDigiPath.remove(process.gtEvmDigis)
 
 #--------------------------------------------------
-# Legacy DQM Paths
+# Stage2 Unpacker and DQM Path
+
+process.load("DQM.L1TMonitor.L1TStage2_cff")
+
+process.l1tMonitorPath = cms.Path(process.l1tStage2Unpack + process.l1tStage2OnlineDQM)
+
+# Remove DQM Modules
+#process.l1tStage2online.remove(process.l1tLayer1)
+#process.l1tStage2online.remove(process.l1tStage2CaloLayer2)
+#process.l1tStage2online.remove(process.l1tStage2Bmtf)
+#process.l1tStage2online.remove(process.l1tStage2Emtf)
+#process.l1tStage2online.remove(process.l1tStage2uGMT)
+#process.l1tStage2online.remove(process.l1tStage2uGt)
+
+#--------------------------------------------------
+# Legacy DQM EndPath
 
 process.load("DQM.L1TMonitor.L1TMonitor_cff")
+
 process.l1tMonitorEndPath = cms.EndPath(process.l1tMonitorEndPathSeq)
 
 #--------------------------------------------------
-# Stage2 DQM Paths
-
-process.load("DQM.L1TMonitor.L1TStage2_cff")
-process.l1tMonitorPath = cms.Path(process.l1tStage2online)
-
-# Remove Subsystem Modules
-#process.l1tStage2online.remove(process.l1tLayer1)
-#process.l1tStage2online.remove(process.l1tStage2CaloLayer2)
-#process.l1tStage2online.remove(process.l1tStage2uGMT)
-#process.l1tStage2online.remove(process.l1tStage2uGt)
-#process.l1tStage2online.remove(process.l1tStage2Bmtf)
-#process.l1tStage2online.remove(process.l1tStage2Emtf)
-
-#--------------------------------------------------
-# Stage2 Unpacking Path
-
-process.stage2UnpackPath = cms.Path(
-    process.l1tCaloLayer1Digis +
-    process.caloStage2Digis +
-    process.gmtStage2Digis +
-    process.gtStage2Digis +
-    process.BMTFStage2Digis + 
-    #process.omtfStage2Digis +
-    process.emtfStage2Digis
-)
-
-#--------------------------------------------------
-# L1 Trigger DQM Schedule
+# L1T Online DQM Schedule
 
 process.schedule = cms.Schedule(
     process.rawToDigiPath,
-    process.stage2UnpackPath,
     process.l1tMonitorPath,
     #process.l1tMonitorClientPath,
     process.l1tMonitorEndPath,
@@ -90,7 +75,6 @@ process.schedule = cms.Schedule(
 
 #--------------------------------------------------
 # Heavy Ion Specific Fed Raw Data Collection Label
-#--------------------------------------------------
 
 print "Running with run type = ", process.runType.getRunType()
 process.castorDigis.InputLabel = cms.InputTag("rawDataCollector")

--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -3,14 +3,20 @@ import FWCore.ParameterSet.Config as cms
 source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/0CAC70DE-3C01-E611-84B8-02163E01346D.root", 
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/0EC9F919-4001-E611-BB95-02163E01391D.root",
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/1CF4C821-3F01-E611-A25A-02163E012A04.root",
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/586CE231-3E01-E611-8D60-02163E0127E3.root",
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/5C448328-3E01-E611-92A4-02163E0142A8.root",
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/7EBF1912-3F01-E611-B2F3-02163E01339E.root",
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/8A77C6E0-3B01-E611-AC71-02163E014557.root",
+        #"root://eoscms//store/express/Commissioning2016/ExpressPhysics/FEVT/Express-v1/000/269/612/00000/94D3D8D5-3C01-E611-BE3A-02163E01391D.root",
         #"/store/data/Commissioning2016/ZeroBias1/RAW/v1/000/269/060/00000/06A51B35-27FF-E511-9155-02163E0144C3.root",
         #"/store/data/Commissioning2016/ZeroBias1/RAW/v1/000/269/060/00000/0AEFA3F4-1DFF-E511-914E-02163E011B3F.root",
         #"/store/data/Commissioning2016/ZeroBias1/RAW/v1/000/269/060/00000/1E91A739-1AFF-E511-A3CE-02163E011F71.root",
         #"root://eoscms//store/express/Commissioning2016/ExpressCosmics/FEVT/Express-v1/000/268/733/00000/5669AE2E-CAFC-E511-9402-02163E01452B.root",
         #"root://eoscms//store/express/Commissioning2016/ExpressCosmics/FEVT/Express-v1/000/268/733/00000/A459B232-CAFC-E511-B119-02163E011856.root",
         "file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/DQMTest/MinimumBias__RAW__v1__165633__1CC420EE-B686-E011-A788-0030487CD6E8.root",
-        #"/store/data/Commissioning2014/Cosmics/RAW//v3/000/224/380/00000/E05943D1-1227-E411-BB8E-02163E00F0C4.root"
-        #"/store/data/Commissioning2014/Cosmics/RAW/v3/000/224/380/00000/68FDADE5-1227-E411-8AA6-02163E00A10C.root"
     )
  
     # For .dat files, use the following block instead.   

--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -52,6 +52,7 @@ class L1TStage2EMTF : public DQMEDAnalyzer {
   MonitorElement* emtfMode;
   MonitorElement* emtfQuality;
   MonitorElement* emtfQualityvsMode;
+  MonitorElement* emtfHQPhi;
 
   MonitorElement* emtfMuonBX;
   MonitorElement* emtfMuonhwPt;

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -198,8 +198,8 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     // Event Record Header
     const l1t::emtf::EventHeader* EventHeader = EMTFOutput->PtrEventHeader();
     int Endcap = EventHeader->Endcap();
-    //int Sector = EventHeader->SP_ts();
-     
+    //int Sector = EventHeader->Sector();
+    
     if (!EventHeader->Rdy()) emtfErrors->Fill(5);
 
     // ME (LCTs) Data Record
@@ -218,25 +218,26 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
       // Evaluate histogram index and chamber number with respect to station and ring.
       int hist_index = 0, chamber_number = 0;//, nhist_index = 0, nchamber_number = 0;
-       
+      
+      /* 
       if (Station > 1 && Ring == 1) chamber_number = (Sector * 3) + CSC_ID + (Ring * -3);
       else chamber_number = ((Sector-1) * 6) + CSC_ID + -3*((Ring-1) % 3);
       if (Subsector == 2) chamber_number +=3;
 
       if (Station == 1) hist_index = 8 - (Ring - 1) % 3;
       if (Station > 1) hist_index = 8 - (Station * 2 + Ring - 2);
-      
-     /* 
+      */
+
       if (Station == 1) {
         if (Ring == 1 || Ring == 4) {
           hist_index = 8;
-          chamber_number = (Sector * 6) + CSC_ID;
+          chamber_number = ((Sector-1) * 6) + CSC_ID;
         } else if (Ring == 2) {
           hist_index = 7;
-          chamber_number = (Sector * 6) + CSC_ID - 3;
+          chamber_number = ((Sector-1) * 6) + CSC_ID - 3;
         } else if (Ring == 3) {
           hist_index = 6;
-          chamber_number = (Sector * 6) + CSC_ID - 6;
+          chamber_number = ((Sector-1) * 6) + CSC_ID - 6;
         }
         if (Subsector == 2) chamber_number += 3;
       } else if (Ring == 1) {
@@ -247,7 +248,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
         } else if (Station == 4) {
           hist_index = 1;
         }
-        chamber_number = (Sector * 3) + CSC_ID;
+        chamber_number = ((Sector-1) * 3) + CSC_ID;
       } else if (Ring == 2) {
         if (Station == 2) {
           hist_index = 4;
@@ -256,8 +257,12 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
         } else if (Station == 4) {
           hist_index = 0;
         }
-        chamber_number = (Sector * 6) + CSC_ID - 3;
-      }*/
+        chamber_number = ((Sector-1) * 6) + CSC_ID - 3;
+      }
+
+
+
+
      if (Endcap > 0) hist_index = 17 - hist_index;
 
       if (ME->SE()) emtfErrors->Fill(1);
@@ -294,8 +299,8 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     for (std::vector<l1t::emtf::SP>::const_iterator SP = SPCollection->begin(); SP != SPCollection->end(); ++SP) {
       float Pt = SP->Pt();
       float Eta = SP->Eta_GMT();
-      float Phi_GMT_global_rad = SP->Phi_GMT_global() * (M_PI/180);
-      if (Phi_GMT_global_rad > M_PI) Phi_GMT_global_rad -= 2*M_PI;
+      float Phi_GMT_global_rad = SP->Phi_GMT_global_rad();
+    
       int Quality = SP->Quality();
       int Mode = SP->Mode();
       int Sector;

--- a/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
+++ b/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
@@ -13,24 +13,24 @@ namespace l1t {
       explicit EventHeader(uint64_t dataword);
     
     EventHeader() : 
-      l1a(-99), l1a_bxn(-99), sp_ts(-99), endcap(-99), sector(-99), sp_ersv(-99), sp_addr(-99), 
+      l1a(-99), l1a_bxn(-99), endcap(-99), sector(-99), sp_ersv(-99), sp_addr(-99), 
 	tbin(-99), ddm(-99), spa(-99), rpca(-99), skip(-99), rdy(-99), bsy(-99), osy(-99), 
 	wof(-99), me1a(-99), me1b(-99), me2(-99), me3(-99), me4(-99), format_errors(0), dataword(-99) 
 	{};
       
-    EventHeader(int int_l1a, int int_l1a_bxn, int int_sp_ts, int int_endcap, int int_sector, int int_sp_ersv, int int_sp_addr, 
+    EventHeader(int int_l1a, int int_l1a_bxn, int int_endcap, int int_sector, int int_sp_ersv, int int_sp_addr, 
 		int int_tbin, int int_ddm, int int_spa, int int_rpca, int int_skip, int int_rdy, int int_bsy, int int_osy, 
 		int int_wof, int int_me1a, int int_me1b, int int_me2, int int_me3, int int_me4) :
-      l1a(int_l1a), l1a_bxn(int_l1a_bxn), sp_ts(int_sp_ts), endcap(int_endcap), sector(int_sector), sp_ersv(int_sp_ersv), sp_addr(int_sp_addr), 
+      l1a(int_l1a), l1a_bxn(int_l1a_bxn), endcap(int_endcap), sector(int_sector), sp_ersv(int_sp_ersv), sp_addr(int_sp_addr), 
 	tbin(int_tbin), ddm(int_ddm), spa(int_spa), rpca(int_rpca), skip(int_skip), rdy(int_rdy), bsy(int_bsy), osy(int_osy), 
 	wof(int_wof), me1a(int_me1a), me1b(int_me1b), me2(int_me2), me3(int_me3), me4(int_me4), format_errors(0), dataword(-99)
     	{};
       
       virtual ~EventHeader() {};
-      
+     
+
       void set_l1a(int bits)           { l1a = bits;         };
       void set_l1a_bxn(int bits)       { l1a_bxn = bits;     };
-      void set_sp_ts(int bits)         { sp_ts = bits;       };
       void set_endcap(int bits)        { endcap = bits;      };
       void set_sector(int bits)        { sector = bits;      };
       void set_sp_ersv(int bits)       { sp_ersv = bits;     };
@@ -54,7 +54,6 @@ namespace l1t {
       
       int      L1A()           const { return l1a;           };
       int      L1A_BXN()       const { return l1a_bxn;       };
-      int      SP_ts()         const { return sp_ts;         };
       int      Endcap()        const { return endcap;        };
       int      Sector()        const { return sector;        };
       int      SP_ersv()       const { return sp_ersv;       };
@@ -79,7 +78,6 @@ namespace l1t {
     private:
       int l1a;
       int l1a_bxn;
-      int sp_ts;
       int endcap;
       int sector;
       int sp_ersv;

--- a/DataFormats/L1TMuon/interface/EMTF/SP.h
+++ b/DataFormats/L1TMuon/interface/EMTF/SP.h
@@ -20,7 +20,7 @@ namespace l1t {
 	me4_CSC_ID(-99), me4_sector(-99), me4_neighbor(-99), me4_trk_stub_num(-99), me1_delay(-99), 
 	me2_delay(-99), me3_delay(-99), me4_delay(-99), tbin_num(-99), hl(-99), c(-99), vc(-99), 
 	vt(-99), se(-99), bc0(-99), pt(-99), phi_local(-99), phi_local_rad(-99), phi_global(-99), 
-	phi_GMT(-99), phi_GMT_corr(-99), phi_GMT_rad(-99), phi_GMT_global(-99), eta_GMT(-99), 
+	phi_GMT(-99), phi_GMT_corr(-99), phi_GMT_rad(-99), phi_GMT_global(-99),phi_GMT_global_rad(-99), eta_GMT(-99), 
 	format_errors(0), dataword(-99) 
 	{};
 
@@ -45,6 +45,9 @@ namespace l1t {
       float calc_eta_GMT(int bits)               { return bits * 0.010875;                                   };
       int   calc_eta_GMT_int(float val)          { return val / 0.010875;                                    };
       float calc_phi_global(float loc, int sect) { return loc + 15 + (sect - 1) * 60;                        };
+      float calc_phi_global_rad(float loc, int sect) {  float _phi_global_rad = (loc + 15 + (sect - 1) *60)*(pi/180); 
+                                                        if (_phi_global_rad>pi) _phi_global_rad-=2*pi;
+                                                        return _phi_global_rad; };
       int   calc_mode()                          { return 8*(me1_CSC_ID > 0) + 4*(me2_CSC_ID > 0) + 2*(me3_CSC_ID > 0) + (me4_CSC_ID > 0); };
 
       // Converts CSC_ID, sector, subsector, and neighbor
@@ -100,6 +103,7 @@ namespace l1t {
                                                      set_phi_GMT_corr_only(calc_phi_GMT_corr(phi_GMT_int));     };
       void set_phi_global(float loc, int sect)     { set_phi_global_only(calc_phi_global(loc, sect));           };
       void set_phi_GMT_global(float loc, int sect) { set_phi_GMT_global_only(calc_phi_global(loc, sect));       };
+      void set_phi_GMT_global_rad(float loc, int sect) {set_phi_GMT_global_rad_only(calc_phi_global_rad(loc, sect));};
       void set_eta_GMT_int(int  bits)              { eta_GMT_int = bits;
                                                      set_eta_GMT_only(calc_eta_GMT(eta_GMT_int));               };
       void set_eta_GMT(float val)                  { eta_GMT= val;
@@ -184,6 +188,7 @@ namespace l1t {
       float    Phi_GMT_corr()     const { return phi_GMT_corr;     };
       float    Phi_GMT_rad()      const { return phi_GMT_rad;      };
       float    Phi_GMT_global()   const { return phi_GMT_global;   };
+      float    Phi_GMT_global_rad() const { return phi_GMT_global_rad; };
       float    Eta_GMT()          const { return eta_GMT;          };
       int      Format_Errors()    const { return format_errors;    };
       uint64_t Dataword()         const { return dataword;         }; 
@@ -201,6 +206,7 @@ namespace l1t {
       void set_phi_GMT_rad_only(float val)    { phi_GMT_rad = val;    };
       void set_phi_GMT_int_only(int  bits)    { phi_GMT_int = bits;   };
       void set_phi_GMT_global_only(float val) { phi_GMT_global = val; };
+      void set_phi_GMT_global_rad_only(float val) {phi_GMT_global_rad = val; };
       void set_eta_GMT_only(float val)        { eta_GMT = val;        };
       void set_eta_GMT_int_only(int  bits)    { eta_GMT_int = bits;   };
 
@@ -248,6 +254,7 @@ namespace l1t {
       float phi_GMT_corr;
       float phi_GMT_rad;
       float phi_GMT_global;
+      float phi_GMT_global_rad;
       float eta_GMT;
       int  format_errors;
       uint64_t dataword;

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockHeaders.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockHeaders.cc
@@ -183,7 +183,6 @@ namespace l1t {
 	
 	EventHeader_.set_l1a     ( GetHexBits(HD1a,  0, 11, HD1b,  0, 11) );
 	EventHeader_.set_l1a_bxn ( GetHexBits(HD1d,  0, 11) );
-	EventHeader_.set_sp_ts   ( GetHexBits(HD2b,  8, 11) );
 	EventHeader_.set_endcap  ( GetHexBits(HD2b, 11, 11) ? -1 : 1 ); 
 	EventHeader_.set_sector  ( GetHexBits(HD2b,  8, 10) + 1 );      
 	EventHeader_.set_sp_ersv ( GetHexBits(HD2b,  5,  7) );

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockSP.cc
@@ -123,7 +123,8 @@ namespace l1t {
 
 	SP_.set_phi_GMT_int    ( TwosCompl(8, GetHexBits(SP1b, 0, 7)) );
 	SP_.set_phi_GMT_global ( SP_.Phi_GMT(), (res->at(iOut)).PtrEventHeader()->Sector() );
-	mu_.setHwPhi           ( TwosCompl(8, GetHexBits(SP1b, 0, 7)) );
+	SP_.set_phi_GMT_global_rad ( SP_.Phi_GMT(), (res->at(iOut)).PtrEventHeader()->Sector() );
+  mu_.setHwPhi           ( TwosCompl(8, GetHexBits(SP1b, 0, 7)) );
 	SP_.set_quality        ( GetHexBits(SP1b,  8, 11) ); // After 01.04.16
 	mu_.setHwQual          ( GetHexBits(SP1b,  8, 11) ); // After 01.04.16
 	SP_.set_bc0            ( GetHexBits(SP1b, 12, 12) );


### PR DESCRIPTION
EMTF changes:
-Added a 1D high-quality Phi histogram
-Sector is no longer gotten from EventHeader, but from SP and ME separately now and goes 1-6
-SP's phi values are now taken straight from Phi_GMT_global_rad instead of converting Phi_GMT_global from degrees to radians
-Fixed off-by-one error on emtfLCTBX's Y-axis

Unpacker Changes
-removed SP_ts() from EventHeader
-added Phi_GMT_global_rad() to SP
