### PR TITLE
Update to Calo Layer 2 data vs emulator comparison

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
@@ -308,6 +308,12 @@ void L1TStage2CaloLayer2Comp::produce (
   edm::LogProblem("l1tcalol2ebec")
     << "Processing event " << e.id() << std::endl;
 
+  if(caloTowerDataCol->size()==0){
+    edm::LogProblem("l1tcalol2ebec")
+      << "Empty caloTowers. Skipping event " << std::endl;
+    return;
+  }
+
   if (!compareJets(jetDataCol, jetEmulCol)) {
     eventGood = false;
   }


### PR DESCRIPTION
Make customiseReEmulateCaloLayer2 compatible with event-by-event comparison script. 
Output comparison root file with only required (sim)caloStage2Digis. Drastically speeds up comparisons from RAW.