### PR TITLE
Revert default caloParams emulator config

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -33,9 +33,10 @@ if eras.stage1L1Trigger.isChosen() and not eras.stage2L1Trigger.isChosen():
 #
 if eras.stage2L1Trigger.isChosen():
     print "L1TCalorimeter Conditions configured for Stage-2 (2016) trigger. "
+    
     # from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis    
-     from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v2_2_cfi import *
-    #from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_0_inconsistent_cfi import *
-    #
+    
+    from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v2_2_cfi import *    
+    
     # What about CaloConfig?  Related:  How will we switch PP/HH?
     #

--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -34,8 +34,8 @@ if eras.stage1L1Trigger.isChosen() and not eras.stage2L1Trigger.isChosen():
 if eras.stage2L1Trigger.isChosen():
     print "L1TCalorimeter Conditions configured for Stage-2 (2016) trigger. "
     # from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis    
-    # from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v2_2_cfi import *
-    from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_0_inconsistent_cfi import *
+     from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v2_2_cfi import *
+    #from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_0_inconsistent_cfi import *
     #
     # What about CaloConfig?  Related:  How will we switch PP/HH?
     #


### PR DESCRIPTION
- Reverted default calo trig emu config from v3_0_inconsistent to v2_2 (current online config)
