### PR TITLE
Small fix to MPUnpacker, add HT saturation check in emulator

### DIFF
--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/EtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/EtSumUnpacker.cc
@@ -93,7 +93,7 @@ namespace stage2 {
        raw_data = block.payload()[iFrame+1];
 
        l1t::EtSum ht = l1t::EtSum();
-    
+
        ht.setHwPt(raw_data & 0xFFF);
        ht.setType(l1t::EtSum::kTotalHt);       
        ht.setP4( l1t::CaloTools::p4Demux(&ht) );

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010010.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010010.cc
@@ -66,7 +66,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        ethf.setType(l1t::EtSum::kTotalEtHF);
-       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        ethf.setType(l1t::EtSum::kTotalEtxHF);
@@ -78,7 +78,7 @@ namespace stage2 {
        break;
      case 125: // 62
        ethf.setType(l1t::EtSum::kTotalEtHF);
-       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        ethf.setType(l1t::EtSum::kTotalEtxHF);
@@ -106,7 +106,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        etNoHF.setType(l1t::EtSum::kTotalEt);
-       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        etNoHF.setType(l1t::EtSum::kTotalEtx);
@@ -118,7 +118,7 @@ namespace stage2 {
        break;
      case 125: // 62
        etNoHF.setType(l1t::EtSum::kTotalEt);
-       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        etNoHF.setType(l1t::EtSum::kTotalEtx);
@@ -146,7 +146,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        hthf.setType(l1t::EtSum::kTotalHtHF);
-       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        hthf.setType(l1t::EtSum::kTotalHtxHF);
@@ -158,7 +158,7 @@ namespace stage2 {
        break;
      case 125: // 62
        hthf.setType(l1t::EtSum::kTotalHtHF);
-       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        hthf.setType(l1t::EtSum::kTotalHtxHF);
@@ -186,7 +186,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        htNoHF.setType(l1t::EtSum::kTotalHt);
-       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        htNoHF.setType(l1t::EtSum::kTotalHtx);
@@ -198,7 +198,7 @@ namespace stage2 {
        break;
      case 125: // 62
        htNoHF.setType(l1t::EtSum::kTotalHt);
-       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        htNoHF.setType(l1t::EtSum::kTotalHtx);

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010033.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010033.cc
@@ -66,7 +66,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        ethf.setType(l1t::EtSum::kTotalEtHF);
-       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        ethf.setType(l1t::EtSum::kTotalEtxHF);
@@ -78,7 +78,7 @@ namespace stage2 {
        break;
      case 125: // 62
        ethf.setType(l1t::EtSum::kTotalEtHF);
-       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        ethf.setType(l1t::EtSum::kTotalEtxHF);
@@ -107,7 +107,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        etNoHF.setType(l1t::EtSum::kTotalEt);
-       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        etNoHF.setType(l1t::EtSum::kTotalEtx);
@@ -119,7 +119,7 @@ namespace stage2 {
        break;
      case 125: // 62
        etNoHF.setType(l1t::EtSum::kTotalEt);
-       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF) << 16 ) >> 16 );
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        etNoHF.setType(l1t::EtSum::kTotalEtx);
@@ -141,7 +141,7 @@ namespace stage2 {
      // ET EM
      if(block.header().getID()==123 || block.header().getID()==125){
        etEm.setType(l1t::EtSum::kTotalEtEm);
-       etEm.setHwPt( static_cast<int32_t>( uint32_t( ( raw_data >> 16 ) & 0xFFFF) << 16 ) >> 16 );
+       etEm.setHwPt( static_cast<int32_t>( uint32_t( ( raw_data >> 16 ) & 0xFFFF ) );
        res2_->push_back(0,etEm);
 
      }
@@ -156,7 +156,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        hthf.setType(l1t::EtSum::kTotalHtHF);
-       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        hthf.setType(l1t::EtSum::kTotalHtxHF);
@@ -168,7 +168,7 @@ namespace stage2 {
        break;
      case 125: // 62
        hthf.setType(l1t::EtSum::kTotalHtHF);
-       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        hthf.setType(l1t::EtSum::kTotalHtxHF);
@@ -196,7 +196,7 @@ namespace stage2 {
      switch(block.header().getID()){
      case 123: // 61
        htNoHF.setType(l1t::EtSum::kTotalHt);
-       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 121: // 60
        htNoHF.setType(l1t::EtSum::kTotalHtx);
@@ -208,7 +208,7 @@ namespace stage2 {
        break;
      case 125: // 62
        htNoHF.setType(l1t::EtSum::kTotalHt);
-       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFF)) );
        break;
      case 131: // 65
        htNoHF.setType(l1t::EtSum::kTotalHtx);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -168,5 +168,5 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   outputSums.push_back(etSumMissingEtHF);
   outputSums.push_back(htSumMissingHtHF);
   outputSums.push_back(etSumTowCount);
-  
+
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetSumAlgorithmFirmwareImp1.cc
@@ -92,6 +92,9 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
 
     }
 
+    if(ht>65535) ht=65535; // ht saturation
+    
+
     math::XYZTLorentzVector p4;
     
     l1t::EtSum htSumHt(p4,l1t::EtSum::EtSumType::kTotalHt,ht,0,0,0);
@@ -109,7 +112,7 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
     htsums.push_back(htSumHtHF);
     htsums.push_back(htSumHxHF);
     htsums.push_back(htSumHyHF);
-    
+
   }
 }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2MainProcessorImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2MainProcessorImp1.cc
@@ -94,7 +94,7 @@ void l1t::Stage2MainProcessorFirmwareImp1::processEvent(const std::vector<l1t::C
   m_demuxTauAlgo->processEvent( mpTaus, taus );
   m_demuxJetAlgo->processEvent( mpJets, jets );
   m_demuxSumsAlgo->processEvent( mpSums, etSums );
-  
+
 }
 
 


### PR DESCRIPTION
MPUnpacker wasn't handling HT saturation properly. Fixed. We now see that HT saturation is dealt with correctly in MP firmware (i.e. if(ht > 65535) ht = 65535). HT saturation occurs in the demux firmware, when the HT from both eta sides is added. Small bug fix also to emulator to check saturation in emu MP output.