### PR TITLE
Add support for reading out of uGMT muon sets 2-6 to muon unpacker.

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
@@ -10,11 +10,28 @@ namespace l1t {
          event_.put(std::move(regionalMuonCandsOMTF_), "OMTF");
          event_.put(std::move(regionalMuonCandsEMTF_), "EMTF");
          event_.put(std::move(muons_), "Muon");
+         event_.put(std::move(muonsSet2_), "MuonSet2");
+         event_.put(std::move(muonsSet3_), "MuonSet3");
+         event_.put(std::move(muonsSet4_), "MuonSet4");
+         event_.put(std::move(muonsSet5_), "MuonSet5");
+         event_.put(std::move(muonsSet6_), "MuonSet6");
          event_.put(std::move(imdMuonsBMTF_), "imdMuonsBMTF");
          event_.put(std::move(imdMuonsEMTFNeg_), "imdMuonsEMTFNeg");
          event_.put(std::move(imdMuonsEMTFPos_), "imdMuonsEMTFPos");
          event_.put(std::move(imdMuonsOMTFNeg_), "imdMuonsOMTFNeg");
          event_.put(std::move(imdMuonsOMTFPos_), "imdMuonsOMTFPos");
+      }
+
+      MuonBxCollection*
+      GMTCollections::getMuons(const unsigned int set)
+      {
+         if (set == 1) return muons_.get();
+         else if (set == 2) return muonsSet2_.get();
+         else if (set == 3) return muonsSet3_.get();
+         else if (set == 4) return muonsSet4_.get();
+         else if (set == 5) return muonsSet5_.get();
+         else if (set == 6) return muonsSet6_.get();
+         return muons_.get();
       }
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
@@ -17,6 +17,11 @@ namespace l1t {
                regionalMuonCandsOMTF_(new RegionalMuonCandBxCollection()),
                regionalMuonCandsEMTF_(new RegionalMuonCandBxCollection()),
                muons_(new MuonBxCollection()),
+               muonsSet2_(new MuonBxCollection()),
+               muonsSet3_(new MuonBxCollection()),
+               muonsSet4_(new MuonBxCollection()),
+               muonsSet5_(new MuonBxCollection()),
+               muonsSet6_(new MuonBxCollection()),
                imdMuonsBMTF_(new MuonBxCollection()),
                imdMuonsEMTFNeg_(new MuonBxCollection()),
                imdMuonsEMTFPos_(new MuonBxCollection()),
@@ -28,7 +33,7 @@ namespace l1t {
             inline RegionalMuonCandBxCollection* getRegionalMuonCandsBMTF() { return regionalMuonCandsBMTF_.get(); };
             inline RegionalMuonCandBxCollection* getRegionalMuonCandsOMTF() { return regionalMuonCandsOMTF_.get(); };
             inline RegionalMuonCandBxCollection* getRegionalMuonCandsEMTF() { return regionalMuonCandsEMTF_.get(); };
-            inline MuonBxCollection* getMuons() { return muons_.get(); };
+            MuonBxCollection* getMuons(const unsigned int set);
             inline MuonBxCollection* getImdMuonsBMTF() { return imdMuonsBMTF_.get(); };
             inline MuonBxCollection* getImdMuonsEMTFNeg() { return imdMuonsEMTFNeg_.get(); };
             inline MuonBxCollection* getImdMuonsEMTFPos() { return imdMuonsEMTFPos_.get(); };
@@ -40,6 +45,11 @@ namespace l1t {
             std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsOMTF_;
             std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsEMTF_;
             std::unique_ptr<MuonBxCollection> muons_;
+            std::unique_ptr<MuonBxCollection> muonsSet2_;
+            std::unique_ptr<MuonBxCollection> muonsSet3_;
+            std::unique_ptr<MuonBxCollection> muonsSet4_;
+            std::unique_ptr<MuonBxCollection> muonsSet5_;
+            std::unique_ptr<MuonBxCollection> muonsSet6_;
             std::unique_ptr<MuonBxCollection> imdMuonsBMTF_;
             std::unique_ptr<MuonBxCollection> imdMuonsEMTFNeg_;
             std::unique_ptr<MuonBxCollection> imdMuonsEMTFPos_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -52,6 +52,11 @@ namespace l1t {
          prod.produces<RegionalMuonCandBxCollection>("OMTF");
          prod.produces<RegionalMuonCandBxCollection>("EMTF");
          prod.produces<MuonBxCollection>("Muon");
+         prod.produces<MuonBxCollection>("MuonSet2");
+         prod.produces<MuonBxCollection>("MuonSet3");
+         prod.produces<MuonBxCollection>("MuonSet4");
+         prod.produces<MuonBxCollection>("MuonSet5");
+         prod.produces<MuonBxCollection>("MuonSet6");
          prod.produces<MuonBxCollection>("imdMuonsBMTF");
          prod.produces<MuonBxCollection>("imdMuonsEMTFNeg");
          prod.produces<MuonBxCollection>("imdMuonsEMTFPos");
@@ -71,18 +76,56 @@ namespace l1t {
          UnpackerMap res;
 
          auto gmt_in_unp = UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker");
-         auto gmt_out_unp  = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto gmt_out_unp1 = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto gmt_out_unp2 = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto gmt_out_unp3 = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto gmt_out_unp4 = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto gmt_out_unp5 = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto gmt_out_unp6 = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
          auto gmt_imd_unp = UnpackerFactory::get()->make("stage2::IntermediateMuonUnpacker");
 
-         gmt_out_unp->setAlgoVersion(fw);
-         gmt_out_unp->setFedNumber(fed);
+         gmt_out_unp1->setAlgoVersion(fw);
+         gmt_out_unp1->setFedNumber(fed);
+         gmt_out_unp2->setAlgoVersion(fw);
+         gmt_out_unp2->setFedNumber(fed);
+         gmt_out_unp2->setMuonSet(2);
+         gmt_out_unp3->setAlgoVersion(fw);
+         gmt_out_unp3->setFedNumber(fed);
+         gmt_out_unp3->setMuonSet(3);
+         gmt_out_unp4->setAlgoVersion(fw);
+         gmt_out_unp4->setFedNumber(fed);
+         gmt_out_unp4->setMuonSet(4);
+         gmt_out_unp5->setAlgoVersion(fw);
+         gmt_out_unp5->setFedNumber(fed);
+         gmt_out_unp5->setMuonSet(5);
+         gmt_out_unp6->setAlgoVersion(fw);
+         gmt_out_unp6->setFedNumber(fed);
+         gmt_out_unp6->setMuonSet(6);
 
          // input muons
          for (int iLink = 72; iLink < 144; iLink += 2)
             res[iLink] = gmt_in_unp;
+
          // output muons
+         // 1st set
          for (int oLink = 1; oLink < 9; oLink += 2)
-            res[oLink] = gmt_out_unp;
+            res[oLink] = gmt_out_unp1;
+         // 2nd set
+         for (int oLink = 9; oLink < 17; oLink += 2)
+            res[oLink] = gmt_out_unp2;
+         // 3rd set
+         for (int oLink = 17; oLink < 25; oLink += 2)
+            res[oLink] = gmt_out_unp3;
+         // 4th set
+         for (int oLink = 25; oLink < 33; oLink += 2)
+            res[oLink] = gmt_out_unp4;
+         // 5th set
+         for (int oLink = 33; oLink < 41; oLink += 2)
+            res[oLink] = gmt_out_unp5;
+         // 6th set
+         for (int oLink = 41; oLink < 49; oLink += 2)
+            res[oLink] = gmt_out_unp6;
+
          // internal muons
          for (int oLink = 49; oLink < 63; oLink += 2)
             res[oLink] = gmt_imd_unp;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
@@ -29,7 +29,7 @@ namespace l1t {
 
             virtual ~GTCollections();
             
-	    inline MuonBxCollection* getMuons() override { return muons_.get(); };
+	    inline MuonBxCollection* getMuons(const unsigned int set) override { return muons_.get(); };
 	    inline EGammaBxCollection* getEGammas() override { return egammas_.get(); };
             inline EtSumBxCollection* getEtSums() override { return etsums_.get(); };
             inline JetBxCollection* getJets() override { return jets_.get(); };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
@@ -17,7 +17,7 @@ namespace l1t {
            UnpackerCollections(e) { };
 	 virtual ~L1TObjectCollections() ;
 
-         virtual MuonBxCollection* getMuons() { return  0;}
+         virtual MuonBxCollection* getMuons(const unsigned int set) { return  0;}
 	 virtual EGammaBxCollection* getEGammas() { return 0;} //= 0;
 	 virtual EtSumBxCollection* getEtSums() { return 0;}
 	 virtual JetBxCollection* getJets() {return 0; }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -9,7 +9,7 @@
 
 namespace l1t {
    namespace stage2 {
-      MuonUnpacker::MuonUnpacker() : algoVersion_(0)
+      MuonUnpacker::MuonUnpacker() : algoVersion_(0), muonSet_(1)
       {
       }
 
@@ -29,7 +29,7 @@ namespace l1t {
          //lastBX = 0;
          //LogDebug("L1T") << "BX override. Set first BX = lastBX = 0.";
 
-         auto res = static_cast<L1TObjectCollections*>(coll)->getMuons();
+         auto res = static_cast<L1TObjectCollections*>(coll)->getMuons(muonSet_);
          res->setBXRange(firstBX, lastBX);
 
          LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
@@ -73,16 +73,28 @@ namespace l1t {
         return fed_;
       }
 
+      unsigned int
+      MuonUnpacker::getMuonSet()
+      {
+        return muonSet_;
+      }
+
       void
-      MuonUnpacker::setAlgoVersion(unsigned int version)
+      MuonUnpacker::setAlgoVersion(const unsigned int version)
       {
         algoVersion_ = version;
       }
 
       void
-      MuonUnpacker::setFedNumber(int fed)
+      MuonUnpacker::setFedNumber(const int fed)
       {
         fed_ = fed;
+      }
+
+      void
+      MuonUnpacker::setMuonSet(const unsigned int set)
+      {
+        muonSet_ = set;
       }
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -14,12 +14,15 @@ namespace l1t {
 
             unsigned int getAlgoVersion();
             int getFedNumber();
+            unsigned int getMuonSet();
 
-            void setAlgoVersion(unsigned int version);
-            void setFedNumber(int fed);
+            void setAlgoVersion(const unsigned int version);
+            void setFedNumber(const int fed);
+            void setMuonSet(const unsigned int set);
          private:
             unsigned int algoVersion_;
             int fed_;
+            unsigned int muonSet_;
 
       };
    }


### PR DESCRIPTION
The uGMT sends 6 identical copies of its output muons to the 6 uGT boards.
This PR adds support for the sets 2-6 to the unpacker, which puts those muons in 5 additional L1T::Muon collections named MuonSet2 - MuonSet6.

The plan is to read out the additional muon sets for validation events only and compare them to the primary set to check that all uGT boards get the same muons.