### PR TITLE
L1TkMuonProducer: make a null ref that can be stored, instead of a transient one

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -351,7 +351,7 @@ L1TkMuonProducer::runOnMTFCollection_v2(const edm::Handle<EMTFTrackCollection>& 
     float p4e = sqrt(0.105658369*0.105658369 + p3.mag2() );
     math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
 
-    edm::Ref< RegionalMuonCandBxCollection > l1muRef(nullptr, 0); // FIXME! The reference to the muon is null
+    edm::Ref< RegionalMuonCandBxCollection > l1muRef; // FIXME! The reference to the muon is null 
     edm::Ptr< L1TTTrackType > l1tkPtr(l1tksH, il1ttrack);
     float trkisol = -999; // FIXME: now doing as in the TP algo
     L1TkMuonParticle l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);


### PR DESCRIPTION
@l-cadamuro @bachtis
