### PR TITLE
Update L1EG example script

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsProducer.cc
@@ -116,7 +116,8 @@ class L1EGCrystalClusterProducer : public edm::EDProducer {
       std::string towerMapName;
 
       // Fit function to scale L1EG Crystal Pt to Stage-2
-      TF1 ptAdjustFunc = TF1("ptAdjustFunc", "(([0] + [1]*TMath::Exp(-[2]*x))*(1./([3] + [4]*TMath::Exp(-[5]*x))))");
+      //TF1 ptAdjustFunc = TF1("ptAdjustFunc", "(([0] + [1]*TMath::Exp(-[2]*x))*(1./([3] + [4]*TMath::Exp(-[5]*x))))");
+      TF1 ptAdjustFunc = TF1("ptAdjustFunc", "[0] + [1]*TMath::Exp(-[2]*x)");
 
       class SimpleCaloHit
       {
@@ -192,12 +193,15 @@ L1EGCrystalClusterProducer::L1EGCrystalClusterProducer(const edm::ParameterSet& 
    // Fit parameters measured on 28 May 2017, using 500 MeV threshold for ECAL TPs
    // working in CMSSW 920
    // Adjustments to be applied to reco cluster pt
-   ptAdjustFunc.SetParameter( 0, 1.062166 );
-   ptAdjustFunc.SetParameter( 1, 0.298738 );
-   ptAdjustFunc.SetParameter( 2, 0.038971 );
-   ptAdjustFunc.SetParameter( 3, 0.977781 );
-   ptAdjustFunc.SetParameter( 4, -0.054748 );
-   ptAdjustFunc.SetParameter( 5, 0.044248 );
+   //ptAdjustFunc.SetParameter( 0, 1.062166 );
+   //ptAdjustFunc.SetParameter( 1, 0.298738 );
+   //ptAdjustFunc.SetParameter( 2, 0.038971 );
+   //ptAdjustFunc.SetParameter( 3, 0.977781 );
+   //ptAdjustFunc.SetParameter( 4, -0.054748 );
+   //ptAdjustFunc.SetParameter( 5, 0.044248 );
+   ptAdjustFunc.SetParameter( 0, 1.06 );
+   ptAdjustFunc.SetParameter( 1, 0.273 );
+   ptAdjustFunc.SetParameter( 2, 0.0411 );
    
    // Get tower mapping
    if (useTowerMap) {

--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsProducer.cc
@@ -117,7 +117,7 @@ class L1EGCrystalClusterProducer : public edm::EDProducer {
 
       // Fit function to scale L1EG Crystal Pt to Stage-2
       //TF1 ptAdjustFunc = TF1("ptAdjustFunc", "(([0] + [1]*TMath::Exp(-[2]*x))*(1./([3] + [4]*TMath::Exp(-[5]*x))))");
-      TF1 ptAdjustFunc = TF1("ptAdjustFunc", "[0] + [1]*TMath::Exp(-[2]*x)");
+      TF1 ptAdjustFunc = TF1("ptAdjustFunc", "([0] + [1]*TMath::Exp(-[2]*x)) * ([3] + [4]*TMath::Exp(-[5]*x))");
 
       class SimpleCaloHit
       {
@@ -202,6 +202,10 @@ L1EGCrystalClusterProducer::L1EGCrystalClusterProducer(const edm::ParameterSet& 
    ptAdjustFunc.SetParameter( 0, 1.06 );
    ptAdjustFunc.SetParameter( 1, 0.273 );
    ptAdjustFunc.SetParameter( 2, 0.0411 );
+   // Residuals
+   ptAdjustFunc.SetParameter( 3, 1.00 );
+   ptAdjustFunc.SetParameter( 4, 0.567 );
+   ptAdjustFunc.SetParameter( 5, 0.288 );
    
    // Get tower mapping
    if (useTowerMap) {

--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsProducer.cc
@@ -115,8 +115,7 @@ class L1EGCrystalClusterProducer : public edm::EDProducer {
       bool useTowerMap;
       std::string towerMapName;
 
-      // Fit function to scale L1EG Crystal Pt to Stage-2
-      //TF1 ptAdjustFunc = TF1("ptAdjustFunc", "(([0] + [1]*TMath::Exp(-[2]*x))*(1./([3] + [4]*TMath::Exp(-[5]*x))))");
+      // Fit function to scale L1EG Pt to align with electron gen pT
       TF1 ptAdjustFunc = TF1("ptAdjustFunc", "([0] + [1]*TMath::Exp(-[2]*x)) * ([3] + [4]*TMath::Exp(-[5]*x))");
 
       class SimpleCaloHit
@@ -190,15 +189,12 @@ L1EGCrystalClusterProducer::L1EGCrystalClusterProducer(const edm::ParameterSet& 
    produces<l1extra::L1EmParticleCollection>("L1EGCollectionWithCuts");
    produces< BXVector<l1t::EGamma> >("L1EGammaCollectionBXVWithCuts");
 
-   // Fit parameters measured on 28 May 2017, using 500 MeV threshold for ECAL TPs
-   // working in CMSSW 920
+
+   // Fit parameters measured on 11 Aug 2018, using 500 MeV threshold for ECAL TPs
+   // working in CMSSW 10_1_7
    // Adjustments to be applied to reco cluster pt
-   //ptAdjustFunc.SetParameter( 0, 1.062166 );
-   //ptAdjustFunc.SetParameter( 1, 0.298738 );
-   //ptAdjustFunc.SetParameter( 2, 0.038971 );
-   //ptAdjustFunc.SetParameter( 3, 0.977781 );
-   //ptAdjustFunc.SetParameter( 4, -0.054748 );
-   //ptAdjustFunc.SetParameter( 5, 0.044248 );
+   // L1EG cut working points are still a function of non-calibrated pT
+   // First order corrections
    ptAdjustFunc.SetParameter( 0, 1.06 );
    ptAdjustFunc.SetParameter( 1, 0.273 );
    ptAdjustFunc.SetParameter( 2, 0.0411 );

--- a/L1Trigger/L1CaloTrigger/python/test_L1EGCrystalCluster_cfg.py
+++ b/L1Trigger/L1CaloTrigger/python/test_L1EGCrystalCluster_cfg.py
@@ -16,12 +16,17 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 process.source = cms.Source("PoolSource",
    # Set to do test run on official Phase-2 L1T Ntuples
-   fileNames = cms.untracked.vstring('file:root://cmsxrootd.fnal.gov///store/mc/PhaseIISpring17D/SingleE_FlatPt-8to100/GEN-SIM-DIGI-RAW/PU200_90X_upgrade2023_realistic_v9-v1/120000/04B4BF1D-1E2C-E711-BE1C-7845C4FC39D1.root'),
+   fileNames = cms.untracked.vstring('file:root://cms-xrd-global.cern.ch//store/mc/PhaseIIFall17D/SingleE_FlatPt-2to100/GEN-SIM-DIGI-RAW/L1TPU200_93X_upgrade2023_realistic_v5-v1/80000/C0F55AFC-1638-E811-9A14-EC0D9A8221EE.root'),
    inputCommands = cms.untracked.vstring(
                     "keep *",
                     "drop l1tEMTFHitExtras_simEmtfDigis_CSC_HLT",
                     "drop l1tEMTFHitExtras_simEmtfDigis_RPC_HLT",
                     "drop l1tEMTFTrackExtras_simEmtfDigis__HLT",
+                    "drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT",
+                    "drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT",
+                    "drop l1tEMTFHit2016s_simEmtfDigis__HLT",
+                    "drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT",
+                    "drop l1tEMTFTrack2016s_simEmtfDigis__HLT",
    )
 )
 
@@ -30,7 +35,7 @@ process.source = cms.Source("PoolSource",
 # ---- Global Tag :
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '100X_upgrade2023_realistic_v1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '93X_upgrade2023_realistic_v5', '')
 
 # Choose a 2023 geometry!
 process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')


### PR DESCRIPTION
Updated L1EG pT calibrations to align with gen electron pT instead of Stage-2 (Phase-I).  The change in calibration results in approximately a 2% decrease in pT across the entire reco pT spectrum.  This calibration should improve all studies using these as input objects.

The L1 Menu team, @mcepeda and other, can expect a small shift in efficiency turn-on and rate adjustment accordingly.  

Also, updating example script.