### PR TITLE
U gt emul overlap removal

### DIFF
--- a/CondFormats/L1TObjects/interface/L1GtDefinitions.h
+++ b/CondFormats/L1TObjects/interface/L1GtDefinitions.h
@@ -96,6 +96,7 @@ std::string l1GtPsbQuadEnumToString(const L1GtPsbQuad&);
 /// TypeHfRingEtSums : HfRingEtSums
 /// TypeBptx: BPTX (logical result only; definition in BPTX system)
 /// TypeExternal: external conditions (logical result only; definition in L1 GT external systems)
+/// Type2CorrWithOverlapRemoval: three particles, first two with spatial correlations among them, third used for removal if overlap
 enum L1GtConditionType {
     TypeNull,
     Type1s,
@@ -113,7 +114,8 @@ enum L1GtConditionType {
     TypeHfBitCounts,
     TypeHfRingEtSums,
     TypeBptx,
-    TypeExternal
+    TypeExternal,
+    Type2corWithOverlapRemoval
 };
 
 struct L1GtConditionTypeStringToEnum {
@@ -136,7 +138,8 @@ enum L1GtConditionCategory {
     CondHfBitCounts,
     CondHfRingEtSums,
     CondBptx,
-    CondExternal
+    CondExternal,
+    CondCorrelationWithOverlapRemoval
 };
 
 struct L1GtConditionCategoryStringToEnum {

--- a/L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h
+++ b/L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h
@@ -1,0 +1,149 @@
+#ifndef L1Trigger_L1TGlobal_CorrWithOverlapRemovalCondition_h
+#define L1Trigger_L1TGlobal_CorrWithOverlapRemovalCondition_h
+
+/**
+ * \class CorrWithOverlapRemovalCondition
+ * 
+ * 
+ * Description: evaluation of a correlation with overlap removal condition.
+ * 
+ * Implementation:
+ *    <TODO: enter implementation details>
+ *   
+ * \author: Vladimir Rekovic
+ *
+ * 
+ *
+ */
+
+// system include files
+#include <iosfwd>
+#include <string>
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+#include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
+
+// forward declarations
+class GlobalCondition;
+class CorrelationWithOverlapRemovalTemplate;
+
+namespace l1t {
+
+class L1Candidate;
+
+class GlobalBoard;
+
+// class declaration
+class CorrWithOverlapRemovalCondition : public ConditionEvaluation
+{
+
+public:
+
+    /// constructors
+    ///     default
+    CorrWithOverlapRemovalCondition();
+
+    ///     from base template condition (from event setup usually)
+    CorrWithOverlapRemovalCondition(const GlobalCondition*,
+                  const GlobalCondition*,
+		  const GlobalCondition*, 
+		  const GlobalCondition*, 
+                  const GlobalBoard*
+
+            );
+
+    // copy constructor
+    CorrWithOverlapRemovalCondition(const CorrWithOverlapRemovalCondition&);
+
+    // destructor
+    virtual ~CorrWithOverlapRemovalCondition();
+
+    // assign operator
+    CorrWithOverlapRemovalCondition& operator=(const CorrWithOverlapRemovalCondition&);
+
+public:
+
+    /// the core function to check if the condition matches
+    const bool evaluateCondition(const int bxEval) const;
+
+    /// print condition
+     void print(std::ostream& myCout) const;
+
+public:
+
+    ///   get / set the pointer to a Condition
+    inline const CorrelationWithOverlapRemovalTemplate* gtCorrelationWithOverlapRemovalTemplate() const {
+        return m_gtCorrelationWithOverlapRemovalTemplate;
+    }
+
+    void setGtCorrelationWithOverlapRemovalTemplate(const CorrelationWithOverlapRemovalTemplate*);
+
+    ///   get / set the pointer to uGt GlobalBoard
+    inline const GlobalBoard* getuGtB() const {
+        return m_uGtB;
+    }
+
+    void setuGtB(const GlobalBoard*);
+    
+    void setScales(const GlobalScales*);  
+
+/*   //BLW Comment out for now
+    ///   get / set the number of bits for eta of calorimeter objects
+    inline const int gtIfCaloEtaNumberBits() const {
+        return m_ifCaloEtaNumberBits;
+    }
+
+
+    void setGtIfCaloEtaNumberBits(const int&);
+
+    ///   get / set maximum number of bins for the delta phi scales
+    inline const int gtCorrParDeltaPhiNrBins() const {
+        return m_corrParDeltaPhiNrBins;
+    }
+
+    void setGtCorrParDeltaPhiNrBins(const int&);
+*/
+private:
+
+    ///  copy function for copy constructor and operator=
+    void copy(const CorrWithOverlapRemovalCondition& cp);
+
+    /// load  candidates
+    const l1t::L1Candidate* getCandidate(const int bx, const int indexCand) const;
+
+    /// function to check a single object if it matches a condition
+    const bool
+    checkObjectParameter(const int iCondition, const l1t::L1Candidate& cand) const;
+
+private:
+
+    /// pointer to a CorrelationWithOverlapRemovalTemplate
+    const CorrelationWithOverlapRemovalTemplate* m_gtCorrelationWithOverlapRemovalTemplate;
+
+
+    // pointer to subconditions
+    const GlobalCondition* m_gtCond0;
+    const GlobalCondition* m_gtCond1;
+    const GlobalCondition* m_gtCond2; // used for overlap removal
+
+    /// pointer to uGt GlobalBoard, to be able to get the trigger objects
+    const GlobalBoard* m_uGtB;
+    
+    const GlobalScales* m_gtScales;
+
+
+/*   //BLW comment out for now
+    /// number of bits for eta of calorimeter objects
+    int m_ifCaloEtaNumberBits;
+
+    // maximum number of bins for the delta phi scales
+    unsigned int m_corrParDeltaPhiNrBins;
+*/
+
+
+};
+
+}
+#endif

--- a/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
@@ -1,0 +1,167 @@
+#ifndef L1Trigger_L1TGlobal_CorrelationWithOverlapRemovalTemplate_h
+#define L1Trigger_L1TGlobal_CorrelationWithOverlapRemovalTemplate_h
+
+/**
+ * \class CorrelationWithOverlapRemovalTemplate,  motivated by class CorrealtionTemplate
+ *
+ *
+ * Description: L1 Global Trigger correlation with overlap removal template.
+ * Includes spatial correlation for two objects and removal of overlap with third object
+ *
+ * Implementation:
+ *    <TODO: enter implementation details>
+ *
+ * \author: Vladimir Rekovic
+ *
+ * $Date$
+ * $Revision$
+ *
+ */
+
+// system include files
+#include <string>
+#include <iosfwd>
+
+#include <boost/cstdint.hpp>
+
+// user include files
+
+//   base class
+#include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
+
+#include "L1Trigger/L1TGlobal/interface/GlobalDefinitions.h"
+// forward declarations
+
+// class declaration
+class CorrelationWithOverlapRemovalTemplate : public GlobalCondition
+{
+
+public:
+
+    /// constructor(s)
+    ///   default
+    CorrelationWithOverlapRemovalTemplate();
+
+    ///   from condition name
+    CorrelationWithOverlapRemovalTemplate(const std::string& );
+
+    ///   from condition name, the category of first sub-condition, the category of the
+    ///   second sub-condition, the category of third sub-condition, the index of first sub-condition in the cor* vector,
+    ///   the index of second sub-condition in the cor* vector, the index of second sub-condition in the cor* vector
+    CorrelationWithOverlapRemovalTemplate(const std::string&,
+            const l1t::GtConditionCategory&, const l1t::GtConditionCategory&, const l1t::GtConditionCategory&, 
+            const int, const int, const int);
+
+    /// copy constructor
+    CorrelationWithOverlapRemovalTemplate( const CorrelationWithOverlapRemovalTemplate& );
+
+    /// destructor
+    virtual ~CorrelationWithOverlapRemovalTemplate();
+
+    /// assign operator
+    CorrelationWithOverlapRemovalTemplate& operator= (const CorrelationWithOverlapRemovalTemplate&);
+
+public:
+
+    /// typedef for correlation parameters
+    struct CorrelationWithOverlapRemovalParameter
+    {
+	
+	// Cut values in hardware
+        // One for correlation legs, one for overlap removal
+	long long minEtaCutValue[2];
+	long long maxEtaCutValue[2]; 
+	unsigned int precEtaCut[2];
+
+	long long minPhiCutValue[2];
+	long long maxPhiCutValue[2]; 
+	unsigned int precPhiCut[2];
+
+	long long minDRCutValue[2];
+	long long maxDRCutValue[2];
+	unsigned int precDRCut[2]; 
+
+	long long minMassCutValue[2];
+	long long maxMassCutValue[2];
+	unsigned int precMassCut[2]; 
+
+        //Requirement on charge of legs (currently only Mu-Mu).	
+	unsigned int chargeCorrelation[2];
+
+	int corrCutType[2];
+
+    };
+
+
+public:
+
+    /// get / set the category of the thre sub-conditions
+    inline const l1t::GtConditionCategory cond0Category() const {
+        return m_cond0Category;
+    }
+
+    inline const l1t::GtConditionCategory cond1Category() const {
+        return m_cond1Category;
+    }
+
+    inline const l1t::GtConditionCategory cond2Category() const {
+        return m_cond2Category;
+    }
+
+    void setCond0Category(const l1t::GtConditionCategory&);
+    void setCond1Category(const l1t::GtConditionCategory&);
+    void setCond2Category(const l1t::GtConditionCategory&);
+
+    /// get / set the index of the two sub-conditions in the cor* vector from menu
+    inline const int cond0Index() const {
+        return m_cond0Index;
+    }
+
+    inline const int cond1Index() const {
+        return m_cond1Index;
+    }
+
+    inline const int cond2Index() const {
+        return m_cond2Index;
+    }
+
+    void setCond0Index(const int&);
+    void setCond1Index(const int&);
+    void setCond2Index(const int&);
+
+    /// get / set correlation parameters
+
+    inline const CorrelationWithOverlapRemovalParameter* correlationParameter() const
+    {
+        return &m_correlationParameter;
+    }
+
+    void setCorrelationWithOverlapRemovalParameter(const CorrelationWithOverlapRemovalParameter& corrParameter);
+
+
+    /// print the condition
+    virtual void print(std::ostream& myCout) const;
+
+    /// output stream operator
+    friend std::ostream& operator<<(std::ostream&, const CorrelationWithOverlapRemovalTemplate&);
+
+
+private:
+
+    /// copy function for copy constructor and operator=
+    void copy( const CorrelationWithOverlapRemovalTemplate& cp);
+
+
+private:
+
+    l1t::GtConditionCategory m_cond0Category;
+    l1t::GtConditionCategory m_cond1Category;
+    l1t::GtConditionCategory m_cond2Category;
+    int m_cond0Index;
+    int m_cond1Index;
+    int m_cond2Index;
+    CorrelationWithOverlapRemovalParameter m_correlationParameter;
+
+};
+
+#endif

--- a/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
@@ -68,27 +68,38 @@ public:
     {
 	
 	// Cut values in hardware
-        // One for correlation legs, one for overlap removal
-	long long minEtaCutValue[2];
-	long long maxEtaCutValue[2]; 
-	unsigned int precEtaCut[2];
+	long long minEtaCutValue;
+	long long maxEtaCutValue; 
+	unsigned int precEtaCut;
 
-	long long minPhiCutValue[2];
-	long long maxPhiCutValue[2]; 
-	unsigned int precPhiCut[2];
+	long long minPhiCutValue;
+	long long maxPhiCutValue; 
+	unsigned int precPhiCut;
 
-	long long minDRCutValue[2];
-	long long maxDRCutValue[2];
-	unsigned int precDRCut[2]; 
+	long long minDRCutValue;
+	long long maxDRCutValue;
+	unsigned int precDRCut; 
 
-	long long minMassCutValue[2];
-	long long maxMassCutValue[2];
-	unsigned int precMassCut[2]; 
+	long long minMassCutValue;
+	long long maxMassCutValue;
+	unsigned int precMassCut; 
+
+	long long minOverlapRemovalEtaCutValue;
+	long long maxOverlapRemovalEtaCutValue; 
+	unsigned int precOverlapRemovalEtaCut;
+
+	long long minOverlapRemovalPhiCutValue;
+	long long maxOverlapRemovalPhiCutValue; 
+	unsigned int precOverlapRemovalPhiCut;
+
+	long long minOverlapRemovalDRCutValue;
+	long long maxOverlapRemovalDRCutValue;
+	unsigned int precOverlapRemovalDRCut; 
 
         //Requirement on charge of legs (currently only Mu-Mu).	
-	unsigned int chargeCorrelation[2];
+	unsigned int chargeCorrelation;
 
-	int corrCutType[2];
+	int corrCutType;
 
     };
 

--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -68,7 +68,9 @@ enum GtConditionType {
     TypeMinBiasHFP1,
     TypeMinBiasHFM1,
     TypeETTem,
-    TypeExternal
+    TypeExternal,
+    Type2corWithOverlapRemoval
+
 };
 
 struct GtConditionTypeStringToEnum {
@@ -86,7 +88,8 @@ enum GtConditionCategory {
     CondCalo,
     CondEnergySum,
     CondCorrelation,
-    CondExternal
+    CondExternal,
+    CondCorrelationWithOverlapRemoval
 };
 
 struct GtConditionCategoryStringToEnum {

--- a/L1Trigger/L1TGlobal/interface/TriggerMenu.h
+++ b/L1Trigger/L1TGlobal/interface/TriggerMenu.h
@@ -34,6 +34,7 @@
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
 
 
 // forward declarations

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -8,7 +8,9 @@
  *    <TODO: enter implementation details>
  *
  * \orig author: Vasile Mihai Ghete - HEPHY Vienna
- * \author: Vladimir Rekovic
+ *
+ * \new features: Vladimir Rekovic
+ *                - overlap object removal 
  *
  * $Date$
  * $Revision$
@@ -364,8 +366,13 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 	          condition.getType() == esConditionType::TripleMuonWithOverlapRemoval  ||
 	          condition.getType() == esConditionType::QuadMuonWithOverlapRemoval) {
 
-             parseMuon(condition,chipNr,false);
-             //parseOverlapRemoval(condition,chipNr);
+             edm::LogError("TriggerMenuParser") << std::endl
+                << "SingleMuonWithOverlapRemoval" << std::endl
+	        << "DoubleMuonWithOverlapRemoval" << std::endl
+	        << "TripleMuonWithOverlapRemoval" << std::endl
+	        << "QuadMuonWithOverlapRemoval" << std::endl
+                << "The above conditions types WithOverlapRemoval are not implemented yet in the parser. Please remove alogrithms that use this type of condtion from L1T Menu!" << std::endl;
+             //parseMuon(condition,chipNr,false);
 
           } 
           //parse CaloWithOverlapRemoval
@@ -382,8 +389,21 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 		  condition.getType() == esConditionType::TripleJetWithOverlapRemoval  ||
 		  condition.getType() == esConditionType::QuadJetWithOverlapRemoval) {
 
-             parseCalo(condition,chipNr,false); 
-             //parseOverlapRemoval(condition,chipNr);
+             edm::LogError("TriggerMenuParser") << std::endl
+                << "SingleEgammaWithOverlapRemoval" << std::endl
+	        << "DoubleEgammaWithOverlapRemoval" << std::endl
+	        << "TripleEgammaWithOverlapRemoval" << std::endl
+	        << "QuadEgammaWithOverlapRemoval" << std::endl
+	        << "SingleTauWithOverlapRemoval" << std::endl
+	        << "DoubleTauWithOverlapRemoval" << std::endl
+	        << "TripleTauWithOverlapRemoval" << std::endl
+	        << "QuadTauWithOverlapRemoval" << std::endl
+	        << "SingleJetWithOverlapRemoval" << std::endl
+	        << "DoubleJetWithOverlapRemoval" << std::endl
+	        << "TripleJetWithOverlapRemoval" << std::endl
+	        << "QuadJetWithOverlapRemoval" << std::endl
+                << "The above conditions types WithOverlapRemoval are not implemented yet in the parser. Please remove alogrithms that use this type of condtion from L1T Menu!" << std::endl;
+             //parseCalo(condition,chipNr,false); 
 
           } 
           //parse CorrelationWithOverlapRemoval
@@ -2928,10 +2948,10 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
    
 
     // create a new correlation condition
-    CorrelationWithOverlapRemovalTemplate correlationCond(name);
+    CorrelationWithOverlapRemovalTemplate correlationWORCond(name);
 
     // check that the condition does not exist already in the map
-    if ( !insertConditionIntoMap(correlationCond, chipNr)) {
+    if ( !insertConditionIntoMap(correlationWORCond, chipNr)) {
 
         edm::LogError("TriggerMenuParser")
                 << "    Error: duplicate correlation condition (" << name << ")"
@@ -2946,23 +2966,22 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
     // condition type BLW  (Do we change this to the type of correlation condition?)
     GtConditionType cType = l1t::Type2corWithOverlapRemoval;
 
-    // two objects (for sure)
-    const int nrObj = 2;
+    // three objects (for sure)
+    const int nrObj = 3;
 
     // object types and greater equal flag - filled in the loop
-    int intGEq[nrObj] = { -1, -1 };
+    int intGEq[nrObj] = { -1, -1, -1 };
     std::vector<GlobalObject> objType(nrObj);   //BLW do we want to define these as a different type?
     std::vector<GtConditionCategory> condCateg(nrObj);   //BLW do we want to change these categories
 
     // correlation flag and index in the cor*vector
     const bool corrFlag = true;
-    int corrIndexVal[nrObj] = { -1, -1 };
+    int corrIndexVal[nrObj] = { -1, -1, -1 };
 
 
     // Storage of the correlation selection
     CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalParameter corrParameter;
-    corrParameter.chargeCorrelation[0] = 1; //ignore charge correlation
-    corrParameter.chargeCorrelation[1] = 1; //ignore charge correlation
+    corrParameter.chargeCorrelation = 1; //ignore charge correlation for corr-legs
 
 // Get the correlation Cuts on the legs
       int cutType = 0;  
@@ -3011,6 +3030,26 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
 	     corrParameter.precMassCut     = cut.getMinimum().index;
 	     cutType = cutType | 0x8; 
           }
+	  if(cut.getCutType() == esCutType::OverlapRemovalDeltaEta) {
+	     //std::cout << "OverlapRemovalDeltaEta Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;
+	     corrParameter.minOverlapRemovalEtaCutValue = (long long)(minV * pow(10.,cut.getMinimum().index)); 
+	     corrParameter.maxOverlapRemovalEtaCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index)); 
+	     corrParameter.precOverlapRemovalEtaCut     = cut.getMinimum().index;	     
+	     cutType = cutType | 0x10;
+	  } else if (cut.getCutType() == esCutType::OverlapRemovalDeltaPhi) {
+	     //std::cout << "OverlapRemovalDeltaPhi Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;
+	     corrParameter.minOverlapRemovalPhiCutValue = (long long)(minV * pow(10.,cut.getMinimum().index));
+	     corrParameter.maxOverlapRemovalPhiCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index));
+	     corrParameter.precOverlapRemovalPhiCut     = cut.getMinimum().index;
+	     cutType = cutType | 0x20;
+	  } else if (cut.getCutType() == esCutType::OverlapRemovalDeltaR) {
+	     //std::cout << "DeltaR Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;
+	     corrParameter.minOverlapRemovalDRCutValue = (long long)(minV * pow(10.,cut.getMinimum().index));
+	     corrParameter.maxOverlapRemovalDRCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index));
+	     corrParameter.precOverlapRemovalDRCut     = cut.getMinimum().index;
+	     cutType = cutType | 0x40; 
+          }
+
 	}  
 
       }
@@ -3018,9 +3057,9 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
 
 // Get the two objects that form the legs
       const std::vector<esObject>& objects = corrCond.getObjects();
-      if(objects.size() != 2) {
+      if(objects.size() != 3) {
             edm::LogError("TriggerMenuParser")
-                    << "incorrect number of objects for the correlation condition " << name << " corrFlag " << corrFlag << std::endl;
+                    << "incorrect number of objects for the correlation condition with overlap removal " << name << " corrFlag " << corrFlag << std::endl;
             return false;      
       }
       
@@ -3172,23 +3211,25 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
     
 
    // fill the correlation condition
-    correlationCond.setCondType(cType);
-    correlationCond.setObjectType(objType);
-    correlationCond.setCondGEq(gEq);
-    correlationCond.setCondChipNr(chipNr);
+    correlationWORCond.setCondType(cType);
+    correlationWORCond.setObjectType(objType);
+    correlationWORCond.setCondGEq(gEq);
+    correlationWORCond.setCondChipNr(chipNr);
 
-    correlationCond.setCond0Category(condCateg[0]);
-    correlationCond.setCond1Category(condCateg[1]);
+    correlationWORCond.setCond0Category(condCateg[0]);
+    correlationWORCond.setCond1Category(condCateg[1]);
+    correlationWORCond.setCond2Category(condCateg[2]);
 
-    correlationCond.setCond0Index(corrIndexVal[0]);
-    correlationCond.setCond1Index(corrIndexVal[1]);
+    correlationWORCond.setCond0Index(corrIndexVal[0]);
+    correlationWORCond.setCond1Index(corrIndexVal[1]);
+    correlationWORCond.setCond2Index(corrIndexVal[2]);
 
-    correlationCond.setCorrelationParameter(corrParameter);
+    correlationWORCond.setCorrelationWithOverlapRemovalParameter(corrParameter);
 
     if (edm::isDebugEnabled() ) {
 
         std::ostringstream myCoutStream;
-        correlationCond.print(myCoutStream);
+        correlationWORCond.print(myCoutStream);
         LogTrace("TriggerMenuParser") << myCoutStream.str() << "\n"
                 << std::endl;
 
@@ -3197,7 +3238,7 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
     // insert condition into the map
     // condition is not duplicate, check was done at the beginning
 
-    (m_vecCorrelationTemplate[chipNr]).push_back(correlationCond);
+    (m_vecCorrelationWithOverlapRemovalTemplate[chipNr]).push_back(correlationWORCond);
     
     
     //

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -364,7 +364,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 	          condition.getType() == esConditionType::QuadMuonWithOverlapRemoval) {
 
              parseMuon(condition,chipNr,false);
-             parseOverlapRemoval(condition,chipNr);
+             //parseOverlapRemoval(condition,chipNr);
 
           } 
           //parse CaloWithOverlapRemoval
@@ -382,7 +382,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 		  condition.getType() == esConditionType::QuadJetWithOverlapRemoval) {
 
              parseCalo(condition,chipNr,false); 
-             parseOverlapRemoval(condition,chipNr);
+             //parseOverlapRemoval(condition,chipNr);
 
           } 
           //parse CorrelationWithOverlapRemoval
@@ -393,14 +393,14 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 		  condition.getType() == esConditionType::CaloEsumCorrelationWithOverlapRemoval) {
 		    
              parseCorrelation(condition,chipNr);
-             parseOverlapRemoval(condition,chipNr);
+             //parseOverlapRemoval(condition,chipNr);
 
           } 
           //parse InvariantMassWithOverlapRemoval
           else if(condition.getType() == esConditionType::InvariantMassWithOverlapRemoval) {
 
-             parseInvariantMass(condition,chipNr);
-             parseOverlapRemoval(condition,chipNr);
+             parseCorrelation(condition,chipNr);
+             //parseOverlapRemoval(condition,chipNr);
 
 	  } 
       

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -7,7 +7,8 @@
  * Implementation:
  *    <TODO: enter implementation details>
  *
- * \author: Vasile Mihai Ghete - HEPHY Vienna
+ * \orig author: Vasile Mihai Ghete - HEPHY Vienna
+ * \author: Vladimir Rekovic
  *
  * $Date$
  * $Revision$
@@ -390,19 +391,12 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 		  condition.getType() == esConditionType::MuonEsumCorrelationWithOverlapRemoval  ||
 		  condition.getType() == esConditionType::CaloMuonCorrelationWithOverlapRemoval  ||
 		  condition.getType() == esConditionType::CaloCaloCorrelationWithOverlapRemoval  ||
-		  condition.getType() == esConditionType::CaloEsumCorrelationWithOverlapRemoval) {
+		  condition.getType() == esConditionType::CaloEsumCorrelationWithOverlapRemoval  || 
+                  condition.getType() == esConditionType::InvariantMassWithOverlapRemoval) {
 		    
-             parseCorrelation(condition,chipNr);
-             //parseOverlapRemoval(condition,chipNr);
+             parseCorrelationWithOverlapRemoval(condition,chipNr);
 
           } 
-          //parse InvariantMassWithOverlapRemoval
-          else if(condition.getType() == esConditionType::InvariantMassWithOverlapRemoval) {
-
-             parseCorrelation(condition,chipNr);
-             //parseOverlapRemoval(condition,chipNr);
-
-	  } 
       
       }//if condition is a new one
     }//loop over conditions
@@ -2740,6 +2734,317 @@ bool l1t::TriggerMenuParser::parseCorrelation(
 	  // This is potentially a place to slim down the code.  Note: We currently evaluate the
 	  // conditions every time, so even if we put the condition in the vector once, we would 
 	  // still evaluate it multiple times.  This is a place for optimization.
+          {
+	   	                  
+              parseMuonCorr(&object,chipNr);
+	      corrIndexVal[jj] = (m_corMuonTemplate[chipNr]).size() - 1;	     
+	      
+          } else {
+	     LogDebug("TriggerMenuParser") << "Not Adding Correlation Muon Condition to Map...looking for the condition in Muon Cor Vector" << std::endl;
+	     bool found = false;
+	     int index = 0;
+	     while(!found && index<(int)((m_corMuonTemplate[chipNr]).size()) ) {
+	         if( (m_corMuonTemplate[chipNr]).at(index).condName() == object.getName() ) {
+		    LogDebug("TriggerMenuParser") << "Found condition " << object.getName() << " in vector at index " << index << std::endl;
+		    found = true;
+		 } else {
+		    index++;		 
+		 }
+	     }	  
+	     if(found) {
+	        corrIndexVal[jj] = index;
+	     } else {
+	       edm::LogError("TriggerMenuParser") << "FAILURE: Condition " << object.getName() << " is in map but not in cor. vector " << std::endl;
+	     }
+	     
+	  }
+*/
+          parseMuonCorr(&object,chipNr);
+	  corrIndexVal[jj] = (m_corMuonTemplate[chipNr]).size() - 1;	     
+	  
+          //Now set some flags for this subCondition
+	  intGEq[jj] = (object.getComparisonOperator() == esComparisonOperator::GE);
+          objType[jj] = gtMu;
+          condCateg[jj] = CondMuon;
+	  
+        } else if(object.getType() == esObjectType::Egamma ||
+	          object.getType() == esObjectType::Jet    ||
+		  object.getType() == esObjectType::Tau ) {
+	  
+	  // we have an Calo object
+          parseCaloCorr(&object,chipNr);
+	  corrIndexVal[jj] = (m_corCaloTemplate[chipNr]).size() - 1;
+
+          //Now set some flags for this subCondition
+	  intGEq[jj] = (object.getComparisonOperator() == esComparisonOperator::GE);
+          switch(object.getType()) {
+	     case esObjectType::Egamma: { 
+	      objType[jj] = gtEG;
+	     }
+	        break;
+	     case esObjectType::Jet: { 
+	      objType[jj] = gtJet;
+	     }
+	        break;
+	     case esObjectType::Tau: { 
+	      objType[jj] = gtTau;
+	     }
+	        break;
+	      default: {
+	      }
+	        break;	
+          }		 
+          condCateg[jj] = CondCalo;
+          	     
+          
+	  
+	  
+        } else if(object.getType() == esObjectType::ETM   ||
+	          object.getType() == esObjectType::ETMHF ||
+	          object.getType() == esObjectType::TOWERCOUNT ||
+	          object.getType() == esObjectType::HTM ) {
+	 
+	  // we have Energy Sum
+          parseEnergySumCorr(&object,chipNr);
+          corrIndexVal[jj] = (m_corEnergySumTemplate[chipNr]).size() - 1;
+
+          //Now set some flags for this subCondition
+	  intGEq[jj] = (object.getComparisonOperator() == esComparisonOperator::GE);
+          switch(object.getType()) {
+	     case esObjectType::ETM: { 
+	      objType[jj] = GlobalObject::gtETM;
+	     }
+	        break;
+	     case esObjectType::HTM: { 
+	      objType[jj] = GlobalObject::gtHTM;
+	     }
+	        break;
+	     case esObjectType::ETMHF: { 
+	      objType[jj] = GlobalObject::gtETMHF;
+	     }
+	        break;
+	     case esObjectType::TOWERCOUNT: {
+	      objType[jj] = GlobalObject::gtTowerCount;
+	     }
+	        break;
+	      default: {
+	      }
+	        break;			
+          }		 
+          condCateg[jj] = CondEnergySum;
+	  	              
+
+	} else {
+	
+          edm::LogError("TriggerMenuParser")
+                  << "Illegal Object Type " << object.getType() 
+                  << " for the correlation condition " << name << std::endl;
+          return false;	     
+
+	}  //if block on leg types
+
+      }  //loop over legs
+    
+
+    // get greater equal flag for the correlation condition
+    bool gEq = true;
+    if (intGEq[0] != intGEq[1]) {
+        edm::LogError("TriggerMenuParser")
+                << "Inconsistent GEq flags for sub-conditions "
+                << " for the correlation condition " << name << std::endl;
+        return false;
+
+    }
+    else {
+        gEq = (intGEq[0] != 0);
+
+    }
+    
+
+   // fill the correlation condition
+    correlationCond.setCondType(cType);
+    correlationCond.setObjectType(objType);
+    correlationCond.setCondGEq(gEq);
+    correlationCond.setCondChipNr(chipNr);
+
+    correlationCond.setCond0Category(condCateg[0]);
+    correlationCond.setCond1Category(condCateg[1]);
+
+    correlationCond.setCond0Index(corrIndexVal[0]);
+    correlationCond.setCond1Index(corrIndexVal[1]);
+
+    correlationCond.setCorrelationParameter(corrParameter);
+
+    if (edm::isDebugEnabled() ) {
+
+        std::ostringstream myCoutStream;
+        correlationCond.print(myCoutStream);
+        LogTrace("TriggerMenuParser") << myCoutStream.str() << "\n"
+                << std::endl;
+
+    }
+
+    // insert condition into the map
+    // condition is not duplicate, check was done at the beginning
+
+    (m_vecCorrelationTemplate[chipNr]).push_back(correlationCond);
+    
+    
+    //
+    return true;
+}
+
+/**
+ * parseCorrelationWithOverlapRemoval Parse a correlation condition and
+ * insert an entry to the conditions map
+ *
+ * @param node The corresponding node.
+ * @param name The name of the condition.
+ * @param chipNr The number of the chip this condition is located.
+ *
+ * @return "true" if succeeded, "false" if an error occurred.
+ *
+ */
+
+bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(
+        tmeventsetup::esCondition corrCond,
+        unsigned int chipNr) {
+
+    using namespace tmeventsetup;
+
+    std::string condition = "corrWithOverlapRemoval";
+    std::string particle = "test-fix" ;
+    std::string type = l1t2string( corrCond.getType() );
+    std::string name = l1t2string( corrCond.getName() );
+
+    LogDebug("TriggerMenuParser") << " ****************************************** " << std::endl
+     << "     (in parseCorrelation) " << std::endl
+     << " condition = " << condition << std::endl
+     << " particle  = " << particle << std::endl
+     << " type      = " << type << std::endl
+     << " name      = " << name << std::endl;
+
+
+   
+
+    // create a new correlation condition
+    CorrelationWithOverlapRemovalTemplate correlationCond(name);
+
+    // check that the condition does not exist already in the map
+    if ( !insertConditionIntoMap(correlationCond, chipNr)) {
+
+        edm::LogError("TriggerMenuParser")
+                << "    Error: duplicate correlation condition (" << name << ")"
+                << std::endl;
+
+        return false;
+    }
+
+
+// Define some of the quantities to store the parased information
+
+    // condition type BLW  (Do we change this to the type of correlation condition?)
+    GtConditionType cType = l1t::Type2corWithOverlapRemoval;
+
+    // two objects (for sure)
+    const int nrObj = 2;
+
+    // object types and greater equal flag - filled in the loop
+    int intGEq[nrObj] = { -1, -1 };
+    std::vector<GlobalObject> objType(nrObj);   //BLW do we want to define these as a different type?
+    std::vector<GtConditionCategory> condCateg(nrObj);   //BLW do we want to change these categories
+
+    // correlation flag and index in the cor*vector
+    const bool corrFlag = true;
+    int corrIndexVal[nrObj] = { -1, -1 };
+
+
+    // Storage of the correlation selection
+    CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalParameter corrParameter;
+    corrParameter.chargeCorrelation[0] = 1; //ignore charge correlation
+    corrParameter.chargeCorrelation[1] = 1; //ignore charge correlation
+
+// Get the correlation Cuts on the legs
+      int cutType = 0;  
+      const std::vector<esCut>& cuts = corrCond.getCuts();      
+      for (size_t jj = 0; jj < cuts.size(); jj++)
+      {
+        const esCut cut = cuts.at(jj);
+
+	if(cut.getCutType() == esCutType::ChargeCorrelation) { 
+	   if( cut.getData()=="ls" )      corrParameter.chargeCorrelation = 2;
+	   else if( cut.getData()=="os" ) corrParameter.chargeCorrelation = 4;
+	   else corrParameter.chargeCorrelation = 1; //ignore charge correlation
+        } else {
+
+// 
+//  Unitl utm has method to calculate these, do the integer value calculation with precision.
+//
+          double minV = cut.getMinimum().value;
+	  double maxV = cut.getMaximum().value;
+	  
+	  //Scale down very large numbers out of xml
+	  if(maxV > 1.0e8) maxV = 1.0e8;
+	  
+	  if(cut.getCutType() == esCutType::DeltaEta) {
+	     //std::cout << "DeltaEta Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;
+	     corrParameter.minEtaCutValue = (long long)(minV * pow(10.,cut.getMinimum().index)); 
+	     corrParameter.maxEtaCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index)); 
+	     corrParameter.precEtaCut     = cut.getMinimum().index;	     
+	     cutType = cutType | 0x1;
+	  } else if (cut.getCutType() == esCutType::DeltaPhi) {
+	     //std::cout << "DeltaPhi Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;
+	     corrParameter.minPhiCutValue = (long long)(minV * pow(10.,cut.getMinimum().index));
+	     corrParameter.maxPhiCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index));
+	     corrParameter.precPhiCut     = cut.getMinimum().index;
+	     cutType = cutType | 0x2;
+	  } else if (cut.getCutType() == esCutType::DeltaR) {
+	     //std::cout << "DeltaR Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;
+	     corrParameter.minDRCutValue = (long long)(minV * pow(10.,cut.getMinimum().index));
+	     corrParameter.maxDRCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index));
+	     corrParameter.precDRCut     = cut.getMinimum().index;
+	     cutType = cutType | 0x4; 
+	  } else if (cut.getCutType() == esCutType::Mass) {
+	     //std::cout << "Mass Cut minV = " << minV << " Max = " << maxV << " precMin = " << cut.getMinimum().index << " precMax = " << cut.getMaximum().index << std::endl;	  
+	     corrParameter.minMassCutValue = (long long)(minV * pow(10.,cut.getMinimum().index));
+	     corrParameter.maxMassCutValue = (long long)(maxV * pow(10.,cut.getMaximum().index));
+	     corrParameter.precMassCut     = cut.getMinimum().index;
+	     cutType = cutType | 0x8; 
+          }
+	}  
+
+      }
+      corrParameter.corrCutType = cutType;
+
+// Get the two objects that form the legs
+      const std::vector<esObject>& objects = corrCond.getObjects();
+      if(objects.size() != 2) {
+            edm::LogError("TriggerMenuParser")
+                    << "incorrect number of objects for the correlation condition " << name << " corrFlag " << corrFlag << std::endl;
+            return false;      
+      }
+      
+// loop over legs      
+      for (size_t jj = 0; jj < objects.size(); jj++)
+      {
+        const esObject object = objects.at(jj);
+/*      std::cout << "      obj name = " << object->getName() << "\n";
+        std::cout << "      obj type = " << object->getType() << "\n";
+        std::cout << "      obj op = " << object->getComparisonOperator() << "\n";
+        std::cout << "      obj bx = " << object->getBxOffset() << "\n";
+*/
+
+// check the leg type
+        if(object.getType() == esObjectType::Muon) {
+	  // we have a muon  
+
+/*
+          //BLW Hold on to this code we may need to go back to it at some point.
+	  // Now we are putting ALL leg conditions into the vector (so there are duplicates)
+	  // This is potentially a place to slim down the code.  Note: We currently evaluate the
+	  // conditions every time, so even if we put the condition in the vector once, we would 
+	  // still evaluate it multiple times.  This is a place for optimization.
+          {
 	   	                  
               parseMuonCorr(&object,chipNr);
 	      corrIndexVal[jj] = (m_corMuonTemplate[chipNr]).size() - 1;	     

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -351,12 +351,58 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 	  {
              parseCorrelation(condition,chipNr);
 
-	  //parse Muons	 	
+	  //parse Externals	 	
 	  } else if(condition.getType() == esConditionType::Externals      )       
 	  {
              parseExternal(condition,chipNr);
 	     	    
-	  }      
+          }      
+          //parse MuonWithOverlapRemoval
+          else if(condition.getType() == esConditionType::SingleMuonWithOverlapRemoval  ||
+	          condition.getType() == esConditionType::DoubleMuonWithOverlapRemoval  ||
+	          condition.getType() == esConditionType::TripleMuonWithOverlapRemoval  ||
+	          condition.getType() == esConditionType::QuadMuonWithOverlapRemoval) {
+
+             parseMuon(condition,chipNr,false);
+             parseOverlapRemoval(condition,chipNr);
+
+          } 
+          //parse CaloWithOverlapRemoval
+          else if(condition.getType() == esConditionType::SingleEgammaWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::DoubleEgammaWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::TripleEgammaWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::QuadEgammaWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::SingleTauWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::DoubleTauWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::TripleTauWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::QuadTauWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::SingleJetWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::DoubleJetWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::TripleJetWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::QuadJetWithOverlapRemoval) {
+
+             parseCalo(condition,chipNr,false); 
+             parseOverlapRemoval(condition,chipNr);
+
+          } 
+          //parse CorrelationWithOverlapRemoval
+          else if(condition.getType() == esConditionType::MuonMuonCorrelationWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::MuonEsumCorrelationWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::CaloMuonCorrelationWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::CaloCaloCorrelationWithOverlapRemoval  ||
+		  condition.getType() == esConditionType::CaloEsumCorrelationWithOverlapRemoval) {
+		    
+             parseCorrelation(condition,chipNr);
+             parseOverlapRemoval(condition,chipNr);
+
+          } 
+          //parse InvariantMassWithOverlapRemoval
+          else if(condition.getType() == esConditionType::InvariantMassWithOverlapRemoval) {
+
+             parseInvariantMass(condition,chipNr);
+             parseOverlapRemoval(condition,chipNr);
+
+	  } 
       
       }//if condition is a new one
     }//loop over conditions

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -28,6 +28,7 @@
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
 
 #include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
@@ -176,6 +177,14 @@ public:
 
     void setVecCorrelationTemplate(
             const std::vector<std::vector<CorrelationTemplate> >&);
+
+    inline const std::vector<std::vector<CorrelationWithOverlapRemovalTemplate> >& vecCorrelationWithOverlapRemovalTemplate() const {
+
+        return m_vecCorrelationWithOverlapRemovalTemplate;
+    }
+
+    void setVecCorrelationWithOverlapRemovalTemplate(
+            const std::vector<std::vector<CorrelationWithOverlapRemovalTemplate> >&);
 
     // get / set the vectors containing the conditions for correlation templates
     //
@@ -345,6 +354,9 @@ private:
     /// parse a correlation condition
     bool parseCorrelation(tmeventsetup::esCondition corrCond, unsigned int chipNr = 0);
 
+    /// parse a correlation condition with overlap removal
+    bool parseCorrelationWithOverlapRemoval(tmeventsetup::esCondition corrCond, unsigned int chipNr = 0);
+
 
     /// parse all algorithms
     //bool parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMParser* parser);
@@ -435,6 +447,7 @@ private:
     std::vector<std::vector<ExternalTemplate> > m_vecExternalTemplate;
 
     std::vector<std::vector<CorrelationTemplate> > m_vecCorrelationTemplate;
+    std::vector<std::vector<CorrelationWithOverlapRemovalTemplate> > m_vecCorrelationWithOverlapRemovalTemplate;
     std::vector<std::vector<MuonTemplate> > m_corMuonTemplate;
     std::vector<std::vector<CaloTemplate> > m_corCaloTemplate;
     std::vector<std::vector<EnergySumTemplate> > m_corEnergySumTemplate;

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondtion.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondtion.cc
@@ -27,7 +27,7 @@
  *      - Loop over all objects of leg3 (overlap-removal leg)
  *        - Retrive its coodrinates, and do conversions depending on the types
  *        - Check for matching with any overlap-removal object.  
- *      - If metched with any overlap object, next leg1 object.
+ *      - If metched with any overlap object, next leg2 object.
  *      - Check for dEta, dPhi, dR, and mass (and charge) correlation with 1st leg object. 
  *        If any correlation cut pass, save leg1-leg2 object combination.
  *    - End loop leg2

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondtion.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondtion.cc
@@ -1,0 +1,1257 @@
+/**
+ * \class CorrWithOverlapRemovalCondition
+ *
+ *
+ * Description: evaluation of a correlation condition.
+ *
+ * Implementation:
+ *    <TODO: enter implementation details>
+ *
+ *
+ */
+
+// this class header
+#include "L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+
+#include "L1Trigger/L1TGlobal/interface/MuCondition.h"
+#include "L1Trigger/L1TGlobal/interface/CaloCondition.h"
+#include "L1Trigger/L1TGlobal/interface/EnergySumCondition.h"
+#include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+
+#include "L1Trigger/L1TGlobal/interface/GlobalBoard.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+// constructors
+//     default
+l1t::CorrWithOverlapRemovalCondition::CorrWithOverlapRemovalCondition() :
+    ConditionEvaluation() {
+
+}
+
+//     from base template condition (from event setup usually)
+l1t::CorrWithOverlapRemovalCondition::CorrWithOverlapRemovalCondition(const GlobalCondition* corrTemplate, 
+                                  const GlobalCondition* cond0Condition,
+				  const GlobalCondition* cond1Condition,
+				  const GlobalCondition* cond2Condition,
+				  const GlobalBoard* ptrGTB
+        ) :
+    ConditionEvaluation(),
+    m_gtCorrelationWithOverlapRemovalTemplate(static_cast<const CorrelationWithOverlapRemovalTemplate*>(corrTemplate)),
+    m_gtCond0(cond0Condition), m_gtCond1(cond1Condition), m_gtCond2(cond2Condition),
+    m_uGtB(ptrGTB)
+{
+
+
+
+}
+
+// copy constructor
+void l1t::CorrWithOverlapRemovalCondition::copy(const l1t::CorrWithOverlapRemovalCondition& cp) {
+
+    m_gtCorrelationWithOverlapRemovalTemplate = cp.gtCorrelationWithOverlapRemovalTemplate();
+    m_uGtB = cp.getuGtB();
+
+    m_condMaxNumberObjects = cp.condMaxNumberObjects();
+    m_condLastResult = cp.condLastResult();
+    m_combinationsInCond = cp.getCombinationsInCond();
+
+    m_verbosity = cp.m_verbosity;
+
+}
+
+l1t::CorrWithOverlapRemovalCondition::CorrWithOverlapRemovalCondition(const l1t::CorrWithOverlapRemovalCondition& cp) :
+    ConditionEvaluation() {
+
+    copy(cp);
+
+}
+
+// destructor
+l1t::CorrWithOverlapRemovalCondition::~CorrWithOverlapRemovalCondition() {
+
+    // empty
+
+}
+
+// equal operator
+l1t::CorrWithOverlapRemovalCondition& l1t::CorrWithOverlapRemovalCondition::operator=(const l1t::CorrWithOverlapRemovalCondition& cp) {
+    copy(cp);
+    return *this;
+}
+
+// methods
+void l1t::CorrWithOverlapRemovalCondition::setGtCorrelationWithOverlapRemovalTemplate(const CorrelationWithOverlapRemovalTemplate* caloTempl) {
+
+    m_gtCorrelationWithOverlapRemovalTemplate = caloTempl;
+
+}
+
+///   set the pointer to uGT GlobalBoard
+void l1t::CorrWithOverlapRemovalCondition::setuGtB(const GlobalBoard* ptrGTB) {
+
+    m_uGtB = ptrGTB;
+
+}
+
+
+void l1t::CorrWithOverlapRemovalCondition::setScales(const GlobalScales* sc) 
+{
+    m_gtScales = sc;
+}
+
+
+
+// try all object permutations and check spatial correlations, if required
+const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxEval) const {
+
+    // std::cout << "m_isDebugEnabled = " << m_isDebugEnabled << std::endl;
+    // std::cout << "m_verbosity = " << m_verbosity << std::endl;
+    
+
+    //std::ostringstream myCout;
+    //m_gtCorrelationWithOverlapRemovalTemplate->print(myCout);
+    //LogDebug("L1TGlobal") 
+    //   << "CorrelationWithOverlapRemoval Condition Evaluation \n" << myCout.str() << std::endl;
+
+    bool condResult = false;
+    bool reqObjResult = false;
+
+    // number of objects in condition (it is 2, no need to retrieve from
+    // condition template) and their type
+    int nObjInCond = 2;
+    std::vector<GlobalObject> cndObjTypeVec(nObjInCond);
+
+    // evaluate first the two sub-conditions (Type1s)
+
+    const GtConditionCategory cond0Categ = m_gtCorrelationWithOverlapRemovalTemplate->cond0Category();
+    const GtConditionCategory cond1Categ = m_gtCorrelationWithOverlapRemovalTemplate->cond1Category();
+
+    //Decide if we have a mixed (muon + cal) condition
+    bool convertCaloScales = false;
+    if( (cond0Categ == CondMuon && (cond1Categ == CondCalo || cond1Categ == CondEnergySum) )  ||
+        (cond1Categ == CondMuon && (cond0Categ == CondCalo || cond0Categ == CondEnergySum) ) )
+	convertCaloScales = true;
+	
+    const MuonTemplate* corrMuon = 0;
+    const CaloTemplate* corrCalo = 0;
+    const EnergySumTemplate* corrEnergySum = 0;
+
+    // FIXME copying is slow...
+    CombinationsInCond cond0Comb;
+    CombinationsInCond cond1Comb;
+    
+    switch (cond0Categ) {
+        case CondMuon: {
+            corrMuon = static_cast<const MuonTemplate*>(m_gtCond0);
+            MuCondition muCondition(corrMuon, m_uGtB,
+                    0,0); //BLW these are counts that don't seem to be used...perhaps remove
+
+            muCondition.evaluateConditionStoreResult(bxEval);
+            reqObjResult = muCondition.condLastResult();
+
+            cond0Comb = (muCondition.getCombinationsInCond());
+            cndObjTypeVec[0] = (corrMuon->objectType())[0];
+
+            if (m_verbosity ) {
+                std::ostringstream myCout;
+                muCondition.print(myCout);
+
+                LogDebug("L1TGlobal") << myCout.str() << std::endl;
+            }
+        }
+            break;
+        case CondCalo: {
+            corrCalo = static_cast<const CaloTemplate*>(m_gtCond0);
+
+            CaloCondition caloCondition(corrCalo, m_uGtB,
+                    0, 0, 0, 0); //BLW these are counters that don't seem to be used...perhaps remove.
+
+            caloCondition.evaluateConditionStoreResult(bxEval);
+            reqObjResult = caloCondition.condLastResult();
+
+            cond0Comb = (caloCondition.getCombinationsInCond());
+            cndObjTypeVec[0] = (corrCalo->objectType())[0];
+
+            if (m_verbosity) {
+                std::ostringstream myCout;
+                caloCondition.print(myCout);
+
+                LogDebug("L1TGlobal") << myCout.str() << std::endl;
+            }
+        }
+            break;
+        case CondEnergySum: {
+
+            corrEnergySum = static_cast<const EnergySumTemplate*>(m_gtCond0);
+            EnergySumCondition eSumCondition(corrEnergySum, m_uGtB);
+
+            eSumCondition.evaluateConditionStoreResult(bxEval);
+            reqObjResult = eSumCondition.condLastResult();
+
+            cond0Comb = (eSumCondition.getCombinationsInCond());
+            cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
+
+            if (m_verbosity ) {
+                std::ostringstream myCout;
+                eSumCondition.print(myCout);
+
+                LogDebug("L1TGlobal") << myCout.str() << std::endl;
+            }
+        }
+            break;
+        default: {
+            // should not arrive here, there are no correlation conditions defined for this object
+            return false;
+        }
+            break;
+    }
+
+    // return if first subcondition is false
+    if (!reqObjResult) {
+            LogDebug("L1TGlobal")
+                    << "\n  First sub-condition false, second sub-condition not evaluated and not printed."
+                    << std::endl;
+        return false;
+    }
+
+    // second object
+    reqObjResult = false;
+
+    switch (cond1Categ) {
+        case CondMuon: {
+            corrMuon = static_cast<const MuonTemplate*>(m_gtCond1);
+            MuCondition muCondition(corrMuon, m_uGtB,
+                    0,0); //BLW these are counts that don't seem to be used...perhaps remove
+
+            muCondition.evaluateConditionStoreResult(bxEval);
+            reqObjResult = muCondition.condLastResult();
+
+            cond1Comb = (muCondition.getCombinationsInCond());
+            cndObjTypeVec[1] = (corrMuon->objectType())[0];
+
+            if (m_verbosity) {
+                std::ostringstream myCout;
+                muCondition.print(myCout);
+
+               LogDebug("L1TGlobal") << myCout.str() << std::endl;
+            }
+        }
+            break;
+        case CondCalo: {
+            corrCalo = static_cast<const CaloTemplate*>(m_gtCond1);
+            CaloCondition caloCondition(corrCalo, m_uGtB,
+                    0, 0, 0, 0); //BLW these are counters that don't seem to be used...perhaps remove.
+
+            caloCondition.evaluateConditionStoreResult(bxEval);
+            reqObjResult = caloCondition.condLastResult();
+
+            cond1Comb = (caloCondition.getCombinationsInCond());
+            cndObjTypeVec[1] = (corrCalo->objectType())[0];
+
+            if (m_verbosity ) {
+                std::ostringstream myCout;
+                caloCondition.print(myCout);
+
+                LogDebug("L1TGlobal") << myCout.str() << std::endl;
+            }
+
+        }
+            break;
+        case CondEnergySum: {
+            corrEnergySum = static_cast<const EnergySumTemplate*>(m_gtCond1);
+	    
+            EnergySumCondition eSumCondition(corrEnergySum, m_uGtB);
+
+            eSumCondition.evaluateConditionStoreResult(bxEval);
+            reqObjResult = eSumCondition.condLastResult();
+
+            cond1Comb = (eSumCondition.getCombinationsInCond());
+            cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
+
+            if (m_verbosity) {
+                std::ostringstream myCout;
+                eSumCondition.print(myCout);
+
+                LogDebug("L1TGlobal") << myCout.str() << std::endl;
+            }
+        }
+            break;
+        default: {
+            // should not arrive here, there are no correlation conditions defined for this object
+            return false;
+        }
+            break;
+    }
+
+    // return if second sub-condition is false
+    if (!reqObjResult) {
+        return false;
+    } else {
+        LogDebug("L1TGlobal") << "\n"
+                << "    Both sub-conditions true for object requirements."
+                << "    Evaluate correlation requirements.\n" << std::endl;
+
+    }
+
+    // since we have two good legs get the correlation parameters
+    CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalParameter corrPar =
+        *(m_gtCorrelationWithOverlapRemovalTemplate->correlationParameter());
+
+
+    // vector to store the indices of the calorimeter objects
+    // from the combination evaluated in the condition
+    SingleCombInCond objectsInComb;
+    objectsInComb.reserve(nObjInCond);
+
+    // clear the m_combinationsInCond vector
+    (combinationsInCond()).clear();
+
+    // pointers to objects
+    const BXVector<const l1t::Muon*>*        candMuVec    = 0;
+    const BXVector<const l1t::L1Candidate*>* candCaloVec  = 0;
+    const BXVector<const l1t::EtSum*>*       candEtSumVec = 0;
+
+    bool etSumCond = false;
+    
+    // make the conversions of the indices, depending on the combination of objects involved
+    // (via pair index)
+
+    int phiIndex0  = 0;
+    double phi0Phy = 0.;
+    int phiIndex1  = 0;
+    double phi1Phy = 0.;
+
+    int etaIndex0  = 0;
+    double eta0Phy = 0.;
+    int etaIndex1  = 0;
+    double eta1Phy = 0.;
+    int etaBin0    = 0;
+    int etaBin1    = 0;
+
+    int etIndex0  = 0;
+    int etBin0    = 0;
+    double et0Phy = 0.;
+    int etIndex1  = 0;
+    int etBin1    = 0;
+    double et1Phy = 0.;
+    
+    int chrg0 = -1;
+    int chrg1 = -1;
+
+// Determine the number of phi bins to get cutoff at pi
+    int phiBound = 0;
+    if(cond0Categ == CondMuon || cond1Categ == CondMuon) {
+        GlobalScales::ScaleParameters par = m_gtScales->getMUScales();
+        //phiBound = par.phiBins.size()/2;
+	phiBound = (int)((par.phiMax - par.phiMin)/par.phiStep)/2;
+    } else {
+        //Assumes all calorimeter objects are on same phi scale
+        GlobalScales::ScaleParameters par = m_gtScales->getEGScales();
+        //phiBound = par.phiBins.size()/2;
+	phiBound = (int)((par.phiMax - par.phiMin)/par.phiStep)/2;
+    }	
+    LogDebug("L1TGlobal") << "Phi Bound = " << phiBound << std::endl;
+    
+
+// Keep track of objects for LUTS
+    std::string lutObj0 = "NULL";
+    std::string lutObj1 = "NULL";
+
+
+    LogTrace("L1TGlobal")
+            << "  Sub-condition 0: std::vector<SingleCombInCond> size: "
+            << (cond0Comb.size()) << std::endl;
+    LogTrace("L1TGlobal")
+            << "  Sub-condition 1: std::vector<SingleCombInCond> size: "
+            << (cond1Comb.size()) << std::endl;
+
+
+    // loop over all combinations which produced individually "true" as Type1s
+    //  
+    // BLW: Optimization issue: potentially making the same comparison twice  
+    //                          if both legs are the same object type.
+    for (std::vector<SingleCombInCond>::const_iterator it0Comb =
+            cond0Comb.begin(); it0Comb != cond0Comb.end(); it0Comb++) {
+
+        // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in (*it0Comb)[0]
+        // ... but add protection to not crash
+        int obj0Index = -1;
+
+        if ((*it0Comb).size() > 0) {
+            obj0Index = (*it0Comb)[0];
+        } else {
+            LogTrace("L1TGlobal")
+                    << "\n  SingleCombInCond (*it0Comb).size() "
+                    << ((*it0Comb).size()) << std::endl;
+            return false;
+        }
+
+// Collect the information on the first leg of the correlation
+        switch (cond0Categ) {
+            case CondMuon: {
+	        lutObj0 = "MU";
+                candMuVec = m_uGtB->getCandL1Mu();
+                phiIndex0 =  (candMuVec->at(bxEval,obj0Index))->hwPhi(); //(*candMuVec)[obj0Index]->phiIndex();
+                etaIndex0 =  (candMuVec->at(bxEval,obj0Index))->hwEta();
+		etIndex0  =  (candMuVec->at(bxEval,obj0Index))->hwPt();
+		chrg0     =  (candMuVec->at(bxEval,obj0Index))->hwCharge();
+		int etaBin0 = etaIndex0;
+		if(etaBin0<0) etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0; //twos complement		
+//		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
+		
+		etBin0 = etIndex0;
+		int ssize = m_gtScales->getMUScales().etBins.size();
+		if (etBin0 >= ssize){ 
+		  etBin0 = ssize-1; 			  
+		  LogTrace("L1TGlobal") 
+		    << "muon0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
+		} 
+		
+		// Determine Floating Pt numbers for floating point caluclation
+		std::pair<double, double> binEdges = m_gtScales->getMUScales().phiBins.at(phiIndex0);
+		phi0Phy = 0.5*(binEdges.second + binEdges.first);
+		binEdges = m_gtScales->getMUScales().etaBins.at(etaBin0);
+		eta0Phy = 0.5*(binEdges.second + binEdges.first);		
+		binEdges = m_gtScales->getMUScales().etBins.at(etBin0);
+		et0Phy = 0.5*(binEdges.second + binEdges.first);
+
+		LogDebug("L1TGlobal") << "Found all quantities for the muon 0" << std::endl;		
+            }
+                break;
+
+// Calorimeter Objects (EG, Jet, Tau)
+            case CondCalo: {
+	       
+               switch(cndObjTypeVec[0]) {
+	         case gtEG: {
+		    lutObj0 = "EG";
+		    candCaloVec = m_uGtB->getCandL1EG();
+		    phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
+		    etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
+		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+		    etaBin0   = etaIndex0;
+		    if(etaBin0<0) etaBin0 = m_gtScales->getEGScales().etaBins.size() + etaBin0;
+//		    LogDebug("L1TGlobal") << "EG0 phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0 << " et " << etIndex0 << std::endl;
+
+                    etBin0 = etIndex0;
+		    int ssize = m_gtScales->getEGScales().etBins.size();
+		    if (etBin0 >= ssize){ 
+		      etBin0 = ssize-1; 			  
+		      LogTrace("L1TGlobal") 
+			<< "EG0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
+		    } 
+	    
+		    // Determine Floating Pt numbers for floating point caluclation
+		    std::pair<double, double> binEdges = m_gtScales->getEGScales().phiBins.at(phiIndex0);
+		    phi0Phy = 0.5*(binEdges.second + binEdges.first);					    
+		    binEdges = m_gtScales->getEGScales().etaBins.at(etaBin0);
+		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
+		    binEdges = m_gtScales->getEGScales().etBins[etBin0];
+		    et0Phy = 0.5*(binEdges.second + binEdges.first);
+		    
+		 }
+		   break;
+		 case gtJet: {
+		    lutObj0 = "JET";
+		    candCaloVec = m_uGtB->getCandL1Jet();
+		    phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
+		    etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
+		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+		    etaBin0 = etaIndex0;
+		    if(etaBin0<0) etaBin0 = m_gtScales->getJETScales().etaBins.size() + etaBin0;
+
+		    etBin0 = etIndex0;
+		    int ssize = m_gtScales->getJETScales().etBins.size();
+		    if (etBin0 >= ssize){ 
+		      //edm::LogWarning("L1TGlobal") 
+		      //<< "jet0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
+		      etBin0 = ssize-1; 			  
+		    } 
+		    
+		    // Determine Floating Pt numbers for floating point caluclation
+		    std::pair<double, double> binEdges = m_gtScales->getJETScales().phiBins.at(phiIndex0);
+		    phi0Phy = 0.5*(binEdges.second + binEdges.first);			
+		    binEdges = m_gtScales->getJETScales().etaBins.at(etaBin0);
+		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
+		    binEdges = m_gtScales->getJETScales().etBins.at(etBin0);
+		    et0Phy = 0.5*(binEdges.second + binEdges.first);
+		    
+		 }
+		   break;
+		 case gtTau: {
+		    candCaloVec = m_uGtB->getCandL1Tau();
+		    phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
+		    etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
+		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+		    etaBin0 = etaIndex0;
+		    if(etaBin0<0) etaBin0 = m_gtScales->getTAUScales().etaBins.size() + etaBin0;
+		    
+		    etBin0 = etIndex0;
+		    int ssize = m_gtScales->getTAUScales().etBins.size();
+		    if (etBin0 >= ssize){ 		      
+		      etBin0 = ssize-1; 			  
+		      LogTrace("L1TGlobal") 
+			<< "tau0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
+		    } 
+
+		    
+		    // Determine Floating Pt numbers for floating point caluclation
+		    std::pair<double, double> binEdges = m_gtScales->getTAUScales().phiBins.at(phiIndex0);
+		    phi0Phy = 0.5*(binEdges.second + binEdges.first);
+		    binEdges = m_gtScales->getTAUScales().etaBins.at(etaBin0);
+		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
+		    binEdges = m_gtScales->getTAUScales().etBins.at(etBin0);
+		    et0Phy = 0.5*(binEdges.second + binEdges.first);		    			
+		    lutObj0 = "TAU";
+		 }
+	           break;
+		 default: {
+		 }  
+	           break;
+	       } //end switch on calo type.
+		
+                //If needed convert calo scales to muon scales for comparison
+                if(convertCaloScales) {
+		  std::string lutName = lutObj0;
+		  lutName += "-MU";
+		  long long tst = m_gtScales->getLUT_CalMuEta(lutName,etaBin0);
+		  LogDebug("L1TGlobal") << lutName <<"  EtaCal = " << etaIndex0 << " etaBin0 = " << etaBin0 << " EtaMu = " << tst << std::endl; 
+		  etaIndex0 = tst;
+		  
+
+		  tst = m_gtScales->getLUT_CalMuPhi(lutName,phiIndex0);
+		  LogDebug("L1TGlobal") << lutName <<"  PhiCal = " << phiIndex0 << " PhiMu = " << tst << std::endl;
+		  phiIndex0 = tst;
+		   		  
+                }
+ 
+            }
+                break;
+		
+// Energy Sums		
+            case CondEnergySum: {
+
+                etSumCond = true;
+		//Stupid mapping between enum types for energy sums.
+		l1t::EtSum::EtSumType type;
+		switch( cndObjTypeVec[0] ){
+		case gtETM:
+		  type = l1t::EtSum::EtSumType::kMissingEt;
+		  lutObj0 = "ETM";
+		  break;
+		case gtETT:
+		  type = l1t::EtSum::EtSumType::kTotalEt;
+		  lutObj0 = "ETT"; 
+		  break;
+		case gtETTem:
+		  type = l1t::EtSum::EtSumType::kTotalEtEm;
+		  lutObj0 = "ETTem"; //should this be just ETT (share LUTs?) Can't be used for CorrCond anyway since now directional information
+		  break;		  
+		case gtHTM:
+		  type = l1t::EtSum::EtSumType::kMissingHt;
+		  lutObj0 = "HTM";
+		  break;
+		case gtHTT:
+		  type = l1t::EtSum::EtSumType::kTotalHt;
+		  lutObj0 = "HTT";
+		  break;
+		case gtETMHF:
+		  type = l1t::EtSum::EtSumType::kMissingEtHF;
+		  lutObj0 = "ETMHF"; 
+		  break;
+		case gtMinBiasHFP0:
+		case gtMinBiasHFM0:
+		case gtMinBiasHFP1:
+		case gtMinBiasHFM1:
+		  type = l1t::EtSum::EtSumType::kMinBiasHFP0;
+		  lutObj0 = "MinBias"; //??Fix?? Not a valid LUT type Can't be used for CorrCond anyway since now directional information
+		  break;
+		default:
+		  edm::LogError("L1TGlobal")
+		    << "\n  Error: "
+		    << "Unmatched object type from template to EtSumType, cndObjTypeVec[0] = "
+		    << cndObjTypeVec[0]
+		    << std::endl;
+		  type = l1t::EtSum::EtSumType::kTotalEt;
+		  break;
+		}
+
+                candEtSumVec = m_uGtB->getCandL1EtSum();
+		
+                for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
+		  if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
+                    phiIndex0 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
+                    etaIndex0 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
+		    etIndex0  =  (candEtSumVec->at(bxEval,iEtSum))->hwPt(); 
+
+
+
+
+
+
+                    //  Get the floating point numbers
+		    if(cndObjTypeVec[0] == gtETM ) {
+		      std::pair<double, double> binEdges = m_gtScales->getETMScales().phiBins.at(phiIndex0);
+		      phi0Phy = 0.5*(binEdges.second + binEdges.first);
+		      eta0Phy = 0.; //No Eta for Energy Sums
+		      
+		      etBin0 = etIndex0;
+		      int ssize = m_gtScales->getETMScales().etBins.size();
+		      assert(ssize > 0);
+		      if (etBin0 >= ssize){ etBin0 = ssize-1; } 			   
+		      
+		      binEdges = m_gtScales->getETMScales().etBins.at(etBin0);
+		      et0Phy = 0.5*(binEdges.second + binEdges.first);
+		    } else if (cndObjTypeVec[0] == gtHTM) {
+		      std::pair<double, double> binEdges = m_gtScales->getHTMScales().phiBins.at(phiIndex0);
+		      phi0Phy = 0.5*(binEdges.second + binEdges.first);
+		      eta0Phy = 0.; //No Eta for Energy Sums
+		      
+		      etBin0 = etIndex0;
+		      int ssize = m_gtScales->getHTMScales().etBins.size();
+		      assert(ssize > 0);
+		      if (etBin0 >= ssize){ etBin0 = ssize-1; } 			   
+
+		      binEdges = m_gtScales->getHTMScales().etBins.at(etBin0);
+		      et0Phy = 0.5*(binEdges.second + binEdges.first);
+		    } else if (cndObjTypeVec[0] == gtETMHF) {
+		      std::pair<double, double> binEdges = m_gtScales->getETMHFScales().phiBins.at(phiIndex0);
+		      phi0Phy = 0.5*(binEdges.second + binEdges.first);
+		      eta0Phy = 0.; //No Eta for Energy Sums
+		      
+		      etBin0 = etIndex0;
+		      int ssize = m_gtScales->getETMHFScales().etBins.size();
+		      assert(ssize > 0);
+		      if (etBin0 >= ssize){ etBin0 = ssize-1; } 			   
+
+		      binEdges = m_gtScales->getETMHFScales().etBins.at(etBin0);
+		      et0Phy = 0.5*(binEdges.second + binEdges.first);
+		    } 
+
+		    
+                    //If needed convert calo scales to muon scales for comparison (only phi for energy sums)
+                    if(convertCaloScales) {
+
+		       std::string lutName = lutObj0;
+		       lutName += "-MU";
+		       long long tst = m_gtScales->getLUT_CalMuPhi(lutName,phiIndex0);
+		       LogDebug("L1TGlobal") << lutName <<"  PhiCal = " << phiIndex0 << " PhiMu = " << tst << std::endl;
+		       phiIndex0 = tst;
+
+                    }
+ 
+                  } //check it is the EtSum we want   
+                } // loop over Etsums
+		
+            }
+                break;
+		
+		
+            default: {
+                // should not arrive here, there are no correlation conditions defined for this object
+		LogDebug("L1TGlobal") << "Error could not find the Cond Category for Leg 0" << std::endl;
+                return false;
+            }
+                break;
+        } //end switch on first leg type
+
+// Now loop over the second leg to get its information
+        for (std::vector<SingleCombInCond>::const_iterator it1Comb =
+                cond1Comb.begin(); it1Comb != cond1Comb.end(); it1Comb++) {
+
+            LogDebug("L1TGlobal") << "Looking at second Condition" << std::endl;  
+            // Type1s: there is 1 object only, no need for a loop (*it1Comb)[0]
+            // ... but add protection to not crash
+            int obj1Index = -1;
+
+            if ((*it1Comb).size() > 0) {
+                obj1Index = (*it1Comb)[0];
+            } else {
+                LogTrace("L1TGlobal")
+                        << "\n  SingleCombInCond (*it1Comb).size() "
+                        << ((*it1Comb).size()) << std::endl;
+                return false;
+            }
+	    
+	    //If we are dealing with the same object type avoid the two legs
+	    // either being the same object 
+	    if( cndObjTypeVec[0] == cndObjTypeVec[1] &&
+	               obj0Index == obj1Index ) {
+		
+		       LogDebug("L1TGlobal") << "Corr Condition looking at same leg...skip" << std::endl;
+		       continue;
+	    }	       
+
+            switch (cond1Categ) {
+                case CondMuon: {
+		   lutObj1 = "MU"; 
+                   candMuVec = m_uGtB->getCandL1Mu();
+                   phiIndex1 =  (candMuVec->at(bxEval,obj1Index))->hwPhi(); //(*candMuVec)[obj0Index]->phiIndex();
+                   etaIndex1 =  (candMuVec->at(bxEval,obj1Index))->hwEta();
+		   etIndex1  =  (candMuVec->at(bxEval,obj1Index))->hwPt();
+		   chrg1     =  (candMuVec->at(bxEval,obj1Index))->hwCharge();
+		   etaBin1 = etaIndex1;
+		   if(etaBin1<0) etaBin1 = m_gtScales->getMUScales().etaBins.size() + etaBin1;	   
+//		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
+ 
+		   etBin1 = etIndex1;
+		   int ssize = m_gtScales->getMUScales().etBins.size();
+		   if (etBin1 >= ssize){ 
+		     LogTrace("L1TGlobal") 
+		       << "muon2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+		     etBin1 = ssize-1;   
+		   } 
+
+		   // Determine Floating Pt numbers for floating point caluclation
+		   std::pair<double, double> binEdges = m_gtScales->getMUScales().phiBins.at(phiIndex1);
+		   phi1Phy = 0.5*(binEdges.second + binEdges.first);
+		   binEdges = m_gtScales->getMUScales().etaBins.at(etaBin1);
+		   eta1Phy = 0.5*(binEdges.second + binEdges.first);		
+		   binEdges = m_gtScales->getMUScales().etBins.at(etBin1);
+		   et1Phy = 0.5*(binEdges.second + binEdges.first);		
+	   
+                }
+                    break;
+                case CondCalo: {
+        	   switch(cndObjTypeVec[1]) {
+	             case gtEG: {
+			candCaloVec = m_uGtB->getCandL1EG();
+			phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
+			etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
+			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+			etaBin1   =   etaIndex1;
+			if(etaBin1<0) etaBin1 = m_gtScales->getEGScales().etaBins.size() + etaBin1;
+			
+			etBin1 = etIndex1;
+			int ssize = m_gtScales->getEGScales().etBins.size();
+			if (etBin1 >= ssize){ 
+			  LogTrace("L1TGlobal") 
+			    << "EG1 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+			  etBin1 = ssize-1; 			  
+			} 
+			
+			// Determine Floating Pt numbers for floating point caluclation
+		   	std::pair<double, double> binEdges = m_gtScales->getEGScales().phiBins.at(phiIndex1);
+		   	phi1Phy = 0.5*(binEdges.second + binEdges.first);			
+			binEdges = m_gtScales->getEGScales().etaBins.at(etaBin1);
+			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
+			binEdges = m_gtScales->getEGScales().etBins.at(etBin1);
+			et1Phy = 0.5*(binEdges.second + binEdges.first);
+		    	lutObj1 = "EG";
+		     }
+		       break;
+		     case gtJet: {
+			candCaloVec = m_uGtB->getCandL1Jet();
+			phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
+			etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
+			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+			etaBin1 = etaIndex1;
+			if(etaBin1<0) etaBin1 = m_gtScales->getJETScales().etaBins.size() + etaBin1;
+			
+			etBin1 = etIndex1;						
+			int ssize = m_gtScales->getJETScales().etBins.size();
+			assert(ssize);
+			if (etBin1 >= ssize){ 			  
+			  //edm::LogWarning("L1TGlobal") 
+			  //<< "jet2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+			  etBin1 = ssize-1; 			  
+			} 
+
+			// Determine Floating Pt numbers for floating point caluclation
+		   	std::pair<double, double> binEdges = m_gtScales->getJETScales().phiBins.at(phiIndex1);
+		   	phi1Phy = 0.5*(binEdges.second + binEdges.first);			
+			binEdges = m_gtScales->getJETScales().etaBins.at(etaBin1);
+			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
+			//CRASHES HERE:
+			binEdges = m_gtScales->getJETScales().etBins.at(etBin1);
+			et1Phy = 0.5*(binEdges.second + binEdges.first);
+			lutObj1 = "JET";
+		     }
+		       break;
+		     case gtTau: {
+			candCaloVec = m_uGtB->getCandL1Tau();
+			phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
+			etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
+			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+			etaBin1 = etaIndex1;
+			if(etaBin1<0) etaBin1 = m_gtScales->getTAUScales().etaBins.size() + etaBin1;
+			
+			etBin1 = etIndex1;
+			int ssize = m_gtScales->getTAUScales().etBins.size();
+			if (etBin1 >= ssize){ 
+			  LogTrace("L1TGlobal") 
+			    << "tau2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+			  etBin1 = ssize-1; 			  
+			} 
+						
+			// Determine Floating Pt numbers for floating point caluclation
+		   	std::pair<double, double> binEdges = m_gtScales->getTAUScales().phiBins.at(phiIndex1);
+		   	phi1Phy = 0.5*(binEdges.second + binEdges.first);			
+			binEdges = m_gtScales->getTAUScales().etaBins.at(etaBin1);
+			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
+			binEdges = m_gtScales->getTAUScales().etBins.at(etBin1);
+			et1Phy = 0.5*(binEdges.second + binEdges.first);	
+			lutObj1 = "TAU";
+		     }
+	               break;
+		     default: {
+		     }  
+	           break;
+	           } //end switch on calo type.
+ 
+                   
+                   //If needed convert calo scales to muon scales for comparison
+                   if(convertCaloScales) {
+		   
+		     std::string lutName = lutObj1;
+		     lutName += "-MU";
+		     long long tst = m_gtScales->getLUT_CalMuEta(lutName,etaBin1);
+		     LogDebug("L1TGlobal") << lutName <<"  EtaCal = " << etaIndex1 << " EtaMu = " << tst << std::endl; 
+		     etaIndex1 = tst;
+
+
+		     tst = m_gtScales->getLUT_CalMuPhi(lutName,phiIndex1);
+		     LogDebug("L1TGlobal") << lutName <<"  PhiCal = " << phiIndex1 << " PhiMu = " << tst << std::endl;
+		     phiIndex1 = tst;
+
+                   }
+
+
+                }
+                    break;
+                case CondEnergySum: {
+
+                   LogDebug("L1TGlobal") << "Looking at second Condition as Energy Sum: " << cndObjTypeVec[1] << std::endl;
+                   etSumCond = true;
+		   
+		   //Stupid mapping between enum types for energy sums.
+		   l1t::EtSum::EtSumType type;
+		   switch( cndObjTypeVec[1] ){
+		   case gtETM:
+		     type = l1t::EtSum::EtSumType::kMissingEt;
+		     lutObj1 = "ETM";
+		     break;
+		   case gtETT:
+		     type = l1t::EtSum::EtSumType::kTotalEt;
+		     lutObj1 = "ETT";
+		     break;
+		   case gtETTem:
+		     type = l1t::EtSum::EtSumType::kTotalEtEm;
+		     lutObj1 = "ETTem";
+		     break;		     
+		   case gtHTM:
+		     type = l1t::EtSum::EtSumType::kMissingHt;
+		     lutObj1 = "HTM";
+		     break;
+		   case gtHTT:
+		     type = l1t::EtSum::EtSumType::kTotalHt;
+		     lutObj1 = "HTT";
+		     break;
+		   case gtETMHF:
+		     type = l1t::EtSum::EtSumType::kMissingEtHF;
+		     lutObj1 = "ETMHF";
+		     break;
+		   case gtMinBiasHFP0:
+		   case gtMinBiasHFM0:
+		   case gtMinBiasHFP1:
+		   case gtMinBiasHFM1:
+		     type = l1t::EtSum::EtSumType::kMinBiasHFP0;
+		     lutObj1 = "MinBias";
+		  break;		     
+		   default:
+		     edm::LogError("L1TGlobal")
+		       << "\n  Error: "
+		       << "Unmatched object type from template to EtSumType, cndObjTypeVec[1] = "
+		       << cndObjTypeVec[1]
+		       << std::endl;
+		     type = l1t::EtSum::EtSumType::kTotalEt;
+		     break;
+		   }
+                   
+		   
+		   candEtSumVec = m_uGtB->getCandL1EtSum();
+		    
+		   LogDebug("L1TGlobal") << "obj " << lutObj1 << " Vector Size " << candEtSumVec->size(bxEval) << std::endl; 
+                   for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
+		     if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
+                       phiIndex1 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
+                       etaIndex1 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
+		       etIndex1  =  (candEtSumVec->at(bxEval,iEtSum))->hwPt(); 
+
+		       // Determine Floating Pt numbers for floating point caluclation
+		       
+		       if(cndObjTypeVec[1] == gtETM) {
+		         std::pair<double, double> binEdges = m_gtScales->getETMScales().phiBins.at(phiIndex1);
+			 phi1Phy = 0.5*(binEdges.second + binEdges.first);
+			 eta1Phy = 0.; //No Eta for Energy Sums
+			 
+			 etBin1 = etIndex1;
+			 int ssize = m_gtScales->getETMScales().etBins.size();
+			 assert(ssize > 0);
+			 if (etBin1 >= ssize){ etBin1 = ssize-1; } 			   
+		      
+			 binEdges = m_gtScales->getETMScales().etBins.at(etBin1);
+			 et1Phy = 0.5*(binEdges.second + binEdges.first);
+		       } else if(cndObjTypeVec[1] == gtHTM) {
+		         std::pair<double, double> binEdges = m_gtScales->getHTMScales().phiBins.at(phiIndex1);
+			 phi1Phy = 0.5*(binEdges.second + binEdges.first);
+			 eta1Phy = 0.; //No Eta for Energy Sums
+			 
+			 etBin1 = etIndex1;
+			 int ssize = m_gtScales->getHTMScales().etBins.size();
+			 assert(ssize > 0);
+			 if (etBin1 >= ssize){ etBin1 = ssize-1; } 			   
+
+			 binEdges = m_gtScales->getHTMScales().etBins.at(etBin1);
+			 et1Phy = 0.5*(binEdges.second + binEdges.first);
+		       } else if(cndObjTypeVec[1] == gtETMHF) {
+		         std::pair<double, double> binEdges = m_gtScales->getETMHFScales().phiBins.at(phiIndex1);
+			 phi1Phy = 0.5*(binEdges.second + binEdges.first);
+			 eta1Phy = 0.; //No Eta for Energy Sums
+			 
+			 etBin1 = etIndex1;
+			 int ssize = m_gtScales->getETMHFScales().etBins.size();
+			 assert(ssize > 0);
+			 if (etBin1 >= ssize){ etBin1 = ssize-1; } 			   
+
+			 binEdges = m_gtScales->getETMHFScales().etBins.at(etBin1);
+			 et1Phy = 0.5*(binEdges.second + binEdges.first);
+		       }
+
+
+                       //If needed convert calo scales to muon scales for comparison (only phi for energy sums)   
+                       if(convertCaloScales) {
+
+			 std::string lutName = lutObj1;
+			 lutName += "-MU";
+			 long long tst = m_gtScales->getLUT_CalMuPhi(lutName,phiIndex1);
+			 LogDebug("L1TGlobal") << lutName <<"  PhiCal = " << phiIndex1 << " PhiMu = " << tst << std::endl;
+			 phiIndex1 = tst;
+
+                       }
+
+
+                     } //check it is the EtSum we want   
+                   } // loop over Etsums
+
+                }
+                    break;
+                default: {
+                    // should not arrive here, there are no correlation conditions defined for this object
+		    LogDebug("L1TGlobal") << "Error could not find the Cond Category for Leg 0" << std::endl;
+                    return false;
+                }
+                    break;
+            } //end switch on second leg
+
+            if (m_verbosity) {
+                LogDebug("L1TGlobal") << "    Correlation pair ["
+                        << l1TGtObjectEnumToString(cndObjTypeVec[0]) << ", "
+                        << l1TGtObjectEnumToString(cndObjTypeVec[1])
+                        << "] with collection indices [" << obj0Index << ", "
+                        << obj1Index << "] " << " has: \n"
+			<< "     Et  value   = ["<< etIndex0  << ", " << etIndex1  << "]\n"
+			<< "     phi indices = ["<< phiIndex0 << ", " << phiIndex1 << "]\n"
+			<< "     eta indices = ["<< etaIndex0 << ", " << etaIndex1 << "]\n" 
+			<< "     chrg        = ["<< chrg0     << ", " << chrg1     << "]\n"<< std::endl;
+            }
+
+
+// Now perform the desired correlation on these two objects. Assume true until we find a contradition
+            bool reqResult = true;
+	    
+            // clear the indices in the combination
+            objectsInComb.clear();
+
+            objectsInComb.push_back(obj0Index);
+            objectsInComb.push_back(obj1Index);
+
+            // if we get here all checks were successful for this combination
+            // set the general result for evaluateCondition to "true"
+
+
+// These all require some delta eta and phi calculations.  Do them first...for now real calculation but need to
+// revise this to line up with firmware calculations.
+	    double deltaPhiPhy  = fabs(phi1Phy - phi0Phy);
+	    if(deltaPhiPhy> M_PI) deltaPhiPhy = 2.*M_PI - deltaPhiPhy;
+            double deltaEtaPhy  = fabs(eta1Phy - eta0Phy);
+	     
+
+// Determine the integer based delta eta and delta phi
+            int deltaPhiFW = abs(phiIndex0 - phiIndex1);
+	    if(deltaPhiFW>=phiBound) deltaPhiFW = 2*phiBound - deltaPhiFW;
+            std::string lutName = lutObj0;
+            lutName += "-";
+	    lutName += lutObj1;
+	    long long deltaPhiLUT = m_gtScales->getLUT_DeltaPhi(lutName,deltaPhiFW);
+	    unsigned int precDeltaPhiLUT = m_gtScales->getPrec_DeltaPhi(lutName);
+	    
+	    int deltaEtaFW = abs(etaIndex0 - etaIndex1);
+	    long long deltaEtaLUT = 0;
+	    unsigned int precDeltaEtaLUT = 0;
+	    if(!etSumCond) {
+	      deltaEtaLUT = m_gtScales->getLUT_DeltaEta(lutName,deltaEtaFW);
+              precDeltaEtaLUT = m_gtScales->getPrec_DeltaEta(lutName);
+	    }
+
+            //  
+	    LogDebug("L1TGlobal") << "Obj0 phiFW = " << phiIndex0 << " Obj1 phiFW = " << phiIndex1 << "\n"
+	    << "    DeltaPhiFW = " << deltaPhiFW << "\n"
+	    << "    LUT Name = " << lutName << " Prec = " << precDeltaPhiLUT << "  DeltaPhiLUT = " << deltaPhiLUT << "\n"
+	    << "Obj0 etaFW = " << etaIndex0 << " Obj1 etaFW = " << etaIndex1 << "\n"
+	    << "    DeltaEtaFW = " << deltaEtaFW << "\n"
+	    << "    LUT Name = " << lutName << " Prec = " << precDeltaEtaLUT << "  DeltaEtaLUT = " << deltaEtaLUT << std::endl;
+
+
+            // If there is a delta eta, check it.
+            if(corrPar.corrCutType & 0x1) {
+		  
+		  unsigned int preShift = precDeltaEtaLUT - corrPar.precEtaCut;
+		  LogDebug("L1TGlobal")    << "    Testing Delta Eta Cut (" << lutObj0 << "," << lutObj1 << ") [" << (long long)(corrPar.minEtaCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxEtaCutValue*pow(10,preShift)) << "] with precision = " << corrPar.precEtaCut <<"\n"
+					   << "    deltaEtaLUT = " << deltaEtaLUT << "\n"
+					   << "    Precision Shift = " << preShift << "\n"
+					   << "    deltaEta (shift)= " << (deltaEtaLUT/pow(10,preShift+corrPar.precEtaCut)) << "\n"
+					   << "    deltaEtaPhy = " <<  deltaEtaPhy << std::endl; 		      
+		  
+		  //if(preShift>0) deltaEtaLUT /= pow(10,preShift);
+		  if( deltaEtaLUT >= (long long)(corrPar.minEtaCutValue*pow(10,preShift)) &&
+		      deltaEtaLUT <= (long long)(corrPar.maxEtaCutValue*pow(10,preShift)) ) {
+
+		     LogDebug("L1TGlobal") << "    Passed Delta Eta Cut [" << (long long)(corrPar.minEtaCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxEtaCutValue*pow(10,preShift)) << "]" << std::endl;		      
+		       		  
+		 } else {
+		    
+		     LogDebug("L1TGlobal")  << "    Failed Delta Eta Cut [" << (long long)(corrPar.minEtaCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxEtaCutValue*pow(10,preShift)) << "]" << std::endl;		      
+		     reqResult = false;
+		 }	
+	     }
+	          	 
+             //if there is a delta phi check it.
+	     if(corrPar.corrCutType & 0x2) {
+	       	
+		  unsigned int preShift = precDeltaPhiLUT - corrPar.precPhiCut;	  
+		  LogDebug("L1TGlobal")  << "    Testing Delta Phi Cut (" << lutObj0 << "," << lutObj1 << ") [" << (long long)(corrPar.minPhiCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxPhiCutValue*pow(10,preShift)) << "] with precision = " << corrPar.precPhiCut <<"\n"
+					   << "    deltaPhiLUT = " << deltaPhiLUT  << "\n"
+					   << "    Precision Shift = " << preShift << "\n"
+					   << "    deltaPhi (shift)= " << (deltaPhiLUT/pow(10,preShift+corrPar.precPhiCut)) << "\n"
+					   << "    deltaPhiPhy = " <<  deltaPhiPhy << std::endl;  		      
+		  
+		  //if(preShift>0) deltaPhiLUT /= pow(10,preShift);
+		  if( deltaPhiLUT >= (long long)(corrPar.minPhiCutValue*pow(10,preShift)) &&
+		      deltaPhiLUT <= (long long)(corrPar.maxPhiCutValue*pow(10,preShift)) ) {
+
+		     LogDebug("L1TGlobal")  << "    Passed Delta Phi Cut [" << (long long)(corrPar.minPhiCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxPhiCutValue*pow(10,preShift)) << "]" << std::endl;		      
+                    
+		 } else {
+		    
+		     LogDebug("L1TGlobal") << "    Failed Delta Phi Cut [" << (long long)(corrPar.minPhiCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxPhiCutValue*pow(10,preShift)) << "]" << std::endl;		      
+		     reqResult = false;
+		 }	
+	     }
+	            	 
+
+	     if(corrPar.corrCutType & 0x4) {
+	       	
+		  //Assumes Delta Eta and Delta Phi LUTs have the same precision
+		  unsigned int preShift = 2*precDeltaPhiLUT  - corrPar.precDRCut;	  
+		  double deltaRSqPhy = deltaPhiPhy*deltaPhiPhy + deltaEtaPhy*deltaEtaPhy;
+		  long long deltaRSq = deltaEtaLUT*deltaEtaLUT + deltaPhiLUT*deltaPhiLUT;
+				  
+		  LogDebug("L1TGlobal") << "    Testing Delta R Cut (" << lutObj0 << "," << lutObj1 << ") [" << (long long)(corrPar.minDRCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxDRCutValue*pow(10,preShift)) << "] with precision = " << corrPar.precDRCut <<"\n"
+					   << "    deltaPhiLUT = " << deltaPhiLUT << "\n"
+					   << "    deltaEtaLUT = " << deltaEtaLUT << "\n"
+					   << "    deltaRSqLUT = " << deltaRSq <<  "\n"
+					   << "    Precision Shift = " << preShift << "\n" 
+					   << "    deltaRSqLUT (shift)= " << (deltaRSq/pow(10,preShift+corrPar.precDRCut))	<< "\n"				   
+					   << "    deltaRSqPhy = " << deltaRSqPhy << std::endl;		      
+		  
+		  //if(preShift>0) deltaRSq /= pow(10,preShift);
+		  if( deltaRSq >= (long long)(corrPar.minDRCutValue*pow(10,preShift)) &&
+		      deltaRSq <= (long long)(corrPar.maxDRCutValue*pow(10,preShift)) ) {
+
+		     LogDebug("L1TGlobal") << "    Passed Delta R Cut [" << (long long)(corrPar.minDRCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxDRCutValue*pow(10,preShift)) << "]" << std::endl;		      
+                        
+		 } else {
+		    
+		     LogDebug("L1TGlobal") << "    Failed Delta R Cut [" << (int)(corrPar.minDRCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxDRCutValue*pow(10,preShift)) << "]" << std::endl;		      
+		     reqResult = false;
+		 }	
+	    }  	 
+
+	       
+	    if(corrPar.corrCutType & 0x8) {
+	      
+	          //invariant mass calculation based on 
+		  // M = sqrt(2*p1*p2(cosh(eta1-eta2) - cos(phi1 - phi2)))
+		  // but we calculate (1/2)M^2
+		  // 
+                  double cosDeltaPhiPhy  = cos(deltaPhiPhy);
+		  double coshDeltaEtaPhy = cosh(deltaEtaPhy);		  
+		  double massSqPhy = et0Phy*et1Phy*(coshDeltaEtaPhy - cosDeltaPhiPhy);
+
+                  long long cosDeltaPhiLUT = m_gtScales->getLUT_Cos(lutName,deltaPhiFW);
+		  unsigned int precCosLUT = m_gtScales->getPrec_Cos(lutName);
+		  
+                  long long coshDeltaEtaLUT = m_gtScales->getLUT_Cosh(lutName,deltaEtaFW);
+		  unsigned int precCoshLUT = m_gtScales->getPrec_Cosh(lutName);
+		  if(precCoshLUT - precCosLUT != 0) LogDebug("L1TGlobal") << "Warning: Cos and Cosh LUTs on different Precision" << std::endl;
+		  
+		  std::string lutName = lutObj0;
+		  lutName += "-ET";
+		  long long ptObj0 = m_gtScales->getLUT_Pt(lutName,etIndex0);
+		  unsigned int precPtLUTObj0 = m_gtScales->getPrec_Pt(lutName);
+		  
+		  lutName = lutObj1;
+		  lutName += "-ET";
+		  long long ptObj1 = m_gtScales->getLUT_Pt(lutName,etIndex1);
+		  unsigned int precPtLUTObj1 = m_gtScales->getPrec_Pt(lutName);
+		  
+		  // Pt and Angles are at different precission.
+		  long long massSq = ptObj0*ptObj1*(coshDeltaEtaLUT - cosDeltaPhiLUT);
+		  
+		  //Note: There is an assumption here that Cos and Cosh have the same precission
+		  unsigned int preShift = precPtLUTObj0  + precPtLUTObj1 + precCosLUT - corrPar.precMassCut;	
+		  
+		  LogDebug("L1TGlobal") << "    Testing Invaiant Mass (" << lutObj0 << "," << lutObj1 << ") [" << (long long)(corrPar.minMassCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxMassCutValue*pow(10,preShift)) << "] with precision = " << corrPar.precMassCut <<"\n"
+					   << "    deltaPhiLUT  = " << deltaPhiLUT << "  cosLUT  = " << cosDeltaPhiLUT << "\n"
+					   << "    deltaEtaLUT  = " << deltaEtaLUT << "  coshLUT = " << coshDeltaEtaLUT << "\n"
+					   << "    etIndex0     = " << etIndex0 << "    pt0LUT      = " << ptObj0 << " PhyEt0 = " << et0Phy  << "\n"
+					   << "    etIndex1     = " << etIndex1 << "    pt1LUT      = " << ptObj1 << " PhyEt1 = " << et1Phy  <<"\n"
+					   << "    massSq/2     = " << massSq <<  "\n" 
+					   << "    Precision Shift = " << preShift << "\n"	
+					   << "    massSq   (shift)= " << (massSq/pow(10,preShift+corrPar.precMassCut)) << "\n"	      
+					   << "    deltaPhiPhy  = " << deltaPhiPhy << "  cos() = " << cosDeltaPhiPhy << "\n"
+					   << "    deltaEtaPhy  = " << deltaEtaPhy << "  cosh()= " << coshDeltaEtaPhy << "\n"
+					   << "    massSqPhy/2  = " << massSqPhy << "  sqrt(|massSq|) = "<< sqrt(fabs(2.*massSqPhy)) << std::endl; 		      
+		  
+		  //if(preShift>0) massSq /= pow(10,preShift);
+		  if(  massSq > 0. &&
+		      massSq >= (long long)(corrPar.minMassCutValue*pow(10,preShift)) &&
+		      massSq <= (long long)(corrPar.maxMassCutValue*pow(10,preShift))  ) {
+
+		     LogDebug("L1TGlobal") << "    Passed Invariant Mass Cut [" << (long long)(corrPar.minMassCutValue*pow(10,preShift))
+		                           << "," << (long long)(corrPar.maxMassCutValue*pow(10,preShift)) << "]" << std::endl;		      
+                        
+		 } else {
+		    
+		     LogDebug("L1TGlobal") << "    Failed Invariant Mass Cut [" << (long long)(corrPar.minMassCutValue*pow(10,preShift)) 
+		                           << "," << (long long)(corrPar.maxMassCutValue*pow(10,preShift)) << "]" << std::endl;		      
+		     reqResult = false;
+		 }	
+	    } 
+		 
+
+// For Muon-Muon Correlation Check the Charge Correlation if requested
+            bool chrgCorrel = true;
+	    if(cond0Categ==CondMuon && cond1Categ==CondMuon) {
+	      // Check for like-sign
+	      if(corrPar.chargeCorrelation==2 && chrg0 != chrg1 ) chrgCorrel = false;  
+	      // Check for opp-sign
+	      if(corrPar.chargeCorrelation==4 && chrg0 == chrg1 ) chrgCorrel = false;
+	    }
+
+
+            if (reqResult & chrgCorrel) {
+
+                condResult = true;
+                (combinationsInCond()).push_back(objectsInComb);
+
+            } 
+
+        } //end loop over second leg
+
+    } //end loop over first leg
+
+
+
+    if (m_verbosity  && condResult) {
+        LogDebug("L1TGlobal") << " pass(es) the correlation condition.\n"
+                 << std::endl;
+    }    
+    
+      
+    return condResult;
+
+}
+
+// load calo candidates
+const l1t::L1Candidate* l1t::CorrWithOverlapRemovalCondition::getCandidate(const int bx, const int indexCand) const {
+
+    // objectType() gives the type for nrObjects() only,
+    // but in a CondCalo all objects have the same type
+    // take type from the type of the first object
+    switch ((m_gtCorrelationWithOverlapRemovalTemplate->objectType())[0]) {
+        case gtEG:
+            return (m_uGtB->getCandL1EG())->at(bx,indexCand);
+            break;
+
+        case gtJet:
+            return (m_uGtB->getCandL1Jet())->at(bx,indexCand);
+            break;
+
+       case gtTau:
+            return (m_uGtB->getCandL1Tau())->at(bx,indexCand);
+            break;
+        default:
+            return 0;
+            break;
+    }
+
+    return 0;
+}
+
+/**
+ * checkObjectParameter - Compare a single particle with a numbered condition.
+ *
+ * @param iCondition The number of the condition.
+ * @param cand The candidate to compare.
+ *
+ * @return The result of the comparison (false if a condition does not exist).
+ */
+
+const bool l1t::CorrWithOverlapRemovalCondition::checkObjectParameter(const int iCondition, const l1t::L1Candidate& cand) const {
+
+
+    return true;
+}
+
+void l1t::CorrWithOverlapRemovalCondition::print(std::ostream& myCout) const {
+
+    myCout << "Dummy Print for CorrWithOverlapRemovalCondition" << std::endl;
+    m_gtCorrelationWithOverlapRemovalTemplate->print(myCout);
+   
+
+    ConditionEvaluation::print(myCout);
+
+}
+

