### PR TITLE
Bugfix so that caloMetBE /= caloMet

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
@@ -233,7 +233,7 @@ void L1JetRecoTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSe
 
   if (caloMetBE.isValid()) {
 
-    doCaloMetBE(caloMet);
+    doCaloMetBE(caloMetBE);
 
   }
   else {


### PR DESCRIPTION
There was a bug where caloMetBE == caloMet in the Ntuples. This is now fixed.
