### PR TITLE
EMTF output muon sorting to match uGMT

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -6,6 +6,10 @@ namespace l1t {
     EMTFCollections::~EMTFCollections()
     {
       // std::cout << "Inside EMTFCollections.cc: ~EMTFCollections" << std::endl;
+      
+      // Sort by processor to match uGMT unpacked order
+      L1TMuonEndCap::sort_uGMT_muons(*regionalMuonCands_);      
+      
       event_.put(std::move(regionalMuonCands_));
       event_.put(std::move(EMTFDaqOuts_));
       event_.put(std::move(EMTFHits_));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -13,8 +13,12 @@
 
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
 
+#include "L1Trigger/L1TMuonEndCap/interface/MicroGMTConverter.h"
+
 namespace l1t {
   namespace stage2 {
+    namespace L1TMuonEndCap = ::emtf;  // use alias 'L1TMuonEndCap' for the namespace 'emtf' used in L1Trigger/L1TMuonEndCap
+	  
     class EMTFCollections : public UnpackerCollections {
     public:
     EMTFCollections(edm::Event& e) :

--- a/L1Trigger/L1TMuonEndCap/interface/MicroGMTConverter.h
+++ b/L1Trigger/L1TMuonEndCap/interface/MicroGMTConverter.h
@@ -23,6 +23,12 @@ public:
   ) const;
 
 private:
-};
+}; // End class MicroGMTConverter
+
+namespace emtf {
+  void sort_uGMT_muons(
+    l1t::RegionalMuonCandBxCollection& cands
+  );
+}
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/src/MicroGMTConverter.cc
+++ b/L1Trigger/L1TMuonEndCap/src/MicroGMTConverter.cc
@@ -100,4 +100,40 @@ void MicroGMTConverter::convert_all(
       out_cands.push_back(bx, out_cand);
     }
   }
+  
+  // Sort by processor to match uGMT unpacked order
+  emtf::sort_uGMT_muons(out_cands);
+
 }
+
+namespace emtf {
+
+void sort_uGMT_muons(
+   l1t::RegionalMuonCandBxCollection& cands
+) {
+  
+  int minBX = cands.getFirstBX();
+  int maxBX = cands.getLastBX();
+  int emtfMinProc =  0; // ME+ sector 1
+  int emtfMaxProc = 11; // ME- sector 6
+  
+  // New collection, sorted by processor to match uGMT unpacked order
+  l1t::RegionalMuonCandBxCollection* sortedCands = new l1t::RegionalMuonCandBxCollection();
+  sortedCands->clear();
+  sortedCands->setBXRange(minBX, maxBX);
+  for (int iBX = minBX; iBX <= maxBX; ++iBX) {
+    for (int proc = emtfMinProc; proc <= emtfMaxProc; proc++) {
+      for (l1t::RegionalMuonCandBxCollection::const_iterator cand = cands.begin(iBX); cand != cands.end(iBX); ++cand) {
+        if (cand->processor() != proc) continue;
+        sortedCands->push_back(iBX, *cand);
+      }
+    }
+  }
+  
+  // Return sorted collection
+  cands.clear();
+  cands = (*sortedCands);
+}
+
+} // End namespace emtf
+

--- a/L1Trigger/L1TMuonEndCap/src/MicroGMTConverter.cc
+++ b/L1Trigger/L1TMuonEndCap/src/MicroGMTConverter.cc
@@ -124,7 +124,9 @@ void sort_uGMT_muons(
   for (int iBX = minBX; iBX <= maxBX; ++iBX) {
     for (int proc = emtfMinProc; proc <= emtfMaxProc; proc++) {
       for (l1t::RegionalMuonCandBxCollection::const_iterator cand = cands.begin(iBX); cand != cands.end(iBX); ++cand) {
-        if (cand->processor() != proc) continue;
+        int cand_proc = cand->processor();
+        if (cand->trackFinderType() == l1t::tftype::emtf_neg) cand_proc += 6;
+        if (cand_proc != proc) continue;
         sortedCands->push_back(iBX, *cand);
       }
     }


### PR DESCRIPTION
Sort unpacked and emulated output RegionalMuonCandBxCollections by processor number, in ascending order, to match uGMT unpacked output.

Also exists as a branch based off central CMSSW_10_0_0:
https://github.com/abrinke1/cmssw/tree/EMTF_uGMT_muon_sorting