### PR TITLE
Add ETT EM to latest MP unpacker

### DIFF
--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010033.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010033.cc
@@ -66,7 +66,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        ethf.setType(l1t::EtSum::kTotalEtHF);
-       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
        break;
      case 121: // 60
        ethf.setType(l1t::EtSum::kTotalEtxHF);
@@ -78,7 +78,7 @@ namespace stage2 {
        break;
      case 125: // 62
        ethf.setType(l1t::EtSum::kTotalEtHF);
-       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
        break;
      case 131: // 65
        ethf.setType(l1t::EtSum::kTotalEtxHF);
@@ -102,11 +102,12 @@ namespace stage2 {
      raw_data = block.payload()[fet + 1];
 
      l1t::EtSum etNoHF = l1t::EtSum();
+     l1t::EtSum etEm = l1t::EtSum();
 
      switch(block.header().getID()){
      case 123: // 61
        etNoHF.setType(l1t::EtSum::kTotalEt);
-       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
        break;
      case 121: // 60
        etNoHF.setType(l1t::EtSum::kTotalEtx);
@@ -118,7 +119,7 @@ namespace stage2 {
        break;
      case 125: // 62
        etNoHF.setType(l1t::EtSum::kTotalEt);
-       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
        break;
      case 131: // 65
        etNoHF.setType(l1t::EtSum::kTotalEtx);
@@ -135,6 +136,15 @@ namespace stage2 {
      LogDebug("L1T") << "ET/METx/METy (no HF): pT " << etNoHF.hwPt();
 
      res2_->push_back(0,etNoHF);
+   
+     
+     // ET EM
+     if(block.header().getID()==123 || block.header().getID()==125){
+       etEm.setType(l1t::EtSum::kTotalEtEm);
+       etEm.setHwPt( static_cast<int32_t>( uint32_t( ( raw_data >> 16 ) & 0xFFFF) << 16 ) >> 16 );
+       res2_->push_back(0,etEm);
+
+     }
 
 
      // HT / MHT(x)/ MHT (y) with HF


### PR DESCRIPTION
The total ET in ECAL was only being unpacked from demux output, not from MP output. Now added to MP_Unpacker_0x10010033.cc.