### PR TITLE
Add calo only workflow

### DIFF
--- a/L1Trigger/Configuration/python/SimL1CaloEmulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1CaloEmulator_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TCalorimeter.simDigis_cff import *
+
+# define a core which can be extended in customizations:
+SimL1CaloEmulator = cms.Sequence( SimL1TCalorimeter )
+
+# Emulators are configured from DB (GlobalTags)
+# but in the integration branch conffigure from static hackConditions
+from L1Trigger.L1TCalorimeter.hackConditions_cff import *

--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -177,6 +177,18 @@ def L1TReEmulFromRAWCalouGT(process):
     process.simGtStage2Digis.MuonInputTag   = cms.InputTag("gtStage2Digis","Muon")
     return process 
 
+def L1TReEmulFromRAWCalo(process):
+    process.load('L1Trigger.Configuration.SimL1CaloEmulator_cff')
+    process.L1TReEmul = cms.Sequence(process.SimL1CaloEmulator)
+    process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag('ecalDigis:EcalTriggerPrimitives')
+    process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('hcalDigis:')
+    process.L1TReEmulPath = cms.Path(process.L1TReEmul)
+    process.schedule.append(process.L1TReEmulPath)
+
+    print "# L1TReEmul sequence:  "
+    print "# {0}".format(process.L1TReEmul)
+    print "# {0}".format(process.schedule)
+    return process
 
 def L1TReEmulMCFromRAW(process):
     L1TReEmulFromRAW(process)

--- a/L1Trigger/L1TNtuples/python/L1NtupleAODCalo_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleAODCalo_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Reconstruction_cff import *
+
+from L1Trigger.L1TNtuples.l1EventTree_cfi import *
+from L1Trigger.L1TNtuples.l1RecoTree_cfi import *
+from L1Trigger.L1TNtuples.l1JetRecoTree_cfi import *
+from L1Trigger.L1TNtuples.l1MetFilterRecoTree_cfi import *
+from L1Trigger.L1TNtuples.l1ElectronRecoTree_cfi import *
+from L1Trigger.L1TNtuples.l1TauRecoTree_cfi import *
+
+L1NtupleAODCalo = cms.Sequence(
+  l1EventTree
+  +l1RecoTree
+  +l1JetRecoTree
+  +l1MetFilterRecoTree
+  +l1ElectronRecoTree
+  +l1TauRecoTree
+)
+

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMUCalo_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMUCalo_cff.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
+from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
+from L1Trigger.L1TNtuples.l1EventTree_cfi import *
+
+l1CaloTowerEmuTree = l1CaloTowerTree.clone()
+l1CaloTowerEmuTree.ecalToken = cms.untracked.InputTag("ecalDigis:EcalTriggerPrimitives")
+l1CaloTowerEmuTree.hcalToken = cms.untracked.InputTag("hcalDigis:")
+l1CaloTowerEmuTree.l1TowerToken = cms.untracked.InputTag("simCaloStage2Layer1Digis")
+l1CaloTowerEmuTree.l1ClusterToken = cms.untracked.InputTag("simCaloStage2Digis", "MP")
+
+l1UpgradeEmuTree = l1UpgradeTree.clone()
+l1UpgradeEmuTree.egToken = cms.untracked.InputTag("simCaloStage2Digis")
+l1UpgradeEmuTree.tauTokens = cms.untracked.VInputTag("simCaloStage2Digis")
+l1UpgradeEmuTree.jetToken = cms.untracked.InputTag("simCaloStage2Digis")
+l1UpgradeEmuTree.sumToken = cms.untracked.InputTag("simCaloStage2Digis")
+
+L1NtupleEMUCalo = cms.Sequence(
+  l1EventTree
+  +l1CaloTowerEmuTree
+  +l1UpgradeEmuTree
+)

--- a/L1Trigger/L1TNtuples/python/L1NtupleRAWCalo_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleRAWCalo_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TNtuples.l1EventTree_cfi import *
+from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
+from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
+
+L1NtupleRAWCalo = cms.Sequence(
+  l1EventTree
+  +l1CaloTowerTree
+  +l1UpgradeTree
+)

--- a/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
+++ b/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
@@ -37,6 +37,20 @@ def L1NtupleAOD(process):
 
     return process
 
+def L1NtupleAODCalo(process):
+
+    L1NtupleTFileOut(process)
+    L1NtupleCustomReco(process)
+
+    process.load('L1Trigger.L1TNtuples.L1NtupleAODCalo_cff')
+    process.l1ntupleaodcalo = cms.Path(
+        process.L1NtupleAODCalo
+    )
+
+    process.schedule.append(process.l1ntupleaodcalo)
+
+    return process
+
 
 def L1NtupleAOD_MC(process):
     
@@ -68,6 +82,18 @@ def L1NtupleRAW(process):
 
     return process
 
+def L1NtupleRAWCalo(process):
+
+    L1NtupleTFileOut(process)
+
+    process.load('L1Trigger.L1TNtuples.L1NtupleRAWCalo_cff')
+    process.l1ntuplerawcalo = cms.Path(
+        process.L1NtupleRAWCalo
+    )
+
+    process.schedule.append(process.l1ntuplerawcalo)
+
+    return process
 
 
 def L1NtupleEMU(process):
@@ -82,6 +108,20 @@ def L1NtupleEMU(process):
     process.schedule.append(process.l1ntupleemu)
 
     return process
+
+def L1NtupleEMUCalo(process):
+
+    L1NtupleTFileOut(process)
+
+    process.load('L1Trigger.L1TNtuples.L1NtupleEMUCalo_cff')
+    process.l1ntupleemucalo = cms.Path(
+        process.L1NtupleEMUCalo
+    )
+
+    process.schedule.append(process.l1ntupleemucalo)
+
+    return process
+
 
 def L1NtupleEMULegacy(process):
 
@@ -118,6 +158,14 @@ def L1NtupleRAWEMU(process):
 
     return process
 
+def L1NtupleRAWEMUCalo(process):
+
+    L1NtupleRAWCalo(process)
+    L1NtupleEMUCalo(process)
+
+    return process
+
+
 def L1NtupleRAWEMULegacy(process):
 
     L1NtupleRAW(process)
@@ -127,11 +175,17 @@ def L1NtupleRAWEMULegacy(process):
     return process
 
 
-
 def L1NtupleAODRAW(process):
 
     L1NtupleRAW(process)
     L1NtupleAOD(process)
+
+    return process
+
+def L1NtupleAODRAWCalo(process):
+
+    L1NtupleRAWCalo(process)
+    L1NtupleAODCalo(process)
 
     return process
 
@@ -153,12 +207,28 @@ def L1NtupleAODRAWEMU(process):
 
     return process
 
+def L1NtupleAODRAWEMUCalo(process):
+
+    L1NtupleRAWCalo(process)
+    L1NtupleEMUCalo(process)
+    L1NtupleAODCalo(process)
+
+    return process
+
 def L1NtupleAODEMU(process):
 
     L1NtupleEMU(process)
     L1NtupleAOD(process)
 
     return process
+
+def L1NtupleAODEMUCalo(process):
+
+    L1NtupleEMUCalo(process)
+    L1NtupleAODCalo(process)
+
+    return process
+
 
 def L1NtupleAODEMU_MC(process):
 


### PR DESCRIPTION
Add re-emulation and l1ntuple customisations to only run calo objects to speed up L1Ntuple production for calo trigger performance studies for 2018 running.

Replaces #651 