### PR TITLE
Phase-2 vertex finder correction

### DIFF
--- a/L1Trigger/VertexFinder/interface/RecoVertexWithTP.h
+++ b/L1Trigger/VertexFinder/interface/RecoVertexWithTP.h
@@ -17,6 +17,7 @@ class RecoVertexWithTP {
 
 public:
   // Fill useful info about tracking particle.
+  RecoVertexWithTP(const float z0);
   RecoVertexWithTP(RecoVertex& vertex, std::map<const edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>, const L1TrackTruthMatched*> trackAssociationMap);
   ~RecoVertexWithTP() {}
 

--- a/L1Trigger/VertexFinder/plugins/VertexAnalyzer.cc
+++ b/L1Trigger/VertexFinder/plugins/VertexAnalyzer.cc
@@ -495,10 +495,9 @@ void VertexAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
   cout << "Input Tracks to L1 Correlator " << numInputTracks << endl;
 
-  l1t::Vertex pvVertexFromEDM = l1tVertexFinder::getPrimaryVertex(*l1VerticesHandle);
   l1t::Vertex tdrPVVertexFromEDM = l1tVertexFinder::getPrimaryVertex(*l1VertexTDRHandle);
 
-  const size_t primaryVertexIndex = &l1tVertexFinder::getPrimaryVertex(*l1VerticesHandle) - &l1VerticesHandle->at(0);
+  const size_t primaryVertexIndex = (l1VerticesHandle->empty() ? 0 : &l1tVertexFinder::getPrimaryVertex(*l1VerticesHandle) - &l1VerticesHandle->at(0));
 
   std::vector<RecoVertexWithTP*> recoVertices;
   recoVertices.reserve(numVertices);
@@ -543,7 +542,7 @@ void VertexAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   TDRVertexBase.setZ(tdrPVVertexFromEDM.z0());
 
   RecoVertexWithTP* TDRVertex = new RecoVertexWithTP(TDRVertexBase, trackAssociationMap);
-  RecoVertexWithTP* RecoPrimaryVertex = recoVertices.at(primaryVertexIndex);
+  RecoVertexWithTP* RecoPrimaryVertex = (l1VerticesHandle->empty() ? new RecoVertexWithTP(-9999.) : recoVertices.at(primaryVertexIndex));
 
   TDRVertex->computeParameters(settings_.vx_weightedmean());
 

--- a/L1Trigger/VertexFinder/python/VertexAnalyzer_cff.py
+++ b/L1Trigger/VertexFinder/python/VertexAnalyzer_cff.py
@@ -60,7 +60,7 @@ L1TVertexAnalyzer = cms.EDAnalyzer('VertexAnalyzer',
         # Minimum number of tracks to accept vertex
         MinTracks   = cms.uint32(2),
         # Compute the z0 position of the vertex with a mean weighted with track momenta
-        WeightedMean = cms.bool(True),
+        WeightedMean = cms.bool(False),
         # Chi2 cut for the Adaptive Vertex Reconstruction Algorithm
         AVR_chi2cut = cms.double(5.),
         # TDR algorithm assumed vertex width [cm]
@@ -70,11 +70,10 @@ L1TVertexAnalyzer = cms.EDAnalyzer('VertexAnalyzer',
         # Kmeans number of clusters
         KmeansNumClusters  = cms.uint32(18),
         # DBSCAN pt threshold
-        DBSCANPtThreshold = cms.double(2.),
+        DBSCANPtThreshold = cms.double(4.),
         # DBSCAN min density tracks
-        DBSCANMinDensityTracks = cms.uint32(1),
-
-        VxMinTrackPt   = cms.double(2.)
+        DBSCANMinDensityTracks = cms.uint32(2),
+        VxMinTrackPt   = cms.double(2.5)
     ),
 
   # Debug printout

--- a/L1Trigger/VertexFinder/python/VertexProducer_cff.py
+++ b/L1Trigger/VertexFinder/python/VertexProducer_cff.py
@@ -17,7 +17,7 @@ VertexProducer = cms.EDProducer('VertexProducer',
         # Minimum number of tracks to accept vertex
         MinTracks   = cms.uint32(2),
         # Compute the z0 position of the vertex with a mean weighted with track momenta
-        WeightedMean = cms.bool(True),
+        WeightedMean = cms.bool(False),
         # Chi2 cut for the Adaptive Vertex Reconstruction Algorithm
         AVR_chi2cut = cms.double(5.),
         # TDR algorithm assumed vertex half-width [cm]
@@ -27,11 +27,10 @@ VertexProducer = cms.EDProducer('VertexProducer',
         # Kmeans number of clusters
         KmeansNumClusters  = cms.uint32(18),
         # DBSCAN pt threshold
-        DBSCANPtThreshold = cms.double(2.),
+        DBSCANPtThreshold = cms.double(4.),
         # DBSCAN min density tracks
-        DBSCANMinDensityTracks = cms.uint32(1),
-
-        VxMinTrackPt   = cms.double(2.)
+        DBSCANMinDensityTracks = cms.uint32(2),
+        VxMinTrackPt   = cms.double(2.5)
     ),
   # Debug printout
   Debug  = cms.uint32(0), #(0=none, 1=print tracks/sec, 2=show filled cells in HT array in each sector of each event, 3=print all HT cells each TP is found in, to look for duplicates, 4=print missed tracking particles by r-z filters, 5 = show debug info about duplicate track removal, 6 = show debug info about fitters)

--- a/L1Trigger/VertexFinder/src/RecoVertexWithTP.cc
+++ b/L1Trigger/VertexFinder/src/RecoVertexWithTP.cc
@@ -2,6 +2,14 @@
 
 namespace l1tVertexFinder {
 
+RecoVertexWithTP::RecoVertexWithTP(const float z0) :
+  z0_(z0),
+  pT_(0.0),
+  met_(-999.)
+{
+}
+
+
 RecoVertexWithTP::RecoVertexWithTP(RecoVertex& vertex, std::map<const edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>, const L1TrackTruthMatched*> trackAssociationMap)
 {
   z0_ = -999.;

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -154,9 +154,11 @@ void VertexFinder::DBSCAN()
     unsigned int numDensityTracks = 0;
     if (fitTracks_[i]->pt() > settings_->vx_dbscan_pt())
       numDensityTracks++;
+    else
+      continue;
     for (unsigned int k = 0; k < fitTracks_.size(); ++k) {
       iterations_++;
-      if (k != i and (fabs(fitTracks_[k]->z0() - fitTracks_[i]->z0()) < settings_->vx_distance() or (fabs(fitTracks_[i]->eta()) > 1.5 and fabs(fitTracks_[k]->z0() - fitTracks_[i]->z0()) < 0.5))) {
+      if (k != i and fabs(fitTracks_[k]->z0() - fitTracks_[i]->z0()) < settings_->vx_distance()) {
         neighbourTrackIds.insert(k);
         if (fitTracks_[k]->pt() > settings_->vx_dbscan_pt()) {
           numDensityTracks++;
@@ -177,16 +179,16 @@ void VertexFinder::DBSCAN()
           std::vector<unsigned int> neighbourTrackIds2;
           for (unsigned int k = 0; k < fitTracks_.size(); ++k) {
             iterations_++;
-            if (fabs(fitTracks_[k]->z0() - fitTracks_[id]->z0()) < settings_->vx_distance() or (fabs(fitTracks_[id]->eta()) > 1.5 and fabs(fitTracks_[k]->z0() - fitTracks_[id]->z0()) < 0.5)) {
+            if (fabs(fitTracks_[k]->z0() - fitTracks_[id]->z0()) < settings_->vx_distance()) {
               neighbourTrackIds2.push_back(k);
             }
           }
 
-          if (neighbourTrackIds2.size() >= settings_->vx_minTracks()) {
+          // if (neighbourTrackIds2.size() >= settings_->vx_minTracks()) {
             for (unsigned int id2 : neighbourTrackIds2) {
               neighbourTrackIds.insert(id2);
             }
-          }
+          // }
         }
         if (find(saved.begin(), saved.end(), id) == saved.end())
           vertex.insert(fitTracks_[id]);
@@ -435,7 +437,6 @@ void VertexFinder::AssociatePrimaryVertex(double trueZ0)
     }
   }
 }
-
 
 void VertexFinder::TDRalgorithm()
 {


### PR DESCRIPTION
This pull request reverses some changes to the phase-2 vertex finder (specifically files `src/VertexFinder.cc`, `python/VertexProducer_cff.py` and `python/VertexAnalyzer_cff.py`) that were mistakenly included in pull request #676, and caused a drop in the vertex-finding efficiency with respect to what was reported in Davide Cieri's detector note (DN2017/045) and the interim TDR.

This pull request also updates to the associated analyzer to prevent the analyzer from crashing if no vertices are reconstructed. However the change to the analyzer should not affect any downstream users of the vertex finder.