### PR TITLE
Saturated tower codes update to L1TCaloLayer1 emulation

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -131,7 +131,11 @@ L1TCaloLayer1::L1TCaloLayer1(const edm::ParameterSet& iConfig) :
 {
   produces<CaloTowerBxCollection>();
   produces<L1CaloRegionCollection>();
-  layer1 = new UCTLayer1;
+
+  // See UCTLayer1.hh for firmware version definitions
+  int fwVersion = iConfig.getParameter<int>("firmwareVersion");
+  layer1 = new UCTLayer1(fwVersion);
+
   vector<UCTCrate*> crates = layer1->getCrates();
   for(uint32_t crt = 0; crt < crates.size(); crt++) {
     vector<UCTCard*> cards = crates[crt]->getCards();

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Digis_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Digis_cfi.py
@@ -17,4 +17,6 @@ simCaloStage2Layer1Digis = cms.EDProducer(
     verbose = cms.bool(False),
     unpackEcalMask = cms.bool(False),
     unpackHcalMask = cms.bool(False),
+    # See UCTLayer1.hh for firmware version
+    firmwareVersion = cms.int32(1),
     )

--- a/L1Trigger/L1TCaloLayer1/src/UCTCard.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTCard.cc
@@ -7,17 +7,18 @@
 #include "UCTGeometry.hh"
 #include "UCTLogging.hh"
 
-UCTCard::UCTCard(uint32_t crt, uint32_t crd) :
+UCTCard::UCTCard(uint32_t crt, uint32_t crd, int fwv) :
   crate(crt),
   card(crd),
-  cardSummary(0) {
+  cardSummary(0),
+  fwVersion(fwv) {
   UCTGeometry g;
   regions.reserve(2*g.getNRegions());
   for(uint32_t rgn = 0; rgn < g.getNRegions(); rgn++) {
     // Negative eta side
-    regions.push_back(new UCTRegion(crate, card, true, rgn));
+    regions.push_back(new UCTRegion(crate, card, true, rgn, fwVersion));
     // Positive eta side
-    regions.push_back(new UCTRegion(crate, card, false, rgn));
+    regions.push_back(new UCTRegion(crate, card, false, rgn, fwVersion));
   }
 }
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTCard.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTCard.hh
@@ -10,7 +10,7 @@ class UCTRegion;
 class UCTCard {
 public:
 
-  UCTCard(uint32_t crt, uint32_t crd);
+  UCTCard(uint32_t crt, uint32_t crd, int fwv);
 
   virtual ~UCTCard();
 
@@ -63,6 +63,7 @@ private:
 
   uint32_t cardSummary;
 
+  const int fwVersion;
 };
 
 #endif

--- a/L1Trigger/L1TCaloLayer1/src/UCTCrate.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTCrate.cc
@@ -7,12 +7,13 @@
 #include "UCTGeometry.hh"
 #include "UCTLogging.hh"
 
-UCTCrate::UCTCrate(uint32_t crt) :
+UCTCrate::UCTCrate(uint32_t crt, int fwv) :
   crate(crt),
-  crateSummary(0) {
+  crateSummary(0), 
+  fwVersion(fwv) {
   UCTGeometry g;
   for(uint32_t card = 0; card < g.getNCards(); card++) {
-    cards.push_back(new UCTCard(crate, card));
+    cards.push_back(new UCTCard(crate, card, fwVersion));
   }
 }
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTCrate.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTCrate.hh
@@ -10,7 +10,7 @@ class UCTCard;
 class UCTCrate {
 public:
 
-  UCTCrate(uint32_t crt);
+  UCTCrate(uint32_t crt, int fwv);
 
   virtual ~UCTCrate();
 
@@ -61,6 +61,7 @@ private:
   std::vector<UCTCard*> cards;
   uint32_t crateSummary;
 
+  const int fwVersion;
 };
 
 #endif

--- a/L1Trigger/L1TCaloLayer1/src/UCTGeometry.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTGeometry.cc
@@ -258,7 +258,11 @@ double UCTGeometry::getUCTTowerEta(int caloEta) {
 }
 
 double UCTGeometry::getUCTTowerPhi(int caloPhi) {
-  if(caloPhi < 0) return -999.;
+  if(caloPhi < 1) return -999.;
+  else if(caloPhi > 72) return +999.;
   uint32_t absCaloPhi = abs(caloPhi) - 1;
-  return (((double) absCaloPhi + 0.5) * 0.0872);
+  if(absCaloPhi < 36)
+    return (((double) absCaloPhi + 0.5) * 0.0872);
+  else
+    return (-(71.5 - (double) absCaloPhi) * 0.0872);
 }

--- a/L1Trigger/L1TCaloLayer1/src/UCTLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTLayer1.cc
@@ -15,11 +15,11 @@
 
 using namespace l1tcalo;
 
-UCTLayer1::UCTLayer1() : uctSummary(0) {
+UCTLayer1::UCTLayer1(int fwv) : uctSummary(0), fwVersion(fwv) {
   UCTGeometry g;
   crates.reserve(g.getNCrates());
   for(uint32_t crate = 0; crate < g.getNCrates(); crate++) {
-    crates.push_back(new UCTCrate(crate));
+    crates.push_back(new UCTCrate(crate, fwVersion));
   }
 }
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
@@ -12,7 +12,12 @@ class UCTTower;
 class UCTLayer1 {
 public:
 
-  UCTLayer1();
+  // Layer1 hardware firmware version
+  // Default (0): initial version for 2016 running
+  // 1: Update to include saturated tower codes to layer 2
+  //    (put online at run >= 275908: http://cmsonline.cern.ch/cms-elog/931059)
+  //
+  UCTLayer1(int fwv=0);
 
   virtual ~UCTLayer1();
 
@@ -58,6 +63,7 @@ private:
   std::vector<UCTCrate*> crates;
 
   uint32_t uctSummary;
+  const int fwVersion;
 
 };
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTRegion.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTRegion.cc
@@ -23,8 +23,8 @@ using namespace l1tcalo;
 // For the moment we use floating point arithmetic 
 
 const float activityFraction = 0.125;
-const float ecalActivityFraction = 0.125;
-const float miscActivityFraction = 0.125;
+const float ecalActivityFraction = 0.25;
+const float miscActivityFraction = 0.25;
 
 bool vetoBit(bitset<4> etaPattern, bitset<4> phiPattern) {
 
@@ -43,9 +43,10 @@ bool vetoBit(bitset<4> etaPattern, bitset<4> phiPattern) {
      etaPattern != badPattern10 && etaPattern != badPattern11 &&
      etaPattern != badPattern13 && etaPattern != badPattern14 &&
      etaPattern != badPattern15 && phiPattern != badPattern5 && 
-     phiPattern != badPattern7 && phiPattern != badPattern10 && 
+     //     phiPattern != badPattern7 && phiPattern != badPattern10 && 
+     phiPattern != badPattern10 && 
      phiPattern != badPattern11 && phiPattern != badPattern13 && 
-     phiPattern != badPattern14 && phiPattern != badPattern15 &&
+     //phiPattern != badPattern14 && phiPattern != badPattern15 &&
      etaPattern != badPattern9 && phiPattern != badPattern9){
     answer = false;
   }

--- a/L1Trigger/L1TCaloLayer1/src/UCTRegion.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTRegion.cc
@@ -69,19 +69,20 @@ uint32_t getHitTowerLocation(uint32_t *et) {
   return iAve;
 }
 
-UCTRegion::UCTRegion(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn) :
+UCTRegion::UCTRegion(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn, int fwv) :
   crate(crt),
   card(crd),
   region(rgn),
   negativeEta(ne),
-  regionSummary(0) {
+  regionSummary(0),
+  fwVersion(fwv) {
   UCTGeometry g;
   uint32_t nEta = g.getNEta(region);
   uint32_t nPhi = g.getNPhi(region);
   towers.clear();
   for(uint32_t iEta = 0; iEta < nEta; iEta++) {
     for(uint32_t iPhi = 0; iPhi < nPhi; iPhi++) {
-      towers.push_back(new UCTTower(crate, card, ne, region, iEta, iPhi));
+      towers.push_back(new UCTTower(crate, card, ne, region, iEta, iPhi, fwVersion));
     }
   }
 }
@@ -121,7 +122,8 @@ bool UCTRegion::process() {
     regionEcalET += towers[twr]->getEcalET();
   }
   if(regionET > RegionETMask) {
-    LOG_ERROR << "L1TCaloLayer1::UCTRegion::Pegging RegionET" << std::endl;
+    // Region ET can easily saturate, suppress error spam
+    // LOG_ERROR << "L1TCaloLayer1::UCTRegion::Pegging RegionET" << std::endl;
     regionET = RegionETMask;
   }
   regionSummary = (RegionETMask & regionET);

--- a/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh
@@ -25,7 +25,7 @@ namespace l1tcalo {
 class UCTRegion {
 public:
 
-  UCTRegion(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn);
+  UCTRegion(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn, int fwv);
 
   virtual ~UCTRegion();
 
@@ -120,6 +120,7 @@ protected:
 
   uint32_t regionSummary;
 
+  const int fwVersion;
 };
 
 #endif

--- a/L1Trigger/L1TCaloLayer1/src/UCTTower.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTTower.cc
@@ -39,14 +39,20 @@ bool UCTTower::process() {
     calibratedHCALET = value & etInputMax;
     logHCALET = (value & 0x7000) >> 12;
   }
-  if(calibratedECALET==0xFF && calibratedHCALET==0xFF)
-    towerData = 0x1FF;
-  else if(calibratedECALET==0xFF)
-    towerData = 0x1FE;
-  else if(calibratedHCALET==0xFF)
-    towerData = 0x1FD;
-  else
+
+  // Saturation codes implemented in fwVersion 1
+  if(fwVersion >= 1) {
+    if(calibratedECALET==0xFF && calibratedHCALET==0xFF)
+      towerData = 0x1FF;
+    else if(calibratedECALET==0xFF)
+      towerData = 0x1FE;
+    else if(calibratedHCALET==0xFF)
+      towerData = 0x1FD;
+    else
+      towerData = calibratedECALET + calibratedHCALET;
+  } else {
     towerData = calibratedECALET + calibratedHCALET;
+  }
 
   if(towerData > etMask) towerData = etMask;
   uint32_t er = 0;
@@ -157,7 +163,8 @@ const uint16_t UCTTower::location() const {
   return l;
 }
 
-UCTTower::UCTTower(uint16_t location) {
+UCTTower::UCTTower(uint16_t location, int fwv) :
+  fwVersion(fwv) {
   if((location & 0x8000) != 0) negativeEta = true;
   crate =  (location & 0x1800) >> 11;
   card =   (location & 0x0700) >>  8;

--- a/L1Trigger/L1TCaloLayer1/src/UCTTower.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTTower.cc
@@ -39,7 +39,15 @@ bool UCTTower::process() {
     calibratedHCALET = value & etInputMax;
     logHCALET = (value & 0x7000) >> 12;
   }
-  towerData = calibratedECALET + calibratedHCALET;
+  if(calibratedECALET==0xFF && calibratedHCALET==0xFF)
+    towerData = 0x1FF;
+  else if(calibratedECALET==0xFF)
+    towerData = 0x1FE;
+  else if(calibratedHCALET==0xFF)
+    towerData = 0x1FD;
+  else
+    towerData = calibratedECALET + calibratedHCALET;
+
   if(towerData > etMask) towerData = etMask;
   uint32_t er = 0;
   if(calibratedECALET == 0 || calibratedHCALET == 0) {

--- a/L1Trigger/L1TCaloLayer1/src/UCTTower.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTTower.hh
@@ -31,7 +31,7 @@ class UCTLayer1;
 class UCTTower {
 public:
 
-  UCTTower(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn, uint32_t eta, uint32_t phi) :
+  UCTTower(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn, uint32_t eta, uint32_t phi, int fwv) :
     crate(crt),
     card(crd),
     region(rgn),
@@ -45,10 +45,11 @@ public:
     ecalLUT(0),
     hcalLUT(0),
     hfLUT(0),
-    towerData(0)
+    towerData(0),
+    fwVersion(fwv)
   {}
 
-  UCTTower(uint16_t location);
+  UCTTower(uint16_t location, int fwv);
   
   virtual ~UCTTower() {;}
 
@@ -171,6 +172,8 @@ private:
 
   uint32_t towerData;
 
+  // Keep track of possible algorithm changes
+  const int fwVersion;
 };
 
 #endif

--- a/L1Trigger/L1TCaloLayer1/test/testL1TCaloLayer1.py
+++ b/L1Trigger/L1TCaloLayer1/test/testL1TCaloLayer1.py
@@ -50,7 +50,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 #process.load('L1Trigger.Configuration.CaloTriggerPrimitives_cff')
 
 # To get L1 CaloParams
-process.load('L1Trigger.L1TCalorimeter.caloStage2Params_cfi')
+process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v2_1_cfi')
 # To get CaloTPGTranscoder
 process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
 


### PR DESCRIPTION
This provides special codes for saturated tower, using spare values at the top of the 9-bit E+H value sent to Layer2.
