### PR TITLE
EMTF emulator bugfixes to improve data-emulator agreement

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTFHit.h
+++ b/DataFormats/L1TMuon/interface/EMTFHit.h
@@ -11,7 +11,9 @@
 #include <iostream>
 
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/L1TMuon/interface/EMTF/ME.h"
 
 namespace l1t {
@@ -22,29 +24,41 @@ namespace l1t {
   EMTFHit() :
     
     // Using -999 instead of -99 b/c this seems most common in the emulator.  Unfortunate. - AWB 17.03.16
-    endcap(-999), station(-999), ring(-999), sector(-999), sector_index(-999), subsector(-999), chamber(-999), csc_ID(-999), 
-      neighbor(-999), mpc_link(-999), wire(-999), strip(-999), track_num(-999), quality(-999), pattern(-999), bend(-999), 
-      valid(-999), sync_err(-999), bc0(-999), bx(-999), stub_num(-999), is_CSC_hit(-999), is_RPC_hit(-999)
+    endcap(-999), station(-999), ring(-999), sector(-999), sector_index(-999), subsector(-999), 
+      chamber(-999), csc_ID(-999), roll(-999), rpc_layer(-999), neighbor(-999), mpc_link(-999), 
+      wire(-999), strip(-999), strip_hi(-999), strip_low(-999), track_num(-999), quality(-999), 
+      pattern(-999), bend(-999), valid(-999), sync_err(-999), bc0(-999), bx(-999), stub_num(-999), 
+      is_CSC_hit(-999), is_RPC_hit(-999)
       {};
     
     virtual ~EMTFHit() {};
 
     void ImportCSCDetId (const CSCDetId& _detId);
     CSCDetId CreateCSCDetId();
+    void ImportRPCDetId (const RPCDetId& _detId);
+    RPCDetId CreateRPCDetId();
     void ImportCSCCorrelatedLCTDigi (const CSCCorrelatedLCTDigi& _digi);
     CSCCorrelatedLCTDigi CreateCSCCorrelatedLCTDigi();
+    void ImportRPCDigi (const RPCDigi& _digi);
+    RPCDigi CreateRPCDigi();
     void ImportME (const emtf::ME _ME );
 
     void PrintSimulatorHeader();
     void PrintForSimulator();
 
     void SetCSCDetId         (CSCDetId id)                 { csc_DetId         = id;        }
+    void SetRPCDetId         (RPCDetId id)                 { rpc_DetId         = id;        }
     void SetCSCLCTDigi       (CSCCorrelatedLCTDigi digi)   { csc_LCTDigi       = digi;      }
+    void SetRPCDigi          (RPCDigi digi)                { rpc_Digi          = digi;      }
     
     CSCDetId CSC_DetId                          () const { return csc_DetId;    }
+    RPCDetId RPC_DetId                          () const { return rpc_DetId;    }
     CSCCorrelatedLCTDigi CSC_LCTDigi            () const { return csc_LCTDigi;  }
+    RPCDigi RPC_Digi                            () const { return rpc_Digi;  }
     const CSCDetId * PtrCSC_DetId               () const { return &csc_DetId;   }
+    const RPCDetId * PtrRPC_DetId               () const { return &rpc_DetId;   }
     const CSCCorrelatedLCTDigi * PtrCSC_LCTDigi () const { return &csc_LCTDigi; }
+    const RPCDigi * PtrRPC_Digi                 () const { return &rpc_Digi; }
 
     void set_endcap         (int  bits) { endcap        = bits; }
     void set_station        (int  bits) { station       = bits; }
@@ -54,10 +68,14 @@ namespace l1t {
     void set_subsector      (int  bits) { subsector     = bits; }
     void set_chamber        (int  bits) { chamber       = bits; }
     void set_csc_ID         (int  bits) { csc_ID        = bits; }
+    void set_roll           (int  bits) { roll          = bits; }
+    void set_rpc_layer      (int  bits) { rpc_layer     = bits; }
     void set_neighbor       (int  bits) { neighbor      = bits; }
     void set_mpc_link       (int  bits) { mpc_link      = bits; }
     void set_wire           (int  bits) { wire          = bits; }
     void set_strip          (int  bits) { strip         = bits; }
+    void set_strip_hi       (int  bits) { strip_hi      = bits; }
+    void set_strip_low      (int  bits) { strip_low     = bits; }
     void set_track_num      (int  bits) { track_num     = bits; }
     void set_quality        (int  bits) { quality       = bits; }
     void set_pattern        (int  bits) { pattern       = bits; }
@@ -78,10 +96,14 @@ namespace l1t {
     int   Subsector      ()  const { return subsector;      }
     int   Chamber        ()  const { return chamber  ;      }
     int   CSC_ID         ()  const { return csc_ID   ;      }
+    int   Roll           ()  const { return roll     ;      }
+    int   RPC_layer      ()  const { return rpc_layer;      }
     int   Neighbor       ()  const { return neighbor ;      }
     int   MPC_link       ()  const { return mpc_link ;      }
     int   Wire           ()  const { return wire     ;      }
     int   Strip          ()  const { return strip    ;      }
+    int   Strip_hi       ()  const { return strip_hi ;      }
+    int   Strip_low      ()  const { return strip_low;      }
     int   Track_num      ()  const { return track_num;      }
     int   Quality        ()  const { return quality  ;      }
     int   Pattern        ()  const { return pattern  ;      }
@@ -98,7 +120,9 @@ namespace l1t {
   private:
     
     CSCDetId csc_DetId;
+    RPCDetId rpc_DetId;
     CSCCorrelatedLCTDigi csc_LCTDigi;
+    RPCDigi rpc_Digi;
     
     int   endcap;       // -1 or 1.  Filled in EMTFHit.cc from CSCDetId, modified
     int   station;      //  1 -  4.  Filled in EMTFHit.cc from CSCDetId
@@ -108,10 +132,14 @@ namespace l1t {
     int   subsector;    //  1 -  2.  Filled in EMTFHit.cc or emulator using calc_subsector above
     int   chamber;      //  1 - 36.  Filled in EMTFHit.cc from CSCDetId
     int   csc_ID;       //  1 -  9.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi or emulator from CSCData
+    int   roll;         //  Sub-division of ring for RPC hits
+    int   rpc_layer;    //  Forward-backward bit for RPC hits
     int   neighbor;     //  0 or 1.  Filled in EMTFBlockME.cc 
     int   mpc_link;     //  1 -  3.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi
     int   wire;         //  1 -  ?.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi
     int   strip;        //  1 -  ?.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi
+    int   strip_hi;     //  Highest strip number in an RPC cluster
+    int   strip_low;    //  Lowest strip number in an RPC cluster
     int   track_num;    //  ? -  ?.  Filled in emulator from CSCData 
     int   quality;      //  0 - 15.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi
     int   pattern;      //  0 - 10.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi

--- a/DataFormats/L1TMuon/interface/EMTFHitExtra.h
+++ b/DataFormats/L1TMuon/interface/EMTFHitExtra.h
@@ -19,7 +19,7 @@ namespace l1t {
     
   EMTFHitExtra() :
     
-      bx0(-999), layer(-999), zone_hit(-999), phi_hit(-999), phi_z_val(-999), phi_loc_int(-999), 
+      bx0(-999), layer(-999), zone(-999), phi_hit(-999), phi_zone(-999), phi_loc_int(-999), 
       phi_loc_deg(-999), phi_loc_rad(-999), phi_glob_deg(-999), phi_glob_rad(-999), phi_geom_rad(-999), 
       theta_int(-999), theta_loc(-999), theta_deg(-999), theta_rad(-999), eta(-999)
       {};
@@ -28,15 +28,33 @@ namespace l1t {
 
     void ImportCSCCorrelatedLCTDigi (const CSCCorrelatedLCTDigi& _digi);
     EMTFHit CreateEMTFHit();
+    EMTFHitExtra Clone() {
+      EMTFHitExtra ht;
+      ht.set_endcap(Endcap()); ht.set_station(Station()); ht.set_ring(Ring()); ht.set_sector(Sector()); 
+      ht.set_sector_index(Sector_index()); ht.set_subsector(Subsector()); ht.set_chamber(Chamber()); 
+      ht.set_csc_ID(CSC_ID()); ht.set_roll(Roll()); ht.set_rpc_layer(RPC_layer()); ht.set_neighbor(Neighbor()); 
+      ht.set_mpc_link(MPC_link()); ht.set_wire(Wire()); ht.set_strip(Strip()); ht.set_strip_hi(Strip_hi()); 
+      ht.set_strip_low(Strip_low()); ht.set_track_num(Track_num()); ht.set_quality(Quality()); ht.set_pattern(Pattern()); 
+      ht.set_bend(Bend()); ht.set_valid(Valid()); ht.set_sync_err(Sync_err()); ht.set_bc0(BC0()); ht.set_bx(BX()); 
+      ht.set_stub_num(Stub_num()); ht.set_is_CSC_hit(Is_CSC_hit()); ht.set_is_RPC_hit(Is_RPC_hit()); 
 
+      ht.SetCSCDetId(CSC_DetId()); ht.SetRPCDetId(RPC_DetId()); ht.SetCSCLCTDigi(CSC_LCTDigi()); ht.SetRPCDigi(RPC_Digi());
+
+      ht.set_bx0(BX0()); ht.set_layer(Layer()); ht.set_zone(Zone()); ht.set_phi_hit(Phi_hit()); ht.set_phi_zone(Phi_zone()); 
+      ht.set_phi_loc_int(Phi_loc_int()); ht.set_phi_loc_deg(Phi_loc_deg()); ht.set_phi_loc_rad(Phi_loc_rad()); 
+      ht.set_phi_glob_deg(Phi_glob_deg()); ht.set_phi_glob_rad(Phi_glob_rad()); ht.set_phi_geom_rad(Phi_geom_rad()); 
+      ht.set_theta_int(Theta_int()); ht.set_theta_loc(Theta_loc()); ht.set_theta_deg(Theta_deg()); ht.set_theta_rad(Theta_rad()); 
+      ht.set_eta(Eta()); 
+      return ht;
+    }
     void SetZoneContribution (std::vector<int> vect_ints)  { zone_contribution = vect_ints; }
     std::vector<int> Zone_contribution          () const { return zone_contribution; }
 
     void set_bx0            (int  bits) { bx0           = bits; }
     void set_layer          (int  bits) { layer         = bits; }
-    void set_zone_hit       (int  bits) { zone_hit      = bits; }
+    void set_zone           (int  bits) { zone          = bits; }
     void set_phi_hit        (int  bits) { phi_hit       = bits; }
-    void set_phi_z_val      (int  bits) { phi_z_val     = bits; }
+    void set_phi_zone       (int  bits) { phi_zone      = bits; }
     void set_phi_loc_int    (int  bits) { phi_loc_int   = bits; }
     void set_phi_loc_deg    (float val) { phi_loc_deg   = val;  }
     void set_phi_loc_rad    (float val) { phi_loc_rad   = val;  }
@@ -51,9 +69,9 @@ namespace l1t {
 
     int   BX0            ()  const { return bx0;            }
     int   Layer          ()  const { return layer;          }
-    int   Zone_hit       ()  const { return zone_hit;       }
+    int   Zone           ()  const { return zone;           }
     int   Phi_hit        ()  const { return phi_hit;        }
-    int   Phi_Z_val      ()  const { return phi_z_val;      }
+    int   Phi_zone       ()  const { return phi_zone;       }
     int   Phi_loc_int    ()  const { return phi_loc_int;    }
     float Phi_loc_deg    ()  const { return phi_loc_deg;    }
     float Phi_loc_rad    ()  const { return phi_loc_rad;    }
@@ -73,9 +91,9 @@ namespace l1t {
     
     int   bx0;          //  1-3600.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi
     int   layer;
-    int   zone_hit;     //  4 - 118. Filled in emulator from ConvertedHit.Zhit()
+    int   zone;         //  4 - 118. Filled in emulator from ConvertedHit.Zhit()
     int   phi_hit;      //  1 - 42.  Filled in emulator from ConvertedHit.Ph_hit()
-    int   phi_z_val;    //  1 -  6.  Filled in emulator from ConvertedHit.Phzvl()
+    int   phi_zone;     //  1 -  6.  Filled in emulator from ConvertedHit.Phzvl()
     int   phi_loc_int;  //  ? -  ?.  Filled in emulator from ConvertedHit.Phi()
     float phi_loc_deg;  //  ? -  ?.  Filled in emulator, calculated from phi_loc_int with GetPackedPhi
     float phi_loc_rad;  //  ? -  ?.  Filled in emulator, calculated from phi_loc_int with GetPackedPhi

--- a/L1Trigger/L1TMuon/interface/deprecate/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/deprecate/MuonTriggerPrimitive.h
@@ -130,6 +130,9 @@ namespace L1TMuon {
     //copy
     TriggerPrimitive(const TriggerPrimitive&);
 
+    // Create a copy of TP1 with wire of TP2
+    TriggerPrimitive(const TriggerPrimitive& tp1, const TriggerPrimitive& tp2);
+
     TriggerPrimitive& operator=(const TriggerPrimitive& tp);
     bool operator==(const TriggerPrimitive& tp) const;
 

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -108,6 +108,27 @@ TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid,
   _csc.cscID   = digi.getCSCID();
 }
 
+// Create copy of TP1 with wire from TP2
+TriggerPrimitive::TriggerPrimitive(const TriggerPrimitive& tp1, const TriggerPrimitive& tp2) {
+
+  _subsystem 	= TriggerPrimitive::kCSC;
+  _id 		= tp1.detId<CSCDetId>();
+  _csc.trknmb 	= tp1._csc.trknmb; 
+  _csc.valid 	= tp1._csc.valid; 
+  _csc.quality 	= tp1._csc.quality; 
+  _csc.keywire 	= tp2._csc.keywire; 
+  _csc.strip 	= tp1._csc.strip; 
+  _csc.pattern 	= tp1._csc.pattern; 
+  _csc.bend 	= tp1._csc.bend; 
+  _csc.bx 	= tp1._csc.bx; 
+  _csc.mpclink 	= tp1._csc.mpclink; 
+  _csc.bx0 	= tp1._csc.bx0; 
+  _csc.syncErr 	= tp1._csc.syncErr;
+  _csc.cscID 	= tp1._csc.cscID;
+
+}
+
+
 // constructor from RPC data
 TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
 				   const unsigned strip,

--- a/L1Trigger/L1TMuonEndCap/interface/BXAnalyzer.h
+++ b/L1Trigger/L1TMuonEndCap/interface/BXAnalyzer.h
@@ -31,14 +31,36 @@ std::vector<std::vector<ConvertedHit>> GroupBX(std::vector<ConvertedHit> ConvHit
       output[1].push_back(*i);
   }
   
+  for(int i=0;i<3;i++){
+		
+    for(std::vector<ConvertedHit>::iterator it = output[i].begin();it != output[i].end();it++){
+      for(std::vector<ConvertedHit>::iterator it2 = it;it2 != output[i].end();it2++){
+	
+	if(it == it2) continue;
+	
+	//add that phis have to be equal if assuming that a phi position can have only 2 possible thetas
+	if(it->Station() == it2->Station() && it->Id() == it2->Id() ){
+	  
+	  it->SetTheta2(it2->Theta());
+	  it2->SetTheta2(it->Theta());
+	  
+	  it->AddTheta(it2->Theta());
+	  it2->AddTheta(it->Theta());
+	}
+	
+      }
+    }
+    
+  }
+  
   return output;
   
 }
 
 PatternOutput DeleteDuplicatePatterns(std::vector<PatternOutput> Pout){
-  
+
   std::vector<int> tmp (192,0);//was 128
-  std::vector<std::vector<int>> rank (4,tmp), layer(4,tmp),straightness(4,tmp);
+  std::vector<std::vector<int>> rank (4,tmp), layer(4,tmp),straightness(4,tmp),bxgroup(4,tmp);
   std::vector<ConvertedHit> Hits;
   
   for(int i=0;i<3;i++){
@@ -48,17 +70,18 @@ PatternOutput DeleteDuplicatePatterns(std::vector<PatternOutput> Pout){
     for(int zone=0;zone<4;zone++){
       for(int strip=0;strip<192;strip++){//was 128
 	
-	if(Pout[i].detected.rank[zone][strip] >= rank[zone][strip]){
+	if(Pout[i].detected.rank[zone][strip] > rank[zone][strip]){
 	  
 	  rank[zone][strip] = Pout[i].detected.rank[zone][strip];
 	  layer[zone][strip] = Pout[i].detected.layer[zone][strip];
 	  straightness[zone][strip] = Pout[i].detected.straightness[zone][strip];
+	  bxgroup[zone][strip] = i+1;
 	  set = 1;
 	}
       }
     }
     
-    if(set && (Pout[i].hits.size() > Hits.size())){
+    if(set ){/*//&& (Pout[i].hits.size() >= Hits.size())){*/
       
       std::vector<ConvertedHit> test = Pout[i].hits;
       
@@ -70,16 +93,15 @@ PatternOutput DeleteDuplicatePatterns(std::vector<PatternOutput> Pout){
   }
   
   QualityOutput qout;
-  
   qout.rank = rank;
   qout.layer = layer;
   qout.straightness = straightness;
+  qout.bxgroup = bxgroup;
   
   PatternOutput output;
-  
   output.detected = qout;
   output.hits = Hits;
-  
+	
   return output;
   
 }

--- a/L1Trigger/L1TMuonEndCap/interface/Deltas.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Deltas.h
@@ -10,28 +10,19 @@
 DeltaOutput Deltas(MatchingOutput Mout, int zone, int winner){
   
   //bool verbose = false;
-  
+	
   PhOutput phmatch = Mout.PhiMatch();
   ThOutput thmatch = Mout.ThetaMatch();
-  
-  /*for comparison only
-    for(int xx=0;xx<4;xx++){
-    
-    if(phmatch[zone][winner][xx].Phi() != -999 && verbose)
-    std::cout<<"phmatch["<<zone<<"]["<<winner<<"]["<<xx<<"] = "<<phmatch[zone][winner][xx].Phi()<<"\n\n";
-    }
-  */
+  ThOutput2 t2 = Mout.TMatch2();
   
   /////////////////////////////////////
   ///Set Null dphi and dtheta arrays///
   /////////////////////////////////////
   int dphi[6] = {-999,-999,-999,-999,-999,-999};
-  int dtmp[6] = {-999,-999,-999,-999,-999,-999};
-  int dtmpi[6] = {-999,-999,-999,-999,-999,-999};
-  int dth[6][4] = {{-999,-999,-999,-999},{-999,-999,-999,-999},
-		   {-999,-999,-999,-999},{-999,-999,-999,-999},
-		   {-999,-999,-999,-999},{-999,-999,-999,-999}};
-
+  int dtmp2[6] = {-999,-999,-999,-999,-999,-999};
+  int dtmp2_ths[6][2] = {{-999,-999},{-999,-999},{-999,-999},{-999,-999},{-999,-999},{-999,-999}};
+  
+  
   for(int s1=0;s1<3;s1++){
     
     for(int s2=s1+1;s2<4;s2++){
@@ -40,39 +31,51 @@ DeltaOutput Deltas(MatchingOutput Mout, int zone, int winner){
       ///  calc delta phis  /// indexing procedure dphi[s2-1] for the first 3 and dphi[s1+s2] for the rest 
       /////////////////////////
       
-      //if using station one and both hits are valid
-      if((s1 == 0) && (phmatch[zone][winner][s1].Phi() != -999) && (phmatch[zone][winner][s2].Phi() != -999)){ 
+      if((s1 == 0) && (phmatch[zone][winner][s1].Phi() != -999) && (phmatch[zone][winner][s2].Phi() != -999)){ //if using station one and both hits are valid
 	
 	dphi[s2-1] = phmatch[zone][winner][s1].Phi() - phmatch[zone][winner][s2].Phi();
       }
-      //if not using station one and both hits are valid
-      else if((s1 != 0) && (phmatch[zone][winner][s1].Phi() != -999) && (phmatch[zone][winner][s2].Phi() != -999)){
-	
+      else if((s1 != 0) && (phmatch[zone][winner][s1].Phi() != -999) && (phmatch[zone][winner][s2].Phi() != -999)){//if not using station one and both hits are valid
+					
 	dphi[s1+s2] = phmatch[zone][winner][s1].Phi() - phmatch[zone][winner][s2].Phi();	
       }
+			
       
       ///////////////////////// There is a further index on dTh because there are 4 dth combinations 
       /// calc delta theta  /// possible if there are two theta segments for both stations. 
       ///////////////////////// EXPLAIN ABOUT [I+J] AND [I+J+1] 
       
-      for(int i=0;i<2;i++){
-	
-	for(int j=0;j<2;j++){
+      for(unsigned int t1=0;t1<phmatch[zone][winner][s1].AllThetas().size();t1++){
+	for(unsigned int t2=0;t2<phmatch[zone][winner][s2].AllThetas().size();t2++){
 	  
-	  int thi = thmatch[zone][winner][s1][i].Theta();
-	  int thj = thmatch[zone][winner][s2][j].Theta();
-	  int deltath = thi - thj;
+	  int dth_tmp = phmatch[zone][winner][s2].AllThetas()[t2] - phmatch[zone][winner][s1].AllThetas()[t1];
 	  
-	  if((s1 == 0) && (thi != -999) && (thj != -999)){///need to fix still////
+	  if(s1 == 0){
 	    
-	    if(!i){dth[s2-1][i+j] = deltath;}
-	    else{dth[s2-1][i+j+1] = deltath;}
+	    if(dtmp2[s2-1] != -999){
+	      dtmp2[s2-1] = dth_tmp;
+	      dtmp2_ths[s2-1][0] = phmatch[zone][winner][s1].AllThetas()[t1];
+	      dtmp2_ths[s2-1][1] = phmatch[zone][winner][s2].AllThetas()[t2];
+	    }
+	    else if(abs(dth_tmp) < abs(dtmp2[s2-1])){
+	      dtmp2[s2-1] = dth_tmp;
+	      dtmp2_ths[s2-1][0] = phmatch[zone][winner][s1].AllThetas()[t1];
+	      dtmp2_ths[s2-1][1] = phmatch[zone][winner][s2].AllThetas()[t2];
+	    }
 	    
 	  }
-	  else if((s1 != 0) && (thi != -999) && (thj != -999)){
+	  else{
 	    
-	    if(!i){dth[s1+s2][i+j] = deltath;}
-	    else{dth[s1+s2][i+j+1] = deltath;}
+	    if(dtmp2[s2+s1] != -999){
+	      dtmp2[s2+s1] = dth_tmp;
+	      dtmp2_ths[s1+s2][0] = phmatch[zone][winner][s1].AllThetas()[t1];
+	      dtmp2_ths[s2+s1][1] = phmatch[zone][winner][s2].AllThetas()[t2];
+	    }
+	    else if(abs(dth_tmp) < abs(dtmp2[s2+s1])){
+	      dtmp2[s2+s1] = dth_tmp;
+	      dtmp2_ths[s1+s2][0] = phmatch[zone][winner][s1].AllThetas()[t1];
+	      dtmp2_ths[s2+s1][1] = phmatch[zone][winner][s2].AllThetas()[t2];
+	    }
 	  }
 	  
 	}
@@ -80,8 +83,7 @@ DeltaOutput Deltas(MatchingOutput Mout, int zone, int winner){
       
     }
   } 
-  
-  
+	
   int vmask[3] = {0,0,0};
   const unsigned int mask[6] = {0x3,0x5,0x9,0x6,0xa,0xc};
   //////////////////////////////////////////////////////////////////////////////////////////
@@ -100,49 +102,19 @@ DeltaOutput Deltas(MatchingOutput Mout, int zone, int winner){
   
   for(int p=0;p<6;p++){
     
-    //if(dphi[p] != -999 && verbose)
-    //	std::cout<<"dphi["<<p<<"] = "<<dphi[p]<<"\n\n";
-    
-    for(int l=0;l<4;l++){
-      
-      //if(dth[p][l] != -999 && verbose){std::cout<<"dth["<<p<<"]["<<l<<"] = "<<dth[p][l]<<"\n\n";}
-      
-      if(abs(dth[p][l]) < fabs(dtmp[p])){//get best dtheta(i.e. the smallest)
-	
-	//if(verbose) std::cout<<"chose second hit theta  index-"<<p<<std::endl;
-	
-	dtmp[p] = dth[p][l];
-	
-	dtmpi[p] = l;//says which combination of dth is the one to choose (because there are 4 possible as stated above^)
-      }
-    }
-    
-    if((abs(dtmp[p]) <= 4) && (dtmp[p] != -999)){//if dtheta is small enought and valid
-      
-      //std::cout<<"valid "<<p<<std::endl;
-      
+    if((abs(dtmp2[p]) <= 4) && (dtmp2[p] != -999)){//if dtheta is small enought and valid
       vmask[mindex[p]] |= mask[p];	
     } 
   }
   
-  //for(int q=0;q<3;q++){
-  //	if(vmask[q] && verbose)
-  //		std::cout<<"vmask["<<q<<"] = "<<vmask[q]<<std::endl;
-  //}
-  
   unsigned int vstat = vmask[0];
   
-  //if(vstat && verbose){std::cout<<"vstat = "<<vstat<<std::endl;}
-  
   if( !vstat || (vstat & vmask[1])){vstat |= vmask[1];}
-  
-  ///if(vstat && verbose){std::cout<<"vstat = "<<vstat<<std::endl;}
-  
   if( !vstat || (vstat & vmask[2])){vstat |= vmask[2];}
   
-  //if(vstat && verbose){std::cout<<"vstat = "<<vstat<<std::endl;}
-  
-  const unsigned int vstatindex[11] = {0xc,0xa,0x6,0xe,0x9,0x5,0xd,0x3,0xb,0x7,0xf};
+  //if(vstat ){std::cout<<"vstat = "<<vstat<<std::endl;}//
+  /*
+  //const unsigned int vstatindex[11] = {0xc,0xa,0x6,0xe,0x9,0x5,0xd,0x3,0xb,0x7,0xf};
   /////////////////////////////////////////////////////////////////////////////////////////////
   /// vstatindex[11] is a list of possible combinations of valid and present stations
   /// in order of increasing quality(i.e. if all stations are present and valid it's 
@@ -160,99 +132,65 @@ DeltaOutput Deltas(MatchingOutput Mout, int zone, int winner){
   /// stations 1,2 and 3 present --> 0x7 --> 0111
   /// all stations present       --> 0xf --> 1111
   /////////////////////////////////////////////////////////////////////////////////////////////
-  const unsigned int viindex[2][11] = {{5,4,3,3,2,1,1,0,0,0,0},
-				       {5,4,3,5,2,1,5,0,4,3,3}};///index on which entry of vstatindex[11] to choose for both dphi and dtheta
-  
-  std::vector<int> d (2,-999);
+  //const unsigned int viindex[2][11] = {{5,4,3,3,2,1,1,0,0,0,0},{5,4,3,5,2,1,5,0,4,3,3}};///index on which entry of vstatindex[11] to choose for both dphi and dtheta
+  */
+
+  std::vector<int> d (6,-999);
   std::vector<std::vector<int>> deltas (2,d);//deltas[0]->dPhi & deltas[1]->dTheta
   
-  for(int c=0;c<11;c++){
+  for(int i=0;i<6;i++){
     
-    if(vstat == vstatindex[c]){
-      
-      deltas[0][0] = dphi[viindex[0][c]];
-      deltas[0][1] = dphi[viindex[1][c]];
-      deltas[1][0] = dtmp[viindex[0][c]];
-      deltas[1][1] = dtmp[viindex[1][c]];
-    }
+    deltas[0][i] = dphi[i];
+    deltas[1][i] = dtmp2[i];
   }
   
   ///////////Set Precise Phi&Theta//////////
-  int phi = 0, theta = 0, id = 0;
+  int phi = 0, theta = 0;//, id = 0;
   if(vstat & 2){//ME2 Present
     
-		//phi is simple, we have only one per station to choose from
+    //phi is simple, we have only one per station to choose from
     phi = phmatch[zone][winner][1].Phi();
     
     //for theta, select delta to best station, use dtmpi as index
-    if(dtmp[0] != -999){
-      
-      if(dtmpi[0] < 2)
-	id = 1;
-      
-      theta = thmatch[zone][winner][1][id].Theta();
+    if(dtmp2[0] != -999){
+      theta = dtmp2_ths[0][1];//t2[zone][winner][1][id];
     }
-    else if(dtmp[3] != -999){
-      
-      if(dtmpi[3] > 1)
-	id = 1;
-      
-      theta = thmatch[zone][winner][1][id].Theta();
+    else if(dtmp2[3] != -999){
+      theta = dtmp2_ths[3][0];//t2[zone][winner][1][id];
     }
-    else if(dtmp[4] != -999){
-      
-      if(dtmpi[4] > 1)
-	id = 1;
-      
-      theta = thmatch[zone][winner][1][id].Theta();
+    else if(dtmp2[4] != -999){
+      theta = dtmp2_ths[4][0];//t2[zone][winner][1][id];
     }
     
   }
   else if(vstat & 4){//ME3 Present, but not ME2
-    
+	
     phi = phmatch[zone][winner][2].Phi();
-    
-    if(dtmp[1] != -999){
-      
-      if(dtmpi[1] < 2)
-	id = 1;
-      
-      theta = thmatch[zone][winner][2][id].Theta();
+    if(dtmp2[1] != -999){
+      theta = dtmp2_ths[1][1];//t2[zone][winner][2][id];
     }
-    else if(dtmp[5] != -999){
-      
-      if(dtmpi[5] > 1)
-	id = 1;
-      
-      theta = thmatch[zone][winner][2][id].Theta();
+    else if(dtmp2[5] != -999){
+      theta = dtmp2_ths[5][0];//t2[zone][winner][2][id];
     }
   }
   else if(vstat & 8){//ME4 Present but not ME2 or ME3
-    
     phi = phmatch[zone][winner][3].Phi();
-    if(dtmp[2] != -999){
-      
-      if(dtmpi[2] < 2)
-	id = 1;
-      
-      
-      theta = thmatch[zone][winner][3][id].Theta();
+    if(dtmp2[2] != -999){
+      theta = dtmp2_ths[2][1];//t2[zone][winner][3][id];
     }
   }
-  
-  
+	
   //////////////////////////////////////////
   
   int rank = (Mout.Winners()[zone][winner].Rank()<<1);
   
+  //if(rank) std::cout<<"rank = "<<rank<<"\n";
   ///here we separate stations 3 and 4////
   if(vstat & 8){rank |= 1;}else{rank &= 0x7e;}//if station 4 add to rank, else keep everythign and zero the bit which indicates station 4 is present
   if(vstat & 4){rank |= 2;}else{rank &= 0x7d;}//if station 3 add to rank, else keep everythign and zero the bit which indicates station 3 is present
   if(vstat & 2){rank |= 8;}else{rank &= 0x77;}//if station 2 add to rank, else keep everythign and zero the bit which indicates station 2 is present
   if(vstat & 1){rank |= 32;}else{rank &= 0x5f;}//if station 1 add to rank, else keep everythign and zero the bit which indicates station 1 is present
-  
   if(vstat == 0 || vstat == 1 || vstat == 2 || vstat == 4 || vstat == 8){rank = 0;}//removes single, and ME3--ME4 hit combinations
-  
   DeltaOutput output;
   Mout.SetPhOut(phmatch);
   Winner win = Mout.Winners()[zone][winner];
@@ -265,19 +203,37 @@ DeltaOutput Deltas(MatchingOutput Mout, int zone, int winner){
 }
 
 std::vector<std::vector<DeltaOutput>> CalcDeltas(MatchingOutput Mout){
-  
+
   DeltaOutput output;output.SetNull();
   
   std::vector<DeltaOutput> o (3,output);
   std::vector<std::vector<DeltaOutput>> out (4,o);
   
   for(int zone=0;zone<4;zone++){
-    
     for(int winner=0;winner<3;winner++){
-      
       out[zone][winner] = Deltas(Mout, zone, winner);
     }
   }	
-  
+	
   return out;
+}
+
+std::vector<std::vector<std::vector<DeltaOutput>>> CalcDeltas_Hold(std::vector<MatchingOutput> Mout){
+  
+  DeltaOutput output;output.SetNull();
+  
+  std::vector<DeltaOutput> o (3,output);
+  std::vector<std::vector<DeltaOutput>> out (4,o);
+  std::vector<std::vector<std::vector<DeltaOutput>>> Output (3,out);
+  
+  for(int bx=0;bx<3;bx++){
+    for(int zone=0;zone<4;zone++){
+      for(int winner=0;winner<3;winner++){
+	Output[bx][zone][winner] = Deltas(Mout[bx], zone, winner);
+      }
+    }
+  }
+  
+  return Output;
+  
 }

--- a/L1Trigger/L1TMuonEndCap/interface/EmulatorClasses.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EmulatorClasses.h
@@ -11,24 +11,22 @@ typedef std::vector<std::vector<int>> Code;
 typedef std::vector<std::vector<std::vector<int>>> BXHold;
 
 //
+
+
 class ConvertedHit{
   
  public:
   
-  void SetValues(int phi,int theta,int ph_hit,int phzvl,int station,int sub,
-		 int id,int quality,int pattern,int wire,int strip,int BX){
-    
-    _ph = phi;_th = theta;_phit = ph_hit;_phzvl = phzvl;_sta = station;_sub = sub;
-    _id = id;_qual = quality;_patt = pattern;_wire = wire;_strip = strip;_zhit = -999;_bx = BX;
-    
+  void SetValues(int phi,int theta,int ph_hit,int phzvl,int station,int sub,int id,int quality,int pattern,int wire,int strip,int BX){
+    _ph = phi;_th = theta;_phit = ph_hit;_phzvl = phzvl;_sta = station;_sub = sub;_id = id;_qual = quality;_patt = pattern;
+    _wire = wire;_strip = strip;_zhit = -999;_bx = BX;_th2 = -999;
   };
   
   void SetNull(){
-    _ph = -999;_th = -999;_phit = -999;_phzvl = -999;_sta = -999;_sub = -999;
-    _id = -999;_qual = -999;_patt = 0;_wire = -999;_strip = -999;_zhit = -999;
+    _ph = -999;_th = -999;_th2 = -999;_phit = -999;_phzvl = -999;_sta = -999;_sub = -999;_id = -999;_qual = -999;_patt = 0;
+    _wire = -999;_strip = -999;_zhit = -999;
   };
-  
-  
+		
   void SetId(int id){
     _id = id;
   };
@@ -38,19 +36,17 @@ class ConvertedHit{
   };
   
   void SetZhit(int zhit){_zhit = zhit;};
-  
   void SetTheta(int theta){_th = theta;};
-  
+  void SetTheta2(int theta2){_th2 = theta2;};
   void SetTP(TriggerPrimitive tp){_tp = tp;};
-  
   void SetSectorIndex(int sectorIndex){_sectorIndex = sectorIndex;};
-  
   void SetZoneContribution(std::vector<int> zonecontribution){_zonecont = zonecontribution;};
-  
   void SetNeighbor(int neighbor){_isNeighbor = neighbor;};
-  
+  void AddTheta(int theta){_thetas.push_back(theta);};
+		
   int Phi(){return _ph;};
   int Theta(){return _th;};
+  int Theta2(){return _th2;};
   int Ph_hit(){return _phit;};
   int Phzvl(){return _phzvl;};
   int Station(){return _sta;};
@@ -66,11 +62,12 @@ class ConvertedHit{
   int IsNeighbor(){return _isNeighbor;};
   TriggerPrimitive TP(){return _tp;};
   std::vector<int> ZoneContribution(){return _zonecont;};
+  std::vector<int> AllThetas(){return _thetas;};
   
- private:
-  int _ph,_th,_phit,_phzvl,_sta,_sub,_id,_qual,_patt,_wire,_strip,_zhit,_bx, _sectorIndex, _isNeighbor;
+	private:
+  int _ph,_th, _th2,_phit,_phzvl,_sta,_sub,_id,_qual,_patt,_wire,_strip,_zhit,_bx, _sectorIndex, _isNeighbor;
   TriggerPrimitive _tp;
-  std::vector<int> _zonecont;
+  std::vector<int> _zonecont, _thetas;
   
 };
 
@@ -80,50 +77,49 @@ struct ZonesOutput{
 };
 
 struct QualityOutput{
-  Code rank, layer,straightness;
+  Code rank, layer,straightness, bxgroup;
 };
-
 
 struct PatternOutput{
   QualityOutput detected;
   std::vector<ConvertedHit> hits;
+  // int bxgroup;
 };
-
 
 struct Wier{
   int rank, strip;
 };
 
 class Winner{
-  
- public:
 
+	public:
   //Default Constructor: rank & strip = 0///
   Winner(){_rank = 0;_strip = 0;};
   
   int Rank(){return _rank;}
   int Strip(){return _strip;}
+  int BXGroup(){return _bxgroup;}
   
   void SetValues(int rank, int strip){
-    
     _rank = rank;
     _strip = strip;
   }
   void SetRank(int rank){
-    
     _rank = rank;
   }
   
- private:
+  void SetBXGroup(int bxgroup){
+    _bxgroup = bxgroup;
+  }
   
-  int _rank, _strip;
+ private:
+  int _rank, _strip, _bxgroup;
   
 };
 
 class SortingOutput{
   
  public:
-  
   void SetHits(std::vector<ConvertedHit> hits){_hits = hits;};
   void SetWinners(std::vector<std::vector<Winner>> winners){_winners = winners;};
   void SetValues(std::vector<std::vector<Winner>> winners, std::vector<ConvertedHit> hits){_winners = winners;_hits = hits;};
@@ -132,27 +128,23 @@ class SortingOutput{
   std::vector<std::vector<Winner>> Winners(){return _winners;};
   
  private:
-  
   std::vector<ConvertedHit> _hits;
   std::vector<std::vector<Winner>> _winners;
   
 };
 
-
 typedef std::vector<std::vector<std::vector<std::vector<ConvertedHit>>>> ThOutput;
+typedef std::vector<std::vector<std::vector<std::vector<int>>>> ThOutput2;
 typedef std::vector<std::vector<std::vector<ConvertedHit>>> PhOutput;
 class MatchingOutput{
   
  public:
-  
   void SetHits(std::vector<ConvertedHit> hits){_hits = hits;};
   void SetWinners(std::vector<std::vector<Winner>> winners){_winners = winners;};
   void SetThOut(ThOutput th_output){_th_output = th_output;};
   void SetPhOut(PhOutput ph_output){_ph_output = ph_output;};
   void SetSegment(std::vector<int> segment){_segment = segment;};
-  void SetValues(ThOutput th_output,PhOutput ph_output,std::vector<ConvertedHit> hits,
-		 std::vector<std::vector<Winner>> winners,std::vector<int> segment){
-			
+  void SetValues(ThOutput th_output,PhOutput ph_output,std::vector<ConvertedHit> hits,std::vector<std::vector<Winner>> winners,std::vector<int> segment){
     _th_output = th_output;
     _ph_output = ph_output;
     _hits = hits;
@@ -160,28 +152,32 @@ class MatchingOutput{
     _segment = segment;
   }
   
+  void setM2(ThOutput2 t2){
+    _th_output2 = t2;
+  }
+  
   std::vector<ConvertedHit> Hits(){return _hits;}; 
   std::vector<std::vector<Winner>> Winners(){return _winners;};
   ThOutput ThetaMatch(){return _th_output;};
+  ThOutput2 TMatch2(){return _th_output2;};
   PhOutput PhiMatch(){return _ph_output;};
   std::vector<int> Segment(){return _segment;};
   
  private:
-  
   std::vector<ConvertedHit> _hits;
   std::vector<std::vector<Winner>> _winners;
   ThOutput _th_output;
+  ThOutput2 _th_output2;
   PhOutput _ph_output;
   std::vector<int> _segment;
-  
+	
 };
 
 class DeltaOutput{
-  
+
  public:
   void SetNull(){_Phi = -999;_Theta = -999;};
   void SetValues(MatchingOutput Mout, std::vector<std::vector<int>> Deltas, int Phi, int Theta, Winner winner){
-    
     _Mout = Mout;_Deltas = Deltas;_Phi = Phi; _Theta = Theta;_winner = winner;
   }
   
@@ -192,7 +188,6 @@ class DeltaOutput{
   Winner GetWinner(){return _winner;};
   
  private:
-  
   MatchingOutput _Mout;
   std::vector<std::vector<int>> _Deltas;
   int _Phi, _Theta;
@@ -201,7 +196,7 @@ class DeltaOutput{
 };
 
 struct BTrack{
-  
+
 BTrack(): phi(0),theta(0),clctpattern(0){}
   
   Winner winner;

--- a/L1Trigger/L1TMuonEndCap/interface/Matching.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Matching.h
@@ -10,13 +10,13 @@
 
 
 MatchingOutput PhiMatching(SortingOutput Sout){
-  
+
   bool verbose = false;
   
   std::vector<ConvertedHit> Thits = Sout.Hits();
   std::vector<std::vector<Winner>> Winners = Sout.Winners();
   std::vector<int> segment (4,0);
-  int phdiff[4] = {15,15,8,8};
+  int phdiff[4] = {15,7,7,7};
   
   /////////////////////////////////////////
   //// Set Null Ph and Th outputs /////////
@@ -25,68 +25,93 @@ MatchingOutput PhiMatching(SortingOutput Sout){
   std::vector<ConvertedHit> p (4,tt);std::vector<std::vector<ConvertedHit>> pp (3,p);
   PhOutput ph_output (4,pp);
   
+  int t2 = -999;
+  std::vector<int> q2 (2,t2);
+  std::vector<std::vector<int>> qq2 (4,q2);std::vector<std::vector<std::vector<int>>> qqq2 (3,qq2);
+  ThOutput2 th_output2 (4,qqq2);
+  
+  
   std::vector<ConvertedHit> q (2,tt);
   std::vector<std::vector<ConvertedHit>> qq (4,q);std::vector<std::vector<std::vector<ConvertedHit>>> qqq (3,qq);
   ThOutput th_output (4,qqq);
+  /////////////////////////////////////////
+  /////////////////////////////////////////
   /////////////////////////////////////////
 	
   for(int z=0;z<4;z++){//zone loop
     
     for(int w=0;w<3;w++){//winner loop
-      
+			
       if(Winners[z][w].Rank()){//is there a winner present?	
 	
-	if(verbose) std::cout<<"\n\nWinner position-"<<Winners[z][w].Strip()<<". Zone = "<<z<<std::endl;			
+	if(verbose) std::cout<<"\n\nWinner position-"<<Winners[z][w].Strip()<<". Zone = "<<z<<std::endl;
+	if(verbose) std::cout<<"Number of possible hits to match = "<<Thits.size()<<"\n";			
 	
-	for(std::vector<ConvertedHit>::iterator i = Thits.begin();i != Thits.end();i++){//Possible associated hits
+	//for(std::vector<ConvertedHit>::iterator i = Thits.begin();i != Thits.end();i++){//Possible associated hits
+	for(int i = Thits.size() - 1;i > -1;i--){//Possible associated hits
+	  //for(unsigned int i=0;i<Thits.size();i++){//Possible associated hits
 	  
-	  //int id = i->Id();
+	  //int id = Thits[i].Id();
 	  
-	  if(verbose) std::cout<<"strip = "<<i->Strip()<<", keywire = "<<i->Wire()<<" and zhit-"<<i->Zhit()<<std:: endl;
+	  if(verbose) std::cout<<"station = "<<Thits[i].Station()<<", strip = "<<Thits[i].Strip()<<", keywire = "<<Thits[i].Wire()<<" and zhit-"<<Thits[i].Zhit()<<", bx = "<<Thits[i].BX()<<", phi>>5 = "<<(Thits[i].Phi()>>5)<<"\n";
 	  
 	  // Unused variable
-	  /* bool inzone = 0;///Is the converted hit in the zone we're looking at now? */
-	  /* for(std::vector<int>::iterator znc = i->ZoneContribution().begin();znc != i->ZoneContribution().end();znc++){ */
-	  /* 	if((*znc) == z) */
-	  /* 		inzone = 1;//yes */
-	  /* } */
+	  /* bool inzone = 0;///Is the converted hit in the zone we're looking at now? 
+	     for(std::vector<int>::iterator znc = Thits[i].ZoneContribution().begin();znc != Thits[i].ZoneContribution().end();znc++){ 
+	     if((*znc) == z) 
+	     inzone = 1;//yes 
+	     } */
+	  
+	  bool inBXgroup = false;
+	  
+	  switch(Winners[z][w].BXGroup()){
+	    
+	  case 1: if(Thits[i].BX() > 3 && Thits[i].BX() < 7) inBXgroup = true;break;
+	  case 2: if(Thits[i].BX() > 4 && Thits[i].BX() < 8) inBXgroup = true;break;
+	  case 3: if(Thits[i].BX() > 5 && Thits[i].BX() < 9) inBXgroup = true;break;
+	  default: inBXgroup = false;
+	    
+	  }
 	  
 	  ////////////////////////////////////////////////////////////////////////////////////////////
 	  /////////////////// Setting the matched hits based on phi //////////////////////////////////
 	  ////////////////////////////////////////////////////////////////////////////////////////////
-	  int setstation = i->Station() - 1;
-	  //bool one = ((z == 3) && (i->Station() > 1));                //Zone 3 is handled differently so we
-	  //bool two = ((z == 3) && (i->Station() == 1) && (id > 3));   //have this conditions here
+	  int setstation = Thits[i].Station() - 1;
 	  bool setphi = 0;
-	  //if(one || two)
-	  //	setstation++;
 	  
 	  if(verbose)
 	    std::cout<<"setstation = "<<setstation<<std::endl;
 	  
-	  if((fabs((Winners[z][w].Strip()) - i->Zhit()) <= phdiff[setstation]) ){//is close to winner keystrip and in same zone?
+	  //if(verbose){
+	  
+	  //	std::cout<<"Winners[z][w].Strip(): "<<Winners[z][w].Strip()<<" + 1 - Thits[i].Zhit():"<<Thits[i].Zhit()<<" = "<<(Winners[z][w].Strip() + 1) - Thits[i].Zhit()<<". Thits[i].Phi()>>5 = "<<(Thits[i].Phi() >> 5)<<"\n";
+	  //}
+	  
+	  if((fabs(Winners[z][w].Strip() - (Thits[i].Phi()>>5)) <= phdiff[setstation]) && inBXgroup /*&& inzone*/){//is close to winner keystrip and in same zone?
 	    
 	    if(ph_output[z][w][setstation].Phi() == -999){//has this already been set? no
 	      
 	      if(verbose) std::cout<<"hasn't been set"<<std::endl;
 	      
-	      ph_output[z][w][setstation] = (*i);
+	      ph_output[z][w][setstation] = (Thits[i]);
 	      
-	      if(verbose) std::cout<<"set with strip-"<<i->Strip()<<", and wire-"<<i->Wire()<<std::endl;
+	      if(verbose) std::cout<<"set with strip-"<<Thits[i].Strip()<<", and wire-"<<Thits[i].Wire()<<std::endl;
 	      setphi = true;
 	    }
 	    else{//if yes, find absolute difference between zhit of each hit and keystrip
 	      
 	      if(verbose) std::cout<<"has already been set"<<std::endl;
 	      
-	      int d1 = fabs(ph_output[z][w][setstation].Zhit() - Winners[z][w].Strip());
-	      int d2 = fabs(i->Zhit() - Winners[z][w].Strip());
+	      int d1 = fabs((ph_output[z][w][setstation].Phi()>>5) - Winners[z][w].Strip());
+	      int d2 = fabs((Thits[i].Phi()>>5) - Winners[z][w].Strip());
+	      
+	      if(verbose) std::cout<<"d1 = "<<d1<<" and d2 = "<<d2<<"\n";
 	      
 	      if(d2 < d1){//if new hit is closer then replace phi
 		
-		if(verbose) std::cout<<"this is closer strip-"<<i->Strip()<<", and wire-"<<i->Wire()<<std::endl;
+		if(verbose) std::cout<<"this is closer strip-"<<Thits[i].Strip()<<", and wire-"<<Thits[i].Wire()<<std::endl;
 		
-		ph_output[z][w][setstation] = (*i);
+		ph_output[z][w][setstation] = (Thits[i]);
 		
 		setphi = true;
 		
@@ -94,16 +119,39 @@ MatchingOutput PhiMatching(SortingOutput Sout){
 	      
 	    }
 	    
-	    
 	    /////////////////////////////////////////////////////////////////////////////////////
 	    /////////////  Setting matched theta values; Take both of two from same chamber /////
 	    /////////////////////////////////////////////////////////////////////////////////////
 	    
-	    if(setphi)//only set if phi was also set
-	      th_output[z][w][setstation][0] = (*i);
+	    //if((th_output[z][w][setstation][0].Theta() != -999) && (th_output[z][w][setstation][0].Id() == Thits[i].Id())){//if same chamber take as well
+	    //		th_output[z][w][setstation][1] = (Thits[i]);
+	    //		if(verbose) std::cout<<"in here with set th = "<<th_output[z][w][setstation][0].Theta()<<" and new th = "<<Thits[i].Theta()<<"\n";
+	    //	}
 	    
-	    if((th_output[z][w][setstation][0].Theta() != -999) && (th_output[z][w][setstation][0].Id() == i->Id()))//if same chamber take as well
-	      th_output[z][w][setstation][1] = (*i);
+	    if(setphi){//only set if phi was also set
+	      
+	      th_output2[z][w][setstation][0] = Thits[i].Theta();
+	      
+	      /*if(th_output[z][w][setstation][0].Theta() == -999){
+		th_output[z][w][setstation][0] = (Thits[i]);
+		}
+		else if((th_output[z][w][setstation][0].Theta() != -999) && (th_output[z][w][setstation][0].Id() == Thits[i].Id())){//if same chamber take as well
+		th_output[z][w][setstation][1] = (Thits[i]);
+		if(verbose) std::cout<<"in here with set th = "<<th_output[z][w][setstation][0].Theta()<<" and new th = "<<Thits[i].Theta()<<"\n";
+		}*/
+	      
+	      //if((th_output[z][w][setstation][0].Theta() != -999) && (th_output[z][w][setstation][0].Id() == Thits[i].Id())){//if same chamber take as well
+	      //	th_output[z][w][setstation][1] = (Thits[i]);
+	      //	if(verbose) std::cout<<"in here with set th = "<<th_output[z][w][setstation][0].Theta()<<" and new th = "<<Thits[i].Theta()<<"\n";
+	      //}
+	      //else{
+	      //	th_output[z][w][setstation][0] = (Thits[i]);
+	      
+	      if(Thits[i].Theta2() != -999)
+		th_output2[z][w][setstation][1] = Thits[i].Theta2();
+	      //}
+	      
+	    }
 	    
 	  }
 	}
@@ -115,6 +163,22 @@ MatchingOutput PhiMatching(SortingOutput Sout){
   
   MatchingOutput output;
   output.SetValues(th_output,ph_output,Thits,Winners,segment);
+  output.setM2(th_output2);
+  
+  return output;
+}
+
+std::vector<MatchingOutput> PhiMatching_Hold(std::vector<SortingOutput> Sout){
+  
+  MatchingOutput tmp;
+  std::vector<MatchingOutput> output (3,tmp);
+  
+  if(Sout.size() != 3)
+    std::cout<<"Incorrect BX window size for sorting output. Please check to see why.\n";
+  
+  for(int i=0;i<3;i++){
+    output[i] = PhiMatching(Sout[i]);
+  }
   
   return output;
 }

--- a/L1Trigger/L1TMuonEndCap/interface/PrimitiveConverterRPC.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PrimitiveConverterRPC.h
@@ -1,0 +1,25 @@
+// Trigger Primitive Converter for RPC hits
+//
+// Takes in raw information from the TriggerPrimitive class(part of L1TMuon software package);
+// and outputs vector of 'ConvertedHits'
+//
+
+#include <iostream>
+
+#include "L1Trigger/L1TMuonEndCap/interface/EmulatorClasses.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "L1Trigger/L1TMuonEndCap/interface/EMTFHitTools.h"
+
+class PrimitiveConverterRPC {
+ public:
+  PrimitiveConverterRPC();
+  l1t::EMTFHitExtraCollection convert(std::vector<TriggerPrimitive> TriggPrim, int SectIndex, edm::ESHandle<RPCGeometry> rpc_geom);
+  std::vector<ConvertedHit> fillConvHits(l1t::EMTFHitExtraCollection exHits);
+  bool sameRpcChamber(l1t::EMTFHitExtra hitA, l1t::EMTFHitExtra hitB);
+
+ private:
+
+};

--- a/L1Trigger/L1TMuonEndCap/interface/SortSector.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SortSector.h
@@ -1,11 +1,15 @@
 //////Takes in Pattern Output and delivers three best tracks per zone
 //////
+//////
+//////
+//////
+//////
 
 #include "L1Trigger/L1TMuonEndCap/interface/PhiMemoryImage.h"
 #include "L1Trigger/L1TMuonEndCap/interface/EmulatorClasses.h"
 
 SortingOutput  SortSect(PatternOutput Pout){
-  
+	
   ////variable declaration ///////////////////////////
   QualityOutput Detected = Pout.detected;
   Winner tmp;tmp.SetValues(0,0);
@@ -19,24 +23,87 @@ SortingOutput  SortSect(PatternOutput Pout){
     for(int zone=0;zone<4;zone++){
       
       temp[zone].SetValues(0,0);
-      for(int strip=0;strip<192;strip++){//was 128
+      /*//for(int strip=0;strip<192;strip++){//was 128*/
+      for(int strip=191;strip>-1;strip--){//was 128
+	
+	if(Detected.rank[zone][strip] > temp[zone].Rank()){temp[zone].SetValues(Detected.rank[zone][strip], strip);}
+      }
+      
+      if(temp[zone].Rank()){
+	
+	//removes rank as not to count twice/////////////////
+	Detected.rank[zone][temp[zone].Strip()] = 0;
+	Detected.layer[zone][temp[zone].Strip()] = 0;
+	Detected.straightness[zone][temp[zone].Strip()] = 0;
+	/////////////////////////////////////////////////////
+	Winners[zone][i] = temp[zone];
+	Winners[zone][i].SetBXGroup(Detected.bxgroup[zone][temp[zone].Strip()]);
+      }
+    }
+  }
+  
+  
+  /////////////////////////////////
+  // Printing for Comparison///////
+  /////////////////////////////////
+  /*
+    for(int l=0;l<4;l++){//zone loop
+			
+    for(int m=0;m<3;m++){
+    
+    if(Winners[l][m].Rank())
+    std::cout<<"Winner["<<l<<"]["<<m<<"]!-----Q:"<<Winners[l][m].Rank()<<"  S:"<<Winners[l][m].Strip()<<"\n";
+    
+    }
+    }
+  */	
+  /////////////////////////////////
+  /////////////////////////////////
+  /////////////////////////////////
+  
+  SortingOutput output;
+  
+  output.SetValues(Winners,Pout.hits);
+  
+  return output;
+  
+}
+
+SortingOutput  SortSector(PatternOutput Pout, int bxgroup){
+  
+  ////variable declaration ///////////////////////////
+  QualityOutput Detected = Pout.detected;
+  Winner tmp;tmp.SetValues(0,0);
+  std::vector<Winner> tmmp (3,tmp);
+  std::vector<std::vector<Winner>> Winners (4,tmmp);
+  ////////////////////////////////////////////////////
+  
+  for(int i=0;i<3;i++){//loop to get three best
+    
+    Winner temp[4];
+    for(int zone=0;zone<4;zone++){
+			
+      temp[zone].SetValues(0,0);
+      /*//for(int strip=0;strip<192;strip++){//was 128*/
+      for(int strip=191;strip>-1;strip--){//was 128
 	
 	if(Detected.rank[zone][strip] > temp[zone].Rank()){temp[zone].SetValues(Detected.rank[zone][strip], strip);}
 	
       }
       
       if(temp[zone].Rank()){
-
+				
 	//removes rank as not to count twice/////////////////
 	Detected.rank[zone][temp[zone].Strip()] = 0;
 	Detected.layer[zone][temp[zone].Strip()] = 0;
 	Detected.straightness[zone][temp[zone].Strip()] = 0;
 	/////////////////////////////////////////////////////
-	
 	Winners[zone][i] = temp[zone];
+	Winners[zone][i].SetBXGroup(bxgroup);
       }
     }
   }
+  
   
   /////////////////////////////////
   // Printing for Comparison///////
@@ -63,3 +130,21 @@ SortingOutput  SortSect(PatternOutput Pout){
   return output;
   
 }
+
+
+std::vector<SortingOutput> SortSect_Hold(std::vector<PatternOutput> Pout){
+  
+  SortingOutput tmp;
+  std::vector<SortingOutput> output (3,tmp);
+  
+  if(Pout.size() != 3)
+    std::cout<<"Incorrect number of BX windows! Please check to see why.\n";
+  
+  for(int i=0;i<3;i++){
+    //std::cout<<"start sorting on BX group "<<i<<"\n";
+    output[i] = SortSector(Pout[i], i+1);
+  }
+  
+  return output;
+}
+

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -35,18 +35,25 @@
 #include "L1Trigger/L1TMuonEndCap/interface/EMTFHitTools.h"
 
 using namespace L1TMuon;
+class RPCGeometry;
+// Pointers to the current geometry records
+unsigned long long _geom_cache_id;
+edm::ESHandle<RPCGeometry> _geom_rpc;
 
 
 L1TMuonEndCapTrackProducer::L1TMuonEndCapTrackProducer(const PSet& p) {
 
   inputTokenCSC = consumes<CSCCorrelatedLCTDigiCollection>(p.getParameter<edm::InputTag>("CSCInput"));
   bxShiftCSC = p.getUntrackedParameter<int>("CSCInputBxShift", 0);
+  inputTokenRPC = consumes<RPCDigiCollection>(p.getParameter<edm::InputTag>("RPCInput"));
   
-  produces<l1t::RegionalMuonCandBxCollection >("EMTF");
-  produces< l1t::EMTFTrackCollection >("EMTF");
-  produces< l1t::EMTFHitCollection >("EMTF");  
-  produces< l1t::EMTFTrackExtraCollection >("EMTF");
-  produces< l1t::EMTFHitExtraCollection >("EMTF");  
+  produces<l1t::RegionalMuonCandBxCollection >("");
+  produces< l1t::EMTFTrackCollection >("");
+  produces< l1t::EMTFHitCollection >("");  
+  produces< l1t::EMTFTrackExtraCollection >("");
+  produces< l1t::EMTFHitExtraCollection >("CSC");  
+  produces< l1t::EMTFHitExtraCollection >("RPC");  
+
 }
 
 
@@ -63,11 +70,20 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   std::auto_ptr<l1t::EMTFHitCollection> OutHits (new l1t::EMTFHitCollection);
   std::auto_ptr<l1t::EMTFTrackExtraCollection> OutputTracks (new l1t::EMTFTrackExtraCollection);
   std::auto_ptr<l1t::EMTFHitExtraCollection> OutputHits (new l1t::EMTFHitExtraCollection);
+  std::auto_ptr<l1t::EMTFHitExtraCollection> OutputHitsRPC (new l1t::EMTFHitExtraCollection);
 
   std::vector<BTrack> PTracks[NUM_SECTORS];
+  std::vector<BTrack> PTracks_BX[NUM_SECTORS][3];
 
   std::vector<TriggerPrimitive> tester;
+  std::vector<TriggerPrimitive> tester_rpc;
   //std::vector<InternalTrack> FoundTracks;
+
+  // Get the RPC geometry
+  const MuonGeometryRecord& geom = es.get<MuonGeometryRecord>();
+  unsigned long long geomid = geom.cacheIdentifier();
+  if( _geom_cache_id != geomid )
+    geom.get(_geom_rpc);
 
   
   //////////////////////////////////////////////
@@ -76,8 +92,12 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   
   edm::Handle<CSCCorrelatedLCTDigiCollection> MDC;
   ev.getByToken(inputTokenCSC, MDC);
-  std::vector<TriggerPrimitive> out;
+
+  edm::Handle<RPCDigiCollection> RDC;
+  ev.getByToken(inputTokenRPC, RDC);
   
+  std::vector<TriggerPrimitive> out;
+
   auto chamber = MDC->begin();
   auto chend  = MDC->end();
   for( ; chamber != chend; ++chamber ) {
@@ -101,6 +121,16 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
       }
     }
   }
+
+  auto rchamber = RDC->begin();
+  auto rchend  = RDC->end();
+  for( ; rchamber != rchend; ++rchamber) {
+    auto rdigi = (*rchamber).second.first;
+    auto rdend = (*rchamber).second.second;
+    for( ; rdigi != rdend; ++rdigi) {
+      out.push_back(TriggerPrimitive( (*rchamber).first, rdigi->strip(), 0, rdigi->bx())); // Layer unset.  How to access? - AWB 03.06.16 
+    }
+  }
   
   
   //////////////////////////////////////////////
@@ -117,17 +147,61 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   
   for( ; tp != tpend; ++tp ) {
     if(tp->subsystem() == 1)
-      {
-	//TriggerPrimitiveRef tpref(out,tp - out.cbegin());
-	
-	tester.push_back(*tp);
-	
-	//std::cout<<"\ntrigger prim found station:"<<tp->detId<CSCDetId>().station()<<std::endl;
-      }
+      // tester.push_back(*tp);
+    if(tp->subsystem() == 2)
+      tester_rpc.push_back(*tp);
      }
   //}
+  
+  // Create extra converted hits for chambers with two LCTs (ambiguous strip/wire pairing)
+  for(unsigned int i1=0;i1<out.size();i1++){
+    tester.push_back(out[i1]);
+    
+    for(unsigned int i2=i1+1;i2<out.size();i2++){
+      
+      if ( out[i1].detId<CSCDetId>().station() == out[i2].detId<CSCDetId>().station() &&
+	   out[i1].detId<CSCDetId>().endcap() == out[i2].detId<CSCDetId>().endcap() &&
+	   out[i1].detId<CSCDetId>().triggerSector() == out[i2].detId<CSCDetId>().triggerSector() &&
+	   out[i1].detId<CSCDetId>().ring() == out[i2].detId<CSCDetId>().ring() &&
+	   out[i1].detId<CSCDetId>().chamber() == out[i2].detId<CSCDetId>().chamber() &&
+	   out[i1].getBX() == out[i2].getBX() && out[i1].Id() == out[i2].Id() &&
+	   out[i1].getStrip() != out[i2].getStrip() && out[i1].getWire() != out[i2].getWire() ) {
+	
+	TriggerPrimitive NewWire1(out[i1],out[i2]);
+	TriggerPrimitive NewWire2(out[i2],out[i1]);
+	tester.push_back(NewWire1);
+	tester.push_back(NewWire2);
+      } 
+    } // End loop: for(unsigned int i2=i1+1;i2<out.size();i2++)
+  } // End loop: for(unsigned int i1=0;i1<out.size();i1++)
+
+  
+  uint nHits = OutputHits->size();
+  for (uint iHit = 0; iHit < nHits; iHit++) {
+    for (uint jHit = iHit+1; jHit < nHits; jHit++) {
+      if ( OutputHits->at(iHit).Chamber() != OutputHits->at(jHit).Chamber() ) continue;
+      // if ( OutputHits->at(iHit).Ring() != OutputHits->at(jHit).Ring() ) continue;
+      if ( OutputHits->at(iHit).Sector() != OutputHits->at(jHit).Sector() ) continue;
+      if ( OutputHits->at(iHit).Station() != OutputHits->at(jHit).Station() ) continue;
+      if ( OutputHits->at(iHit).Endcap() != OutputHits->at(jHit).Endcap() ) continue;
+      if ( OutputHits->at(iHit).BX() != OutputHits->at(jHit).BX() ) continue;
+      if ( OutputHits->at(iHit).Neighbor() != OutputHits->at(jHit).Neighbor() ) continue;
+      if ( OutputHits->at(iHit).Strip() == OutputHits->at(jHit).Strip() ) continue;
+      if ( OutputHits->at(iHit).Wire() == OutputHits->at(jHit).Wire() ) continue;
+      
+      l1t::EMTFHitExtra new_hit_1 = OutputHits->at(iHit).Clone();
+      l1t::EMTFHitExtra new_hit_2 = OutputHits->at(jHit).Clone();
+      new_hit_1.set_wire( OutputHits->at(jHit).Wire() );
+      new_hit_2.set_wire( OutputHits->at(iHit).Wire() );
+      new_hit_1.SetCSCLCTDigi( new_hit_1.CreateCSCCorrelatedLCTDigi() );
+      new_hit_2.SetCSCLCTDigi( new_hit_2.CreateCSCCorrelatedLCTDigi() );
+      OutputHits->push_back( new_hit_1 );
+      OutputHits->push_back( new_hit_2 );
+    }
+  }
+
   std::vector<ConvertedHit> CHits[NUM_SECTORS];
-  MatchingOutput MO[NUM_SECTORS];
+  // MatchingOutput MO[NUM_SECTORS];
   
   for(int SectIndex=0;SectIndex<NUM_SECTORS;SectIndex++){//perform TF on all 12 sectors
 
@@ -137,6 +211,11 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     
     std::vector<ConvertedHit> ConvHits = primConv_.convert(tester,SectIndex);
     CHits[SectIndex] = ConvHits;
+
+    l1t::EMTFHitExtraCollection tmp_hits_rpc = primConvRPC_.convert(tester_rpc, SectIndex, _geom_rpc); 
+    for (uint iHit = 0; iHit < tmp_hits_rpc.size(); iHit++) 
+      OutputHitsRPC->push_back( tmp_hits_rpc.at(iHit) );
+    std::vector<ConvertedHit> ConvHitsRPC = primConvRPC_.fillConvHits(tmp_hits_rpc);
     
     // Fill OutputHits with ConvertedHit information
     for (uint iCHit = 0; iCHit < ConvHits.size(); iCHit++) {
@@ -155,9 +234,9 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	  // isMatched = true;
 	  OutputHits->at(iHit).set_neighbor    ( ConvHits.at(iCHit).IsNeighbor());
 	  OutputHits->at(iHit).set_sector_index( ConvHits.at(iCHit).SectorIndex() );
-	  OutputHits->at(iHit).set_zone_hit    ( ConvHits.at(iCHit).Zhit()   );
+	  OutputHits->at(iHit).set_phi_zone    ( ConvHits.at(iCHit).Zhit()   );
 	  OutputHits->at(iHit).set_phi_hit     ( ConvHits.at(iCHit).Ph_hit() );
-	  OutputHits->at(iHit).set_phi_z_val   ( ConvHits.at(iCHit).Phzvl()  );
+	  OutputHits->at(iHit).set_zone        ( ConvHits.at(iCHit).Phzvl()  );
 	  OutputHits->at(iHit).set_phi_loc_int ( ConvHits.at(iCHit).Phi()    );
 	  OutputHits->at(iHit).set_theta_int   ( ConvHits.at(iCHit).Theta()  );
 	  
@@ -173,7 +252,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	  OutHits->push_back( OutputHits->at(iHit).CreateEMTFHit() );
 	}
       } // End loop: for (uint iHit = 0; iHit < OutputHits->size(); iHit++)
-      
+
       // if (isMatched == false) {
       //   std::cout << "***********************************************" << std::endl;
       //   std::cout << "Unmatched ConvHit in event " << ev.id().event() << ", SectIndex " << SectIndex << std::endl;
@@ -231,8 +310,9 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     ///////////////////////////////  same hits. This is where the BX analysis ends; Only 1 list of found patterns is given to the next module.
     
     std::vector<PatternOutput> Pout = Patterns(Zout);
+    std::vector<PatternOutput> Pout_Hold = Pout;
     
-    PatternOutput Test = DeleteDuplicatePatterns(Pout);
+    // PatternOutput Test = DeleteDuplicatePatterns(Pout);
     
     //PrintQuality(Test.detected);
     
@@ -242,7 +322,8 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     ///////Finding 3 Best Pattern//
     ///////////////////////////////
     
-    SortingOutput Sout = SortSect(Test);
+    // SortingOutput Sout = SortSect(Test);
+    std::vector<SortingOutput> Sout_Hold = SortSect_Hold(Pout_Hold);
     
     
     //////////////////////////////////
@@ -250,15 +331,16 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     ////// to segment inputs ///////// and matches the associated full precision triggerprimitives to the detected pattern.
     //////////////////////////////////
     
-    MatchingOutput Mout = PhiMatching(Sout);
-    MO[SectIndex] = Mout;
+    // MatchingOutput Mout = PhiMatching(Sout);
+    std::vector<MatchingOutput> Mout_Hold = PhiMatching_Hold(Sout_Hold);
     
     /////////////////////////////////
     //////// Calculate delta //////// Once we have matched the hits we calculate the delta phi and theta between all
     ////////    ph and th    //////// stations present.
     /////////////////////////////////
     
-    std::vector<std::vector<DeltaOutput>> Dout = CalcDeltas(Mout);////
+    // std::vector<std::vector<DeltaOutput>> Dout = CalcDeltas(Mout);////
+    std::vector<std::vector<std::vector<DeltaOutput>>> Dout_Hold = CalcDeltas_Hold(Mout_Hold);
     
     
     /////////////////////////////////
@@ -266,27 +348,59 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     ////// Best 3 tracks/sector /////  Here ghost busting is done to delete tracks which are comprised of the same associated stubs.
     /////////////////////////////////
     
-    std::vector<BTrack> Bout = BestTracks(Dout);
-    PTracks[SectIndex] = Bout;
-    
+    // std::vector<BTrack> Bout = BestTracks(Dout);
+    // PTracks[SectIndex] = Bout;
+
+    std::vector<std::vector<BTrack>> Bout_Hold = BestTracks_Hold(Dout_Hold);
+    for(int bx=0;bx<3;bx++)
+      PTracks_BX[SectIndex][bx] = Bout_Hold[bx];
+
     
   } // End loop: for(int SectIndex=0;SectIndex<NUM_SECTORS;SectIndex++)
   
   
-  ///////////////////////////////////////
-  /// Collect Muons from all sectors ////
-  ///////////////////////////////////////
+  /////////////////////////////////////// and BX windows and cancel across BXs even though not yet in FW
+  /// Collect Muons from all sectors //// to see if sub percent kind of effect. If more then I can try to
+  /////////////////////////////////////// FW exactly but it will take a lot more thinking. - mrcarver 24.06.16
   
   std::vector<BTrack> PTemp[NUM_SECTORS];
-  std::vector<BTrack> AllTracks;
+  std::vector<BTrack> AllTracks, AllTracks_PreCancel;
   for (int i=0; i<NUM_SECTORS; i++) PTemp[i] = PTracks[i];
   
-  for(int j=0;j<36;j++){
-    
-    if(PTemp[j/3][j%3].phi)//no track
-      AllTracks.push_back(PTemp[j/3][j%3]);
+  for(int bx=0;bx<3;bx++){
+    for(int j=0;j<36;j++){
+      
+      // if(PTemp[j/3][j%3].phi)//no track
+	// AllTracks.push_back(PTemp[j/3][j%3]);
 
+      if(PTracks_BX[j/3][bx][j%3].phi) {//no track
+	AllTracks_PreCancel.push_back(PTracks_BX[j/3][bx][j%3]);
+	if (PTracks_BX[j/3][bx][j%3].theta == 0)
+	  std::cout << "PTrack_BX theta = 0" << std::endl;
+      }
+      
+    }
   }
+
+  // Cancel out duplicate tracks
+  for (unsigned int i1=0; i1 < AllTracks_PreCancel.size(); i1++) {
+    bool dup = false;
+    int ebx = 20, sindex = -1;
+    for (std::vector<ConvertedHit>::iterator A = AllTracks_PreCancel[i1].AHits.begin(); A != AllTracks_PreCancel[i1].AHits.end(); A++) {
+      if (A->TP().getCSCData().bx < ebx) ebx = A->TP().getCSCData().bx;
+      sindex = A->SectorIndex();
+    }
+    for (unsigned int i2 = i1+1; i2 < AllTracks_PreCancel.size(); i2++) {
+      int ebx2 = 20, sindex2 = -1;
+      for (std::vector<ConvertedHit>::iterator A2 = AllTracks_PreCancel[i1].AHits.begin(); A2 != AllTracks_PreCancel[i1].AHits.end(); A2++) {
+	if (A2->TP().getCSCData().bx < ebx2) ebx2 = A2->TP().getCSCData().bx;
+	sindex2 = A2->SectorIndex();
+      }
+      if (ebx == ebx2 && AllTracks_PreCancel[i1].theta == AllTracks_PreCancel[i2].theta && AllTracks_PreCancel[i1].phi == AllTracks_PreCancel[i2].phi && AllTracks_PreCancel[i1].winner.Rank() == AllTracks_PreCancel[i2].winner.Rank() && sindex == sindex2 && sindex != -1 && sindex2 != -1) dup = true;
+    }
+    if (!dup) AllTracks.push_back(AllTracks_PreCancel[i1]);
+  }
+
   
   ///////////////////////////////////
   /// Make Internal track if ////////
@@ -294,7 +408,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   /////////////////////////////////// 
   
   std::vector<l1t::RegionalMuonCand> tester1;
-  std::vector<std::pair<int,l1t::RegionalMuonCand>> holder;
+  std::vector<std::pair<int,l1t::RegionalMuonCand>> holder, holder2;
   
   for(unsigned int fbest=0;fbest<AllTracks.size();fbest++){
     
@@ -307,6 +421,8 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
       tempTrack.rank = AllTracks[fbest].winner.Rank();
       tempTrack.deltas = AllTracks[fbest].deltas;
       std::vector<int> ps, ts;
+
+      if (tempTrack.theta == 0) std::cout << "Track has theta 0" << std::endl;
       
       l1t::EMTFTrackExtra thisTrack;
       thisTrack.set_phi_loc_int ( AllTracks[fbest].phi           );
@@ -322,34 +438,69 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
       if (tempRank & 4)
 	tempStraightness |= 1;
       thisTrack.set_straightness ( tempStraightness );
-      
+
+      int mode = 0;
+      if(tempTrack.rank & 32)
+	mode |= 8;
+      if(tempTrack.rank & 8)
+	mode |= 4;
+      if(tempTrack.rank & 2)
+	mode |= 2;
+      if(tempTrack.rank & 1)
+	mode |= 1;
       
       int sector = -1;
-      bool ME13 = false;
+      // bool ME13 = false;
       int me1address = 0, me2address = 0, CombAddress = 0, mode_uncorr = 0;
       int ebx = 20, sebx = 20;
       int phis[4] = {-99,-99,-99,-99};
       
+      int cHits_in_station[4] = {0,0,0,0};
+      int eHits_in_station[4] = {0,0,0,0};
       for(std::vector<ConvertedHit>::iterator A = AllTracks[fbest].AHits.begin();A != AllTracks[fbest].AHits.end();A++){
 	
 	if(A->Phi() != -999){
+	  cHits_in_station[A->TP().detId<CSCDetId>().station() - 1] += 1;
 	  
 	  l1t::EMTFHitExtra thisHit;
 	  // thisHit.ImportCSCDetId( A->TP().detId<CSCDetId>() );
-	  
+
 	  for (uint iHit = 0; iHit < OutputHits->size(); iHit++) {
-	    if ( A->TP().detId<CSCDetId>().station() == OutputHits->at(iHit).Station() &&
-		 A->TP().getCSCData().cscID          == OutputHits->at(iHit).CSC_ID()  &&
-		 A->Wire()                           == OutputHits->at(iHit).Wire()    &&
-		 A->Strip()                          == OutputHits->at(iHit).Strip()   &&
-		 A->TP().getCSCData().bx - 6         == OutputHits->at(iHit).BX()      &&
-		 A->IsNeighbor()                     == OutputHits->at(iHit).Neighbor() ) {
+	    if ( (A->TP().detId<CSCDetId>().endcap() == 1) == (OutputHits->at(iHit).Endcap() == 1) &&
+		 A->TP().detId<CSCDetId>().station()       == OutputHits->at(iHit).Station() &&
+		 A->TP().detId<CSCDetId>().triggerSector() == OutputHits->at(iHit).Sector()  &&
+		 A->TP().getCSCData().cscID                == OutputHits->at(iHit).CSC_ID()  &&
+		 A->Wire()                                 == OutputHits->at(iHit).Wire()    &&
+		 A->Strip()                                == OutputHits->at(iHit).Strip()   &&
+		 A->TP().getCSCData().bx - 6               == OutputHits->at(iHit).BX()      &&
+		 A->IsNeighbor()                           == OutputHits->at(iHit).Neighbor() ) {
 	      thisHit = OutputHits->at(iHit);
-	      thisTrack.push_HitExtraIndex(iHit);
-	      thisTrack.push_HitExtra(thisHit); // Done before theta windows are applied ... how can we do it after? - AWB 29.04.16
+	      // Hacky fix because ConvertedHits are not removed when theta windows are applied - AWB 30.06.16
+	      if ( (A->TP().detId<CSCDetId>().station() == 1 && (mode & 8)) ||
+		   (A->TP().detId<CSCDetId>().station() == 2 && (mode & 4)) || 
+		   (A->TP().detId<CSCDetId>().station() == 3 && (mode & 2)) || 
+		   (A->TP().detId<CSCDetId>().station() == 4 && (mode & 1)) ) {
+		eHits_in_station[OutputHits->at(iHit).Station() - 1] += 1;
+		thisTrack.push_HitExtraIndex(iHit);
+		thisTrack.push_HitExtra(thisHit); 
+	      }
 	      break;
 	    }
 	  }
+	  
+	  if ( thisHit.Station() < 0 ) {
+	    std::cout << "!@#$ Converted hit with station " << A->TP().detId<CSCDetId>().station() << ", CSC_ID " << A->TP().getCSCData().cscID
+		      << ", sector index " << A->SectorIndex() << ", subsector " << A->Sub()
+		      << ", wire " << A->Wire() << ", strip " << A->Strip() << ", BX " << A->TP().getCSCData().bx - 6 
+		      << ", neighbor " << A->IsNeighbor() << " has no match" << std::endl;
+	    for (uint iHit = 0; iHit < OutputHits->size(); iHit++) 
+	      std::cout << "!@#$ Option " << iHit+1 << " with endcap " << OutputHits->at(iHit).Endcap() 
+			<< ", station " << OutputHits->at(iHit).Station() << ", CSC_ID " << OutputHits->at(iHit).CSC_ID() 
+			<< ", ring " << OutputHits->at(iHit).Ring() << ", chamber " << OutputHits->at(iHit).Chamber()
+			<< ", wire " << OutputHits->at(iHit).Wire() << ", strip " << OutputHits->at(iHit).Strip()
+			<< ", BX " << OutputHits->at(iHit).BX() << ", neighbor " << OutputHits->at(iHit).Neighbor() << std::endl;
+	  }
+	  
 	  thisTrack.set_endcap       ( thisHit.Endcap() );
 	  thisTrack.set_sector_index ( thisHit.Sector_index() );
 	  thisTrack.set_sector       ( l1t::calc_sector_from_index( thisHit.Sector_index() ) );
@@ -386,8 +537,8 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	  }
 	  
 	  
-	  if(A->TP().detId<CSCDetId>().station() == 1 && A->TP().detId<CSCDetId>().ring() == 3)
-	    ME13 = true;
+	  // if(A->TP().detId<CSCDetId>().station() == 1 && A->TP().detId<CSCDetId>().ring() == 3)
+	  //   ME13 = true;
 	  
 	  if(station == 1 && id > 3 && id < 7){
 	    
@@ -416,18 +567,25 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	
       }
       
-      int mode = 0;
-      if(tempTrack.rank & 32)
-	mode |= 8;
-      if(tempTrack.rank & 8)
-	mode |= 4;
-      if(tempTrack.rank & 2)
-	mode |= 2;
-      if(tempTrack.rank & 1)
-	mode |= 1;
+      // if ( ( mode == 15 && (cHits_in_station[0] != 1 || cHits_in_station[1] != 1 || cHits_in_station[2] != 1 || cHits_in_station[3] != 1) ) ||
+      // 	   ( mode == 14 && (cHits_in_station[0] != 1 || cHits_in_station[1] != 1 || cHits_in_station[2] != 1 || cHits_in_station[3] != 0) ) ||
+      // 	   ( mode == 13 && (cHits_in_station[0] != 1 || cHits_in_station[1] != 1 || cHits_in_station[2] != 0 || cHits_in_station[3] != 1) ) ||
+      // 	   ( mode == 11 && (cHits_in_station[0] != 1 || cHits_in_station[1] != 0 || cHits_in_station[2] != 1 || cHits_in_station[3] != 1) ) ||
+      // 	   ( mode ==  7 && (cHits_in_station[0] != 0 || cHits_in_station[1] != 1 || cHits_in_station[2] != 1 || cHits_in_station[3] != 1) ) )
+      // 	std::cout << "Mode " << mode << " track has " << cHits_in_station[0] << " / " << cHits_in_station[1] << " / "
+      // 		  << cHits_in_station[2] << " / " << cHits_in_station[3] << " converted hits in stations 1 / 2 / 3 / 4" << std::endl;
+
+      if ( ( mode == 15 && (eHits_in_station[0] != 1 || eHits_in_station[1] != 1 || eHits_in_station[2] != 1 || eHits_in_station[3] != 1) ) ||
+	   ( mode == 14 && (eHits_in_station[0] != 1 || eHits_in_station[1] != 1 || eHits_in_station[2] != 1 || eHits_in_station[3] != 0) ) ||
+	   ( mode == 13 && (eHits_in_station[0] != 1 || eHits_in_station[1] != 1 || eHits_in_station[2] != 0 || eHits_in_station[3] != 1) ) ||
+	   ( mode == 11 && (eHits_in_station[0] != 1 || eHits_in_station[1] != 0 || eHits_in_station[2] != 1 || eHits_in_station[3] != 1) ) ||
+	   ( mode ==  7 && (eHits_in_station[0] != 0 || eHits_in_station[1] != 1 || eHits_in_station[2] != 1 || eHits_in_station[3] != 1) ) )
+	std::cout << "Mode " << mode << " track has " << eHits_in_station[0] << " / " << eHits_in_station[1] << " / "
+		  << eHits_in_station[2] << " / " << eHits_in_station[3] << " EMTF hits in stations 1 / 2 / 3 / 4" << std::endl;
       
       tempTrack.phis = ps;
       tempTrack.thetas = ts;
+      tempTrack.deltas = AllTracks[fbest].deltas;
       
       // // Before Mulhearn cleanup, May 11
       // unsigned long xmlpt_address = 0;
@@ -484,26 +642,25 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
       // Actual setting in firmware - AWB 12.04.16
       std::pair<int,l1t::RegionalMuonCand> outPair(ebx,outCand);
       
-      if(!ME13 && fabs(eta) > 1.1) {
-	// // Extra debugging output - AWB 29.03.16
-	// std::cout << "Input: eBX = " << ebx << ", seBX = " << sebx << ", pt = " << xmlpt*1.4 
-	// 	    << ", phi = " << AllTracks[fbest].phi << ", eta = " << eta 
-	// 	    << ", theta = " << AllTracks[fbest].theta << ", sign = " << 1 
-	// 	    << ", quality = " << mode << ", trackaddress = " << 1 
-	// 	    << ", sector = " << sector << std::endl;
-	// std::cout << "Output: BX = " << ebx << ", hwPt = " << outCand.hwPt() << ", hwPhi = " << outCand.hwPhi() 
-	// 	    << ", hwEta = " << outCand.hwEta() << ", hwSign = " << outCand.hwSign() 
-	// 	    << ", hwQual = " << outCand.hwQual() << ", link = " << outCand.link()
-	// 	    << ", processor = " << outCand.processor() 
-	// 	    << ", trackFinderType = " << outCand.trackFinderType() << std::endl;
-	holder.push_back(outPair);
-	thisTrack.set_isGMT( 1 );
-      }
+      // // Extra debugging output - AWB 29.03.16
+      // std::cout << "Input: eBX = " << ebx << ", seBX = " << sebx << ", pt = " << xmlpt*1.4 
+      // 	    << ", phi = " << AllTracks[fbest].phi << ", eta = " << eta 
+      // 	    << ", theta = " << AllTracks[fbest].theta << ", sign = " << 1 
+      // 	    << ", quality = " << mode << ", trackaddress = " << 1 
+      // 	    << ", sector = " << sector << std::endl;
+      // std::cout << "Output: BX = " << ebx << ", hwPt = " << outCand.hwPt() << ", hwPhi = " << outCand.hwPhi() 
+      // 	    << ", hwEta = " << outCand.hwEta() << ", hwSign = " << outCand.hwSign() 
+      // 	    << ", hwQual = " << outCand.hwQual() << ", link = " << outCand.link()
+      // 	    << ", processor = " << outCand.processor() 
+      // 	    << ", trackFinderType = " << outCand.trackFinderType() << std::endl;
+      holder.push_back(outPair);
+      thisTrack.set_isGMT( 1 );
+
       OutputTracks->push_back( thisTrack );
       OutTracks->push_back( thisTrack.CreateEMTFTrack() );
     }
   }
-  
+
   OutputCands->setBXRange(-2,2);
   
   for(int sect=0;sect<12;sect++){
@@ -523,11 +680,12 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   }
   
   //ev.put( FoundTracks, "DataITC");
-  ev.put( OutputCands, "EMTF");
-  ev.put( OutHits, "EMTF");      // EMTFHitCollection
-  ev.put( OutTracks, "EMTF");    // EMTFTrackCollection
-  ev.put( OutputHits, "EMTF");   // EMTFHitExtraCollection
-  ev.put( OutputTracks, "EMTF"); // EMTFTrackExtraCollection
+  ev.put( OutputCands, "");
+  ev.put( OutHits, "");      // EMTFHitCollection
+  ev.put( OutTracks, "");    // EMTFTrackCollection
+  ev.put( OutputHits, "CSC");   // EMTFHitExtraCollection
+  ev.put( OutputHitsRPC, "RPC");   // EMTFHitExtraCollection
+  ev.put( OutputTracks, ""); // EMTFTrackExtraCollection
   //std::cout<<"End Upgraded Track Finder Prducer:::::::::::::::::::::::::::\n:::::::::::::::::::::::::::::::::::::::::::::::::\n\n";
   
 }//analyzer

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -680,7 +680,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   }
   
   //ev.put( FoundTracks, "DataITC");
-  ev.put( OutputCands, "");
+  ev.put( OutputCands, "EMTF");
   ev.put( OutHits, "");      // EMTFHitCollection
   ev.put( OutTracks, "");    // EMTFTrackCollection
   ev.put( OutputHits, "CSC");   // EMTFHitExtraCollection

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -47,7 +47,7 @@ L1TMuonEndCapTrackProducer::L1TMuonEndCapTrackProducer(const PSet& p) {
   bxShiftCSC = p.getUntrackedParameter<int>("CSCInputBxShift", 0);
   inputTokenRPC = consumes<RPCDigiCollection>(p.getParameter<edm::InputTag>("RPCInput"));
   
-  produces<l1t::RegionalMuonCandBxCollection >("");
+  produces<l1t::RegionalMuonCandBxCollection >("EMTF");
   produces< l1t::EMTFTrackCollection >("");
   produces< l1t::EMTFHitCollection >("");  
   produces< l1t::EMTFTrackExtraCollection >("");

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
@@ -38,7 +38,16 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 
 #include "L1Trigger/L1TMuonEndCap/interface/PrimitiveConverter.h"
+#include "L1Trigger/L1TMuonEndCap/interface/PrimitiveConverterRPC.h"
 #include "L1Trigger/L1TMuonEndCap/interface/PtAssignment.h"
+
+// For RPCs
+#include "DataFormats/RPCDigi/interface/RPCDigi.h"
+#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
 
 typedef edm::ParameterSet PSet;
 
@@ -81,7 +90,9 @@ public:
   
   edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> inputTokenCSC;
   int bxShiftCSC = 0;
+  edm::EDGetTokenT<RPCDigiCollection> inputTokenRPC;
   PrimitiveConverter primConv_;
+  PrimitiveConverterRPC primConvRPC_;
   l1t::EmtfPtAssignment ptAssignment_;
   
 };

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -5,10 +5,14 @@ import FWCore.ParameterSet.Config as cms
 ##   * 'simCscTriggerPrimitiveDigis','MPCSORTED' : simulated trigger primitives (LCTs) from re-emulating CSC digis
 ##   * 'csctfDigis' : real trigger primitives as received by CSCTF (legacy trigger)
 ##   * 'emtfStage2Digis' : real trigger primitives as received by EMTF, unpacked in EventFilter/L1TRawToDigi/
+## Two options for RPCInput
+##   * 'simMuonRPCDigis' : simulated trigger primitives (LCTs) from emulating RPCs
+##   * 'muonRPCDigis' : real trigger primitives from RPCs, but not unpacked by EMTF
 ## Two options for CSCInputBxShift
 ##   * -2 when using simCscTriggerPrimitiveDigis re-emulated from data
 ##   *  0 in all other cases (MC, csctfDigis or emtfStage2Digis input)
 simEmtfDigis = cms.EDProducer("L1TMuonEndCapTrackProducer",
                               CSCInput = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
-                              CSCInputBxShift = cms.untracked.int32(0)
+                              RPCInput = cms.InputTag('simMuonRPCDigis'),
+                              CSCInputBxShift = cms.untracked.int32(0),
                               )

--- a/L1Trigger/L1TMuonEndCap/src/EMTFHitTools.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFHitTools.cc
@@ -42,6 +42,28 @@ namespace l1t {
   		     (ring == 4) ? 1 : ring, chamber ); // Not sure if this is correct, or what "layer" does. - AWB 27.04.16
   }
 
+  void EMTFHit::ImportRPCDetId( const RPCDetId& _detId) {
+
+    EMTFHit::SetRPCDetId ( _detId ); 
+    
+    EMTFHit::set_endcap    ( _detId.region()    ); // 0 for barrel, +/-1 for +/- endcap
+    EMTFHit::set_station   ( _detId.station()   ); // Same as in CSCs (?)
+    EMTFHit::set_sector    ( _detId.sector()    ); // Same as in CSCs (?)  
+    EMTFHit::set_subsector ( _detId.subsector() ); // Same as in CSCs (?)
+    EMTFHit::set_ring      ( _detId.ring()      ); // Ring number in endcap (from 1 to 3, but only 2 and 3 exist currently)
+    EMTFHit::set_roll      ( _detId.roll()      ); // AKA eta "partition" or "segment": subdivision of ring into 3 parts, noted "C-B-A" in-to-out
+
+    EMTFHit::set_is_CSC_hit ( 0 );
+    EMTFHit::set_is_RPC_hit ( 1 );
+
+  } // End EMTFHit::ImportCSCDetId
+
+  RPCDetId EMTFHit::CreateRPCDetId() {
+    
+    return RPCDetId( endcap, ring, station, sector, rpc_layer, subsector, roll );
+    
+  }
+
   // Based on L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
   // TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid, const CSCCorrelatedLCTDigi& digi)
   // This is what gets filled when "getCSCData()" is called in
@@ -80,6 +102,19 @@ namespace l1t {
   				 bx + 6, 0, 0, sync_err, csc_ID );  
     // Unsure of how to fill "trknmb" or "bx0" - for now filling with 1 and 0. - AWB 27.04.16
     // Appear to be unused in the emulator code. mpclink = 0 (after bx) indicates unsorted.
+  }
+
+  void EMTFHit::ImportRPCDigi( const RPCDigi& _digi ) {
+
+    EMTFHit::SetRPCDigi    ( _digi );
+    EMTFHit::set_strip_hi  ( _digi.strip()  );
+    EMTFHit::set_strip_low ( _digi.strip()  );
+    EMTFHit::set_bx        ( _digi.bx() - 6 );  // Correct offset?
+
+  }
+
+  RPCDigi EMTFHit::CreateRPCDigi() {
+    return RPCDigi( strip, bx + 6 );
   }
 
   void EMTFHit::ImportME( const emtf::ME _ME) {

--- a/L1Trigger/L1TMuonEndCap/src/PatternRecognition.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PatternRecognition.cc
@@ -46,10 +46,10 @@ PatternOutput DetectPatterns(ZonesOutput Eout){
 	  patt[y].BitShift(b-15);  //////Can try and fix later before uploading to CMSSW.
 	}   
 	else if((b-15) < 127){	
-	  patt[y].BitShift(63);patt[y].BitShift(b-78);	
+	  patt[y].BitShift(63);patt[y].BitShift(1);patt[y].BitShift(b-79);
 	}	
 	else{	
-	  patt[y].BitShift(63);patt[y].BitShift(63);patt[y].BitShift(b-141);  //////
+	  patt[y].BitShift(63);patt[y].BitShift(1);patt[y].BitShift(63);patt[y].BitShift(1);patt[y].BitShift(b-143);  //////
 	} 			
 	
 	for(int yy=0;yy != 12;yy++){//loop over 8 long integers of each pattern
@@ -98,9 +98,6 @@ PatternOutput DetectPatterns(ZonesOutput Eout){
     for(int k=0;k<192;k++){//was 128
       
       int qr = ranka_t[zone][k-1], ql = ranka_t[zone][k+1], qc = ranka_t[zone][k];
-      
-      //if(qc && verbose)
-      //	std::cout<<"\n"<<k<<":qc = "<<qc<<" straight: "<<stra[zone][k]<<"  lya: "<<lya[zone][k]<<std::endl; 
       
       if(k==0){qr=0;}
       if(k==191){ql=0;}//was 127

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConverter.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConverter.cc
@@ -121,7 +121,7 @@ std::vector<ConvertedHit> PrimitiveConverter::convert(std::vector<TriggerPrimiti
     if(ring == 4){Id += 9;}
     
     //if(endcap == 1 && sector == 1)//
-    if( (SectIndex ==  (endcap - 1)*6 + sector - 1 )  || IsNeighbor )
+    if( (SectIndex ==  (endcap - 1)*6 + sector - 1 ) || IsNeighbor )
       {
 	
 	//if(verbose){
@@ -491,6 +491,7 @@ std::vector<ConvertedHit> PrimitiveConverter::convert(std::vector<TriggerPrimiti
 	  in = 1;
 	
 	Hit.SetValues(fph,th,ph_hit,phzvl,station,sub,Id,quality,pattern,wire,strip,BX);
+	Hit.AddTheta(th);
 	Hit.SetTP(C3);
 	Hit.SetZhit(zhit);
 	Hit.SetZoneContribution(zonecontribution);

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConverterRPC.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConverterRPC.cc
@@ -1,0 +1,134 @@
+//// Trigger Primitive Converter for RPC hits
+////
+//// Takes in raw information from the TriggerPrimitive class
+//// (part of L1TMuon software package) and outputs vector of 'ConvertedHits'
+////
+
+#include "L1Trigger/L1TMuonEndCap/interface/PrimitiveConverterRPC.h"
+
+PrimitiveConverterRPC::PrimitiveConverterRPC() {
+}
+
+l1t::EMTFHitExtraCollection 
+PrimitiveConverterRPC::convert( std::vector<TriggerPrimitive> TrigPrim, 
+				int SectIndex, edm::ESHandle<RPCGeometry> rpc_geom ) {
+
+  // bool verbose = true;
+  bool verbose = false;
+
+
+  if (verbose) std::cout << "\n========== RPC Primitive Converter ==========" << std::endl;
+
+  l1t::EMTFHitExtraCollection tmpHits;
+  for (std::vector<TriggerPrimitive>::iterator iter = TrigPrim.begin(); iter != TrigPrim.end(); iter++) {
+
+    /// Get all the input variables
+    TriggerPrimitive prim = *iter; // Eventually would like to deprecate TriggerPrimitive entirely - AWB 03.06.16
+    RPCDetId detID = prim.detId<RPCDetId>();
+    RPCDigi digi = RPCDigi( prim.getRPCData().strip, prim.getRPCData().bx );
+
+    // Only include RPC hits from correct sector in endcap
+    if ( abs(detID.region()) != 1 ) continue;
+    if ( SectIndex != (detID.sector() - 1) + (detID.region() == -1)*6 ) continue;
+
+    l1t::EMTFHitExtra thisHit;
+    thisHit.ImportRPCDetId( detID );
+    thisHit.ImportRPCDigi( digi );
+    thisHit.set_sector_index( SectIndex );
+    thisHit.set_layer( prim.getRPCData().layer ); // In RE1/2 there are two layers of chambers: 1 is inner (front) and 2 is outer (rear)
+    
+    tmpHits.push_back( thisHit );
+  }
+
+  l1t::EMTFHitExtraCollection clustHits;
+  for (uint iHit = 0; iHit < tmpHits.size(); iHit++) {
+    l1t::EMTFHitExtra hit1 = tmpHits.at(iHit);
+
+    // Skip hit if it is already in a cluster
+    bool hit_in_cluster = false;
+    for (uint jHit = 0; jHit < clustHits.size(); jHit++) {
+      l1t::EMTFHitExtra clustHit = clustHits.at(jHit);
+      if ( sameRpcChamber(hit1, clustHit) && hit1.Strip_hi() <= clustHit.Strip_hi() && 
+	   hit1.Strip_low() >= clustHit.Strip_low() ) hit_in_cluster = true;
+    }
+    if (hit_in_cluster) continue;
+
+    // Cluster adjascent strip hits.  Phi of cluster corresponds to central strip.
+    // Does this clustering catch all the hits in large clusters? - AWB 03.06.16
+    int prevHi = -999, prevLow = -999;
+    while (hit1.Strip_hi() != prevHi || hit1.Strip_low() != prevLow) {
+      prevHi = hit1.Strip_hi();
+      prevLow = hit1.Strip_low();
+
+      for (uint jHit = 0; jHit < tmpHits.size(); jHit++) {
+	if (iHit == jHit) continue;
+	l1t::EMTFHitExtra hit2 = tmpHits.at(jHit);
+
+	if (not sameRpcChamber(hit1, hit2)) continue;
+	if (hit2.Strip_hi()  == hit1.Strip_hi()  + 1) hit1.set_strip_hi ( hit2.Strip_hi()  );
+	if (hit2.Strip_low() == hit1.Strip_low() - 1) hit1.set_strip_low( hit2.Strip_low() );
+      }
+    }
+    
+    // Get phi and eta
+    std::unique_ptr<const RPCRoll> roll(rpc_geom->roll( hit1.RPC_DetId() ));
+    const LocalPoint lpHi = roll->centreOfStrip(hit1.Strip_hi());
+    const GlobalPoint gpHi = roll->toGlobal(lpHi);
+    const LocalPoint lpLow = roll->centreOfStrip(hit1.Strip_low());
+    const GlobalPoint gpLow = roll->toGlobal(lpLow);
+    roll.release();
+
+    float glob_phi_hi  = gpHi.phi();  // Averaging global point phi's directly does weird things,
+    float glob_phi_low = gpLow.phi(); // e.g. 2*pi/3 + 2*pi/3 = 4*pi/3 = -2*pi/3, so avg. = -pi/3, not 2*pi/3
+    float glob_phi = (glob_phi_hi + glob_phi_low) / 2.0;
+    float glob_eta = (gpHi.eta() + gpLow.eta()) / 2.0;
+
+    if (verbose) std::cout << "RPC cluster phi = " << glob_phi << " (" << glob_phi_hi << ", " << glob_phi_low 
+			   << "), eta = " << glob_eta << " (" << gpHi.eta() << ", " << gpLow.eta() << ")" << std::endl;
+
+    hit1.set_phi_glob_rad( glob_phi );
+    hit1.set_phi_glob_deg( glob_phi*180/Geom::pi() );
+    hit1.set_eta( glob_eta );
+    clustHits.push_back( hit1 );
+
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // Need to set phi_loc_int, theta_int, phi_hit, zone, csc_ID, quality,
+    // pattern, wire, strip, phi_zone, and zone_contribution
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    
+  } // End loop over iHit
+
+  return clustHits;
+
+} // End PrimitiveConverterRPC::convert
+
+std::vector<ConvertedHit>
+PrimitiveConverterRPC::fillConvHits(l1t::EMTFHitExtraCollection exHits) {
+
+  std::vector<ConvertedHit> ConvHits;
+  for (uint iHit = 0; iHit < exHits.size(); iHit++) {
+    l1t::EMTFHitExtra exHit = exHits.at(iHit);
+
+    std::vector<int> zone_contribution;
+
+    ConvertedHit ConvHit;
+    ConvHit.SetValues(exHit.Phi_loc_int(), exHit.Theta_int(), exHit.Phi_hit(), exHit.Zone(), 
+		      exHit.Station(), exHit.Subsector(), exHit.CSC_ID(), exHit.Quality(), 
+		      exHit.Pattern(), exHit.Wire(), exHit.Strip(), exHit.BX() + 6);
+    ConvHit.SetTP( TriggerPrimitive( exHit.RPC_DetId(), exHit.Strip(), exHit.Layer(), exHit.BX() + 6 ) );
+    ConvHit.SetZhit( exHit.Phi_zone() );
+    ConvHit.SetZoneContribution(zone_contribution);
+    ConvHit.SetSectorIndex( exHit.Sector_index() );
+    ConvHit.SetNeighbor(0);
+    ConvHits.push_back(ConvHit);
+  }
+  return ConvHits;
+}
+
+bool PrimitiveConverterRPC::sameRpcChamber( l1t::EMTFHitExtra hitA, l1t::EMTFHitExtra hitB ) {
+
+  if ( hitA.Endcap() == hitB.Endcap() && hitA.Station() == hitB.Station() && hitA.Ring() == hitB.Ring() &&
+       hitA.Roll() == hitB.Roll() && hitA.Sector() == hitB.Sector() && hitA.Subsector() == hitB.Subsector() &&
+       hitA.Layer() == hitB.Layer() ) return true;
+  else return false;
+}

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -926,6 +926,11 @@ unsigned long EmtfPtAssignment::calculateAddress( L1TMuon::InternalTrack track, 
     //////////////////////////////////////////////////
     //// Calculate Delta Phi and Eta Combinations ////
     //////////////////////////////////////////////////
+
+    for(int d=0;d<6;d++){
+      dphi[d] = track.deltas[0][d];
+      deta[d] = track.deltas[1][d];
+    }
 	
     if(phis[0] > 0 && phis[1] > 0){ // 1 - 2
       dphi[0] = phis[1] - phis[0];
@@ -1520,16 +1525,11 @@ unsigned long EmtfPtAssignment::calculateAddress( L1TMuon::InternalTrack track, 
 	if (dPhi12<0) dPhi12Sign = -1;
 	if (dPhi23<0) dPhi23Sign = -1;
 	if (dPhi34<0) dPhi34Sign = -1;
-      
-	if (dPhi12Sign==-1 && dPhi23Sign==-1 && dPhi34Sign==-1)
-	  { dPhi12Sign=1;dPhi23Sign=1;dPhi34Sign=1;}
-	else if (dPhi12Sign==-1 && dPhi23Sign==1 && dPhi34Sign==1)
-	  { dPhi12Sign=1;dPhi23Sign=-1;dPhi34Sign=-1;}
-	else if (dPhi12Sign==-1 && dPhi23Sign==-1 && dPhi34Sign==1)
-	  { dPhi12Sign=1;dPhi23Sign=1;dPhi34Sign=-1;}
-	else if (dPhi12Sign==-1 && dPhi23Sign==1 && dPhi34Sign==-1)
-	  { dPhi12Sign=1;dPhi23Sign=-1;dPhi34Sign=1;}
-      
+
+	dPhi23Sign *= dPhi12Sign;
+	dPhi34Sign *= dPhi12Sign;
+	dPhi12Sign = 1;
+
 	// Make Pt LUT Address
 	int dPhi12_ = getNLBdPhiBin(dPhi12, 7, 512);
 	int dPhi23_ = getNLBdPhiBin(dPhi23, 5, 256);
@@ -1539,7 +1539,7 @@ unsigned long EmtfPtAssignment::calculateAddress( L1TMuon::InternalTrack track, 
 	int FR1_ = FR1;
 	int eta_ = getEtaInt(TrackEta, 5);
 	int Mode_ = mode_inv;
-      
+
 	Address += ( dPhi12_ & ((1<<7)-1)) << 0;
 	Address += ( dPhi23_ & ((1<<5)-1)) << (0+7);
 	Address += ( dPhi34_ & ((1<<6)-1)) << (0+7+5);


### PR DESCRIPTION
Down to 2% of unpacked tracks missing in re-emulation.  Still issues with discrepant mode and pT assignment, but better than before.  Also process RPC trigger primitives.