--- a/L1Trigger/L1TGlobal/src/CorrelationWithOverlapRemovalTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/CorrelationWithOverlapRemovalTemplate.cc
@@ -35,7 +35,7 @@ CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalTemplate()
         : GlobalCondition()
 {
 
-    m_condCategory = l1t::CondCorrelation;
+    m_condCategory = l1t::CondCorrelationWithOverlapRemoval;
     m_condType = l1t::Type2cor;
     m_condChipNr = -1;
 
@@ -60,7 +60,7 @@ CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalTemplate(con
         : GlobalCondition(cName)
 {
 
-    m_condCategory = l1t::CondCorrelation;
+    m_condCategory = l1t::CondCorrelationWithOverlapRemoval;
     m_condType = l1t::Type2cor;
     m_condChipNr = -1;
 
@@ -192,23 +192,30 @@ void CorrelationWithOverlapRemovalTemplate::print(std::ostream& myCout) const
 
     myCout << "\n  CorrelationWithOverlapRemoval parameters " << "[ hex ]" <<  std::endl;
 
-    for (int i=0;i<2;i++) {
-    myCout << "    Cut Type["<<i<<"]:  " << m_correlationParameter.corrCutType[i] << std::endl;
-    myCout << "    minEtaCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.minEtaCutValue[i] << std::endl;
-    myCout << "    maxEtaCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.maxEtaCutValue[i] << std::endl;
-    myCout << "    precEtaCut["<<i<<"]            = " << std::dec << m_correlationParameter.precEtaCut[i]     << std::endl;
-    myCout << "    minPhiCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.minPhiCutValue[i] << std::endl;
-    myCout << "    maxPhiCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.maxPhiCutValue[i] << std::endl;
-    myCout << "    precPhiCut["<<i<<"]            = " << std::dec << m_correlationParameter.precPhiCut[i]     << std::endl;
-    myCout << "    minDRCutValue["<<i<<"]         = " << std::dec << m_correlationParameter.minDRCutValue[i]  << std::endl;
-    myCout << "    maxDRCutValue["<<i<<"]         = " << std::dec << m_correlationParameter.maxDRCutValue[i]  << std::endl;
-    myCout << "    precDRCut["<<i<<"]             = " << std::dec << m_correlationParameter.precDRCut[i]      << std::endl;
-    myCout << "    minMassCutValue["<<i<<"]       = " << std::dec << m_correlationParameter.minMassCutValue[i]<< std::endl;
-    myCout << "    maxMassCutValue["<<i<<"]       = " << std::dec << m_correlationParameter.maxMassCutValue[i]<< std::endl;
-    myCout << "    precMassCut["<<i<<"]           = " << std::dec << m_correlationParameter.precMassCut[i]    << std::endl;
+    myCout << "    Cut Type:  " << m_correlationParameter.corrCutType << std::endl;
+    myCout << "    minEtaCutValue        = " << std::dec << m_correlationParameter.minEtaCutValue << std::endl;
+    myCout << "    maxEtaCutValue        = " << std::dec << m_correlationParameter.maxEtaCutValue << std::endl;
+    myCout << "    precEtaCut            = " << std::dec << m_correlationParameter.precEtaCut     << std::endl;
+    myCout << "    minPhiCutValue        = " << std::dec << m_correlationParameter.minPhiCutValue << std::endl;
+    myCout << "    maxPhiCutValue        = " << std::dec << m_correlationParameter.maxPhiCutValue << std::endl;
+    myCout << "    precPhiCut            = " << std::dec << m_correlationParameter.precPhiCut     << std::endl;
+    myCout << "    minDRCutValue         = " << std::dec << m_correlationParameter.minDRCutValue  << std::endl;
+    myCout << "    maxDRCutValue         = " << std::dec << m_correlationParameter.maxDRCutValue  << std::endl;
+    myCout << "    precDRCut             = " << std::dec << m_correlationParameter.precDRCut      << std::endl;
+    myCout << "    minMassCutValue       = " << std::dec << m_correlationParameter.minMassCutValue<< std::endl;
+    myCout << "    maxMassCutValue       = " << std::dec << m_correlationParameter.maxMassCutValue<< std::endl;
+    myCout << "    precMassCut           = " << std::dec << m_correlationParameter.precMassCut    << std::endl;
+    myCout << "    minOverlapRemovalEtaCutValue        = " << std::dec << m_correlationParameter.minOverlapRemovalEtaCutValue << std::endl;
+    myCout << "    maxOverlapRemovalEtaCutValue        = " << std::dec << m_correlationParameter.maxOverlapRemovalEtaCutValue << std::endl;
+    myCout << "    precOverlapRemovalEtaCut            = " << std::dec << m_correlationParameter.precOverlapRemovalEtaCut     << std::endl;
+    myCout << "    minOverlapRemovalPhiCutValue        = " << std::dec << m_correlationParameter.minOverlapRemovalPhiCutValue << std::endl;
+    myCout << "    maxOverlapRemovalPhiCutValue        = " << std::dec << m_correlationParameter.maxOverlapRemovalPhiCutValue << std::endl;
+    myCout << "    precOverlapRemovalPhiCut            = " << std::dec << m_correlationParameter.precOverlapRemovalPhiCut     << std::endl;
+    myCout << "    minOverlapRemovalDRCutValue         = " << std::dec << m_correlationParameter.minOverlapRemovalDRCutValue  << std::endl;
+    myCout << "    maxOverlapRemovalDRCutValue         = " << std::dec << m_correlationParameter.maxOverlapRemovalDRCutValue  << std::endl;
+    myCout << "    precOverlapRemovalDRCut             = " << std::dec << m_correlationParameter.precOverlapRemovalDRCut      << std::endl;
  
-    myCout << "    chargeCorrelation["<<i<<"]  = " << std::dec << m_correlationParameter.chargeCorrelation[i] << std::endl;
-    }
+    myCout << "    chargeCorrelation  = " << std::dec << m_correlationParameter.chargeCorrelation << std::endl;
 
     // reset to decimal output
     myCout << std::dec << std::endl;

--- a/L1Trigger/L1TGlobal/src/CorrelationWithOverlapRemovalTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/CorrelationWithOverlapRemovalTemplate.cc
@@ -1,0 +1,247 @@
+/**
+ * \class CorrelationWithOverlapRemovalTemplate
+ *
+ *
+ * Description: L1 Global Trigger correlation template.
+ * Includes spatial correlation for two objects of different type.
+ *
+ * Implementation:
+ *    <TODO: enter implementation details>
+ *
+ * \author: Vasile Mihai Ghete - HEPHY Vienna
+ *
+ * $Date$
+ * $Revision$
+ *
+ */
+
+// this class header
+#include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
+
+// system include files
+
+#include <iostream>
+#include <iomanip>
+
+// user include files
+//   base class
+
+// forward declarations
+
+// constructors
+//   default
+
+CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalTemplate()
+        : GlobalCondition()
+{
+
+    m_condCategory = l1t::CondCorrelation;
+    m_condType = l1t::Type2cor;
+    m_condChipNr = -1;
+
+    // there are in fact three objects
+    int nObjects = nrObjects();
+
+    if (nObjects > 0) {
+        m_objectType.reserve(nObjects);
+    }
+
+    m_cond0Category = l1t::CondNull;
+    m_cond1Category = l1t::CondNull;
+    m_cond2Category = l1t::CondNull;
+    m_cond0Index = -1;
+    m_cond1Index = -1;
+    m_cond2Index = -1;
+
+}
+
+//   from condition name
+CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalTemplate(const std::string& cName)
+        : GlobalCondition(cName)
+{
+
+    m_condCategory = l1t::CondCorrelation;
+    m_condType = l1t::Type2cor;
+    m_condChipNr = -1;
+
+    // there are in fact two objects
+    int nObjects = nrObjects();
+
+    if (nObjects > 0) {
+        m_objectType.reserve(nObjects);
+    }
+
+    m_cond0Category = l1t::CondNull;
+    m_cond1Category = l1t::CondNull;
+    m_cond2Category = l1t::CondNull;
+    m_cond0Index = -1;
+    m_cond1Index = -1;
+    m_cond2Index = -1;
+
+}
+
+//   from condition name, the category of first sub-condition, the category of the
+//   second sub-condition, the index of first sub-condition in the cor* vector,
+//   the index of second sub-condition in the cor* vector
+CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalTemplate(const std::string& cName,
+        const l1t::GtConditionCategory& cond0Cat,
+        const l1t::GtConditionCategory& cond1Cat,
+        const l1t::GtConditionCategory& cond2Cat,
+        const int cond0Index,
+        const int cond1index,
+        const int cond2index) :
+    GlobalCondition(cName),
+            m_cond0Category(cond0Cat),
+            m_cond1Category(cond1Cat),
+            m_cond2Category(cond2Cat),
+            m_cond0Index(cond0Index),
+            m_cond1Index(cond1index),
+            m_cond2Index(cond2index)
+
+{
+
+    m_condCategory = l1t::CondCorrelationWithOverlapRemoval;
+    m_condType = l1t::Type2corWithOverlapRemoval;
+    m_condChipNr = -1;
+
+    // there are in fact two objects
+    int nObjects = nrObjects();
+
+    if (nObjects> 0) {
+        m_objectType.resize(nObjects);
+    }
+}
+
+// copy constructor
+CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalTemplate(const CorrelationWithOverlapRemovalTemplate& cp)
+        : GlobalCondition(cp.m_condName)
+{
+    copy(cp);
+}
+
+// destructor
+CorrelationWithOverlapRemovalTemplate::~CorrelationWithOverlapRemovalTemplate()
+{
+    // empty now
+}
+
+// assign operator
+CorrelationWithOverlapRemovalTemplate& CorrelationWithOverlapRemovalTemplate::operator= (const CorrelationWithOverlapRemovalTemplate& cp)
+{
+
+    copy(cp);
+    return *this;
+}
+
+// set the category of the two sub-conditions
+void CorrelationWithOverlapRemovalTemplate::setCond0Category(
+        const l1t::GtConditionCategory& condCateg) {
+
+    m_cond0Category = condCateg;
+}
+
+void CorrelationWithOverlapRemovalTemplate::setCond1Category(
+        const l1t::GtConditionCategory& condCateg) {
+
+    m_cond1Category = condCateg;
+}
+
+void CorrelationWithOverlapRemovalTemplate::setCond2Category(
+        const l1t::GtConditionCategory& condCateg) {
+
+    m_cond2Category = condCateg;
+}
+
+
+// set the index of the two sub-conditions in the cor* vector from menu
+void CorrelationWithOverlapRemovalTemplate::setCond0Index(const int& condIndex) {
+    m_cond0Index = condIndex;
+}
+
+void CorrelationWithOverlapRemovalTemplate::setCond1Index(const int& condIndex) {
+    m_cond1Index = condIndex;
+}
+
+void CorrelationWithOverlapRemovalTemplate::setCond2Index(const int& condIndex) {
+    m_cond2Index = condIndex;
+}
+
+
+// set the correlation parameters of the condition
+void CorrelationWithOverlapRemovalTemplate::setCorrelationWithOverlapRemovalParameter(
+        const CorrelationWithOverlapRemovalParameter& corrParameter) {
+
+    m_correlationParameter = corrParameter;
+
+}
+
+void CorrelationWithOverlapRemovalTemplate::print(std::ostream& myCout) const
+{
+
+    myCout << "\n  CorrelationWithOverlapRemovalTemplate print..." << std::endl;
+
+    GlobalCondition::print(myCout);
+
+    myCout << "\n  First sub-condition category:  " << m_cond0Category <<  std::endl;
+    myCout <<   "  Second sub-condition category: " << m_cond1Category <<  std::endl;
+    myCout <<   "  Third sub-condition category: " << m_cond2Category <<  std::endl;
+
+    myCout << "\n  First sub-condition index:  " << m_cond0Index <<  std::endl;
+    myCout <<   "  Second sub-condition index: " << m_cond1Index <<  std::endl;
+    myCout <<   "  Third sub-condition index: " << m_cond2Index <<  std::endl;
+
+    myCout << "\n  CorrelationWithOverlapRemoval parameters " << "[ hex ]" <<  std::endl;
+
+    for (int i=0;i<2;i++) {
+    myCout << "    Cut Type["<<i<<"]:  " << m_correlationParameter.corrCutType[i] << std::endl;
+    myCout << "    minEtaCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.minEtaCutValue[i] << std::endl;
+    myCout << "    maxEtaCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.maxEtaCutValue[i] << std::endl;
+    myCout << "    precEtaCut["<<i<<"]            = " << std::dec << m_correlationParameter.precEtaCut[i]     << std::endl;
+    myCout << "    minPhiCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.minPhiCutValue[i] << std::endl;
+    myCout << "    maxPhiCutValue["<<i<<"]        = " << std::dec << m_correlationParameter.maxPhiCutValue[i] << std::endl;
+    myCout << "    precPhiCut["<<i<<"]            = " << std::dec << m_correlationParameter.precPhiCut[i]     << std::endl;
+    myCout << "    minDRCutValue["<<i<<"]         = " << std::dec << m_correlationParameter.minDRCutValue[i]  << std::endl;
+    myCout << "    maxDRCutValue["<<i<<"]         = " << std::dec << m_correlationParameter.maxDRCutValue[i]  << std::endl;
+    myCout << "    precDRCut["<<i<<"]             = " << std::dec << m_correlationParameter.precDRCut[i]      << std::endl;
+    myCout << "    minMassCutValue["<<i<<"]       = " << std::dec << m_correlationParameter.minMassCutValue[i]<< std::endl;
+    myCout << "    maxMassCutValue["<<i<<"]       = " << std::dec << m_correlationParameter.maxMassCutValue[i]<< std::endl;
+    myCout << "    precMassCut["<<i<<"]           = " << std::dec << m_correlationParameter.precMassCut[i]    << std::endl;
+ 
+    myCout << "    chargeCorrelation["<<i<<"]  = " << std::dec << m_correlationParameter.chargeCorrelation[i] << std::endl;
+    }
+
+    // reset to decimal output
+    myCout << std::dec << std::endl;
+}
+
+void CorrelationWithOverlapRemovalTemplate::copy(const CorrelationWithOverlapRemovalTemplate& cp)
+{
+
+    m_condName     = cp.condName();
+    m_condCategory = cp.condCategory();
+    m_condType     = cp.condType();
+    m_objectType   = cp.objectType();
+    m_condGEq      = cp.condGEq();
+    m_condChipNr   = cp.condChipNr();
+
+    m_cond0Category = cp.cond0Category();
+    m_cond1Category = cp.cond1Category();
+    m_cond2Category = cp.cond2Category();
+    m_cond0Index = cp.cond0Index();
+    m_cond1Index = cp.cond1Index();
+    m_cond2Index = cp.cond2Index();
+
+    m_correlationParameter = *(cp.correlationParameter());
+
+}
+
+// output stream operator
+std::ostream& operator<<(std::ostream& os, const CorrelationWithOverlapRemovalTemplate& result)
+{
+    result.print(os);
+    return os;
+
+}
+
+
+

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -31,6 +31,7 @@
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CorrCondition.h"
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -9,6 +9,7 @@
  *
  * \author: M. Fierro            - HEPHY Vienna - ORCA version
  * \author: Vasile Mihai Ghete   - HEPHY Vienna - CMSSW version
+ * \author: Vladimir Rekovic - add correlation with overlap removal cases
  *
  * $Date$
  * $Revision$
@@ -34,6 +35,7 @@
 #include "L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CorrCondition.h"
+#include "L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h"
 
 
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
@@ -622,8 +624,6 @@ void l1t::GlobalBoard::runGTL(
                 case CondCorrelation: {
 
 
-
-
                     // get first the sub-conditions
                     const CorrelationTemplate* corrTemplate =
 	            static_cast<const CorrelationTemplate*>(itCond->second);
@@ -696,6 +696,107 @@ void l1t::GlobalBoard::runGTL(
 		    }
 
 		    //  		delete correlationCond;
+
+                
+                }
+                    break;
+                case CondCorrelationWithOverlapRemoval: {
+
+                    // get first the sub-conditions
+                    const CorrelationWithOverlapRemovalTemplate* corrTemplate =
+	            static_cast<const CorrelationWithOverlapRemovalTemplate*>(itCond->second);
+		    const GtConditionCategory cond0Categ = corrTemplate->cond0Category();
+		    const GtConditionCategory cond1Categ = corrTemplate->cond1Category();
+		    const GtConditionCategory cond2Categ = corrTemplate->cond2Category();
+		    const int cond0Ind = corrTemplate->cond0Index();
+		    const int cond1Ind = corrTemplate->cond1Index();
+		    const int cond2Ind = corrTemplate->cond1Index();
+
+		    const GlobalCondition* cond0Condition = 0;
+		    const GlobalCondition* cond1Condition = 0;
+		    const GlobalCondition* cond2Condition = 0;
+
+		    // maximum number of objects received for evaluation of l1t::Type1s condition
+		    int cond0NrL1Objects = 0;
+		    int cond1NrL1Objects = 0;
+		    int cond2NrL1Objects = 0;
+		     LogDebug("L1TGlobal") << " cond0NrL1Objects" << cond0NrL1Objects << "  cond1NrL1Objects  " << cond1NrL1Objects << "  cond2NrL1Objects  " << cond2NrL1Objects << std::endl;
+
+
+		    switch (cond0Categ) {
+			case CondMuon: {
+			    cond0Condition = &((corrMuon[iChip])[cond0Ind]);
+			}
+			    break;
+			case CondCalo: {
+                            cond0Condition = &((corrCalo[iChip])[cond0Ind]);
+			}
+			    break;
+			case CondEnergySum: {
+			    cond0Condition = &((corrEnergySum[iChip])[cond0Ind]);
+			}
+			    break;
+			default: {
+			    // do nothing, should not arrive here
+			}
+			    break;
+		    }
+
+		    switch (cond1Categ) {
+			case CondMuon: {
+			    cond1Condition = &((corrMuon[iChip])[cond1Ind]);
+			}
+			    break;
+			case CondCalo: {
+                            cond1Condition = &((corrCalo[iChip])[cond1Ind]);
+			}
+			    break;
+			case CondEnergySum: {
+			    cond1Condition = &((corrEnergySum[iChip])[cond1Ind]);
+			}
+			    break;
+			default: {
+			    // do nothing, should not arrive here
+			}
+			    break;
+		    }
+
+		    switch (cond2Categ) {
+			case CondMuon: {
+			    cond2Condition = &((corrMuon[iChip])[cond2Ind]);
+			}
+			    break;
+			case CondCalo: {
+                            cond2Condition = &((corrCalo[iChip])[cond2Ind]);
+			}
+			    break;
+			case CondEnergySum: {
+			    cond2Condition = &((corrEnergySum[iChip])[cond2Ind]);
+			}
+			    break;
+			default: {
+			    // do nothing, should not arrive here
+			}
+			    break;
+		    }
+
+		    CorrWithOverlapRemovalCondition* correlationCondWOR =
+			new CorrWithOverlapRemovalCondition(itCond->second, cond0Condition, cond1Condition, cond2Condition, this);
+
+		    correlationCondWOR->setVerbosity(m_verbosity);
+		    correlationCondWOR->setScales(&gtScales);
+		    correlationCondWOR->evaluateConditionStoreResult(iBxInEvent);
+
+		    cMapResults[itCond->first] = correlationCondWOR;
+
+		    if (m_verbosity && m_isDebugEnabled) {
+			std::ostringstream myCout;
+			correlationCondWOR->print(myCout);
+
+			LogTrace("L1TGlobal") << myCout.str() << std::endl;
+		    }
+
+		    //  		delete correlationCondWOR;
 
                 
                 }

--- a/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
@@ -71,7 +71,9 @@ constexpr entry<l1t::GtConditionType> l1GtConditionTypeStringToEnumMap[] = {
 	{"l1t::TypeMinBiasHFP1", l1t::TypeMinBiasHFP1},
 	{"l1t::TypeMinBiasHFM1", l1t::TypeMinBiasHFM1},
         {"l1t::TypeExternal", l1t::TypeExternal},
-        {0, (l1t::GtConditionType) - 1}
+        {0, (l1t::GtConditionType) - 1},
+        {"l1t::Type2corWithOverlapRemoval", l1t::Type2corWithOverlapRemoval}
+
 };
 
 // l1t::GtConditionCategory
@@ -82,7 +84,8 @@ constexpr entry<l1t::GtConditionCategory> l1GtConditionCategoryStringToEnumMap[]
   {"l1t::CondEnergySum", l1t::CondEnergySum},
   {"l1t::CondCorrelation", l1t::CondCorrelation},
   {"l1t::CondExternal", l1t::CondExternal},
-  {0, (l1t::GtConditionCategory) - 1}
+  {0, (l1t::GtConditionCategory) - 1},
+  {"l1t::CondCorrelationWithOverlapRemoval", l1t::CondCorrelationWithOverlapRemoval}
 };
 
 }

--- a/L1Trigger/L1TGlobal/src/classes.h
+++ b/L1Trigger/L1TGlobal/src/classes.h
@@ -6,5 +6,6 @@ namespace L1Trigger_L1TGlobal {
     std::vector<MuonTemplate> dummy1 ;
     std::vector<CaloTemplate> dummy2 ;
     std::vector<CorrelationTemplate> dummy3 ;
+    std::vector<CorrelationWithOverlapRemovalTemplate> dummy4 ;
   };
 }

--- a/L1Trigger/L1TGlobal/src/classes_def.xml
+++ b/L1Trigger/L1TGlobal/src/classes_def.xml
@@ -1,8 +1,12 @@
 <lcgdict>
   <class name="CorrelationTemplate"/>
+  <class name="CorrelationWithOverlapRemovalTemplate"/>
   <class name="CorrelationTemplate::CorrelationParameter"/>
+  <class name="CorrelationWithOverlapRemovalTemplate::CorrelationWithOverlapRemovalParameter"/>
   <class name="std::vector<CorrelationTemplate>"/>
   <class name="std::vector<std::vector<CorrelationTemplate> >"/>
+  <class name="std::vector<CorrelationWithOverlapRemovalTemplate>"/>
+  <class name="std::vector<std::vector<CorrelationWithOverlapRemovalTemplate> >"/>
   <class name="TriggerMenu" class_version="TriggerMenu_V01">
     <field name="m_conditionMap" transient="true" />
     <field name="m_algorithmAliasMap" mapping="blob" />
@@ -15,6 +19,7 @@
     <field name="m_vecCaloTemplate" mapping="blob" />
     <field name="m_vecCastorTemplate" mapping="blob" />
     <field name="m_vecCorrelationTemplate" mapping="blob" />
+    <field name="m_vecCorrelationWithOverlapRemovalTemplate" mapping="blob" />
     <field name="m_vecEnergySumTemplate" mapping="blob" />
     <field name="m_vecExternalTemplate" mapping="blob" />
     <field name="m_vecHfBitCountsTemplate" mapping="blob" />


### PR DESCRIPTION
New features: xml menu parser and GT emulator of correlation conditions with overlap removal.

**New:**
- classes:
  - CorrelationWithOverlapRemovalTemplate
  - CorrWithOverlapRemovalCondition
- condition type:
  - Type2corWithOverlapRemoval 
- condition category
   - condCondCorrelationWithOverlapRemoval

**Parser logic:**
- From XML menu, with help of UTM library, store all the relevant information in CorrelationWithOverlapRemovalTemplate.

**Emulator logic:**
   - Define 3 GtConditionCategories: (1st & 2nd correlation legs, and overlap-removal leg)
   - Loop leg1: over all objects of 1st correlation leg
     - Loop over all objects of leg3 (overlap-removal leg)
     - If metched with any overlap object, next leg1 object.
     - Loop leg2: over all object of 2nd correlation leg
       - Loop over all objects of leg3 (overlap-removal leg)
       - If matched with any overlap object, next leg2 object.
       - If any correlation cut pass, save leg1-leg2 object combination.

TODO: implement indexing cut for overlap-removal leg.  This should be trivial to do, extending the current CorrelationWithOverlapRemovalTemplate.

Note: Need updated UTM library.