### PR TITLE
Eparadas memleak caused by compiler

### DIFF
--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/BMTFUnpackerInputs.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/BMTFUnpackerInputs.cc
@@ -34,7 +34,7 @@ namespace l1t
 				return (value == 0);
 		}
 
-		bool unpacking(const Block& block, UnpackerCollections *coll, std::map<int, qualityHits>& linkAndQual_, const bool& isNewFw)
+		bool unpacking(const Block& block, UnpackerCollections *coll, qualityHits& linkAndQual_, const bool& isNewFw)
 		{
 
 			unsigned int ownLinks[] = {4,5,12,13,20,21,22,23,28,29};
@@ -140,10 +140,14 @@ namespace l1t
 				}
 				else
 				{
+					/*
 					qualityHits temp;
 					temp.linkNo = blockId/2;
 					std::copy(&etaHits[0][0], &etaHits[0][0]+3*7,&temp.hits[0][0]);
 					linkAndQual_[blockId/2] = temp;	
+					*/
+					linkAndQual_.linkNo = blockId/2;
+                                        std::copy(&etaHits[0][0], &etaHits[0][0]+3*7,&linkAndQual_.hits[0][0]);
 				}
 
 			}//ibx

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/BMTFUnpackerInputs.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/BMTFUnpackerInputs.cc
@@ -134,7 +134,7 @@ namespace l1t
 					for (int i = 0; i < 3; i++)
 					{
 						if (zeroFlag[i])
-							theData.push_back(L1MuDTChambThDigi( ibx, wheel, sector, i+1, etaHits[i], linkAndQual_[blockId/2 - 1].hits[i]) );
+							theData.push_back(L1MuDTChambThDigi( ibx, wheel, sector, i+1, etaHits[i], linkAndQual_.hits[i]) );
 					}
 
 				}

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/BMTFUnpackerInputs.h
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/BMTFUnpackerInputs.h
@@ -15,7 +15,8 @@ namespace l1t{
 			public:
 				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
 			private:
-				std::map<int, qualityHits> linkAndQual_;
+				qualityHits linkAndQual_;
+				//std::map<int, qualityHits> linkAndQual_;
 		};
 
 		class BMTFUnpackerInputsNewQual : public Unpacker
@@ -23,7 +24,8 @@ namespace l1t{
 			public:
 				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
 			private:
-				std::map<int, qualityHits> linkAndQual_;
+				qualityHits linkAndQual_;
+				//std::map<int, qualityHits> linkAndQual_;
 		};
 
 	}


### PR DESCRIPTION
@mulhearn @rekovic this is a fix concerning the memory leak that is related to the compiler version.
Test with igprof shown no memory leak and attached can be found the file that came out from the igprof.

[igreport_total.txt](https://github.com/cms-l1t-offline/cmssw/files/550932/igreport_total.txt)
Thanks in advance for merging it.
