### PR TITLE
Fixed CaloNav for iso sums

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/CaloTools.cc
+++ b/L1Trigger/L1TCalorimeter/src/CaloTools.cc
@@ -118,7 +118,7 @@ int l1t::CaloTools::calHwEtSum(int iEta,int iPhi,const std::vector<l1t::CaloTowe
       int towerIEta = l1t::CaloStage2Nav::offsetIEta(iEta,etaNr);
       int towerIPhi = l1t::CaloStage2Nav::offsetIPhi(iPhi,phiNr);
       if(abs(towerIEta)<=iEtaAbsMax){
-	const l1t::CaloTower& tower = getTower(towers,CaloTools::caloEta(towerIEta),towerIPhi);
+	const l1t::CaloTower& tower = getTower(towers,towerIEta,towerIPhi);
 	if(etMode==ECAL) hwEtSum+=tower.hwEtEm();
 	else if(etMode==HCAL) hwEtSum+=tower.hwEtHad();
 	else if(etMode==CALO) hwEtSum+=tower.hwPt();


### PR DESCRIPTION
Minor fix to the emulator to align with firmware (remnant of #567)
Affected size of the isolation window for L1EG and L1Tau when extending into HF (candidates in TT26 and beyond)
Negligible impact on performance