### PR TITLE
L1 Phase2 EG development

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
@@ -7,7 +7,37 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "L1Trigger/L1CaloTrigger/interface/L1EGammaEECalibrator.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
+// we sort the clusters in pt
+bool compare_cluster_pt(const l1t::HGCalMulticluster *cl1 ,
+                        const l1t::HGCalMulticluster *cl2);
+
+bool compare_cluster_pt(const l1t::HGCalMulticluster *cl1 ,
+                        const l1t::HGCalMulticluster *cl2) {
+                          return cl1->pt() > cl2->pt();
+                        }
+
+int get_eta_bin(const l1t::HGCalMulticluster *cl) {
+  float eta_min = 1.;
+  float eta_max = 4.;
+  unsigned n_eta_bins = 150;
+  int eta_bin = floor((fabs(cl->eta()) - eta_min) / ((eta_max - eta_min)/n_eta_bins));
+  if (cl->eta() < 0) return -1*eta_bin; // bin 0 doesn't exist
+  return eta_bin;
+}
+
+
+int get_phi_bin(const l1t::HGCalMulticluster *cl) {
+  float phi_min = -M_PI;
+  float phi_max = M_PI;
+  unsigned n_phi_bins = 63;
+  return floor(fabs(reco::deltaPhi(cl->phi(), phi_min)) / ((phi_max - phi_min)/n_phi_bins));
+}
+
+pair<int, int> get_eta_phi_bin(const l1t::HGCalMulticluster *cl) {
+  return std::make_pair(get_eta_bin(cl), get_phi_bin(cl));
+}
 
 class L1EGammaEEProducer : public edm::EDProducer {
    public:
@@ -38,6 +68,9 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   iEvent.getByToken(multiclusters_token_, multiclusters_h);
   const l1t::HGCalMulticlusterBxCollection& multiclusters = *multiclusters_h;
 
+  std::vector<const l1t::HGCalMulticluster *> selected_multiclusters;
+  std::map<std::pair<int, int>, std::vector<const l1t::HGCalMulticluster *>> etaphi_bins;
+
   // here we loop on the TPGs
   for(auto cl3d = multiclusters.begin(0); cl3d != multiclusters.end(0); cl3d++) {
      // std::cout << "-- CL3D is EG: " <<  cl3d->hwQual() << "   "<< cl3d->eta() <<"   "<< cl3d->pt()<<std::endl;
@@ -54,8 +87,71 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
          eg.setHwIso(1);
          eg.setIsoEt(-1); // just temporarily as a dummy value 
          l1EgammaBxCollection->push_back(0,eg);
+         if (hw_quality == 2) {
+           selected_multiclusters.push_back(&(*cl3d));
+           auto eta_phi_bin = get_eta_phi_bin(&(*cl3d));
+           auto bucket = etaphi_bins.find(eta_phi_bin);
+           if(bucket == etaphi_bins.end()) {
+             std::vector<const l1t::HGCalMulticluster *> vec;
+             vec.push_back(&(*cl3d));
+             etaphi_bins[eta_phi_bin] = vec;
+           } else {
+             bucket->second.push_back(&(*cl3d));
+           }
+
+         }
       }
     }
+  }
+
+  // std::cout << "# of selected HGCAL multiclusters: " << selected_multiclusters.size() << std::endl;
+
+  std::sort(selected_multiclusters.begin(), selected_multiclusters.end(), compare_cluster_pt);
+  std::set<const l1t::HGCalMulticluster *> used_clusters;
+  for(auto cl3d : selected_multiclusters) {
+    if(used_clusters.find(cl3d) == used_clusters.end()) {
+      reco::Candidate::LorentzVector mom = cl3d->p4();
+      // this is not yet used
+      used_clusters.insert(cl3d);
+      auto eta_phi_bin = get_eta_phi_bin(cl3d);
+      // std::cout << " cl pt: " << cl3d->pt()
+      //           << " eta: " << cl3d->eta()
+      //           << " phi: " << cl3d->phi()
+      //           << " eta, phi bin: " << eta_phi_bin.first << "," << eta_phi_bin.second
+      //           << std::endl;
+
+      for(int eta_bin : {eta_phi_bin.first-1, eta_phi_bin.first, eta_phi_bin.first+1}) {
+        for(int phi_bin: {eta_phi_bin.second-1, eta_phi_bin.second, eta_phi_bin.second+1}) {
+          auto bucket = etaphi_bins.find(std::make_pair(eta_bin, phi_bin));
+          if(bucket != etaphi_bins.end()) {
+            // this bucket is not empty
+            for(auto other_cl_ptr: bucket->second) {
+              if(used_clusters.find(other_cl_ptr) == used_clusters.end()) {
+                if(fabs(other_cl_ptr->eta() - cl3d->eta()) < 0.02) {
+                  if(fabs(reco::deltaPhi(other_cl_ptr->phi(), cl3d->phi())) < 0.1) {
+
+                    // std::cout << "MERGE with cl pt: " << other_cl_ptr->pt()
+                    //           << " eta: " << other_cl_ptr->eta()
+                    //           << " phi: " << other_cl_ptr->phi()
+                    //           <<  std::endl;
+                    mom+=other_cl_ptr->p4();
+                    used_clusters.insert(other_cl_ptr);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      l1t::EGamma eg(mom);
+      // FIXME: full duplication with HWqual 2
+      eg.setHwQual(3);
+      eg.setHwIso(1);
+      l1EgammaBxCollection->push_back(0,eg);
+
+    }
+
+
   }
 
   iEvent.put(std::move(l1EgammaBxCollection),"L1EGammaCollectionBXVWithCuts");

--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
@@ -143,7 +143,9 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
           }
         }
       }
-      l1t::EGamma eg(mom);
+      float calib_factor = calibrator_.calibrationFactor(mom.pt(), mom.eta());
+      l1t::EGamma eg=l1t::EGamma(reco::Candidate::PolarLorentzVector(mom.pt()/calib_factor, mom.eta(), mom.phi(), 0.));
+      // l1t::EGamma eg(mom);
       // FIXME: full duplication with HWqual 2
       eg.setHwQual(3);
       eg.setHwIso(1);

--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
@@ -85,7 +85,7 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
          l1t::EGamma eg=l1t::EGamma(reco::Candidate::PolarLorentzVector(cl3d->pt()/calib_factor, cl3d->eta(), cl3d->phi(), 0.));
          eg.setHwQual(hw_quality);
          eg.setHwIso(1);
-         eg.setIsoEt(-1); // just temporarily as a dummy value 
+         eg.setIsoEt(-1); // just temporarily as a dummy value
          l1EgammaBxCollection->push_back(0,eg);
          if (hw_quality == 2) {
            selected_multiclusters.push_back(&(*cl3d));
@@ -110,7 +110,13 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   std::set<const l1t::HGCalMulticluster *> used_clusters;
   for(auto cl3d : selected_multiclusters) {
     if(used_clusters.find(cl3d) == used_clusters.end()) {
-      reco::Candidate::LorentzVector mom = cl3d->p4();
+      // reco::Candidate::LorentzVector mom = cl3d->p4();
+      float pt = cl3d->pt();
+      // we drop the Had component of the energy
+      if(cl3d->hOverE() != -1) pt = cl3d->pt()/(1+cl3d->hOverE());
+      reco::Candidate::PolarLorentzVector mom(pt, cl3d->eta(), cl3d->phi(), 0.);
+      // cl3d->pt()/(1+cl3d->hOverE())
+
       // this is not yet used
       used_clusters.insert(cl3d);
       auto eta_phi_bin = get_eta_phi_bin(cl3d);
@@ -134,7 +140,9 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
                     //           << " eta: " << other_cl_ptr->eta()
                     //           << " phi: " << other_cl_ptr->phi()
                     //           <<  std::endl;
-                    mom+=other_cl_ptr->p4();
+                    float pt_other = other_cl_ptr->pt();
+                    if(other_cl_ptr->hOverE() != -1) pt_other = other_cl_ptr->pt()/(1+other_cl_ptr->hOverE());
+                    mom+=reco::Candidate::PolarLorentzVector(pt_other, other_cl_ptr->eta(), other_cl_ptr->phi(), 0.);
                     used_clusters.insert(other_cl_ptr);
                   }
                 }

--- a/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
@@ -9,3 +9,8 @@ ntuple_TTTracks = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTrackTrigger'),
     TTTracks = cms.InputTag("TTTracksFromTracklet", "Level1TTTracks")
 )
+
+ntuple_tkEle = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
+    TkElectrons = cms.InputTag("L1TkElectrons","EG")
+)

--- a/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+ntuple_egammaEE = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleEgammaEE'),
+    EgammaEE = cms.InputTag('l1EGammaEEProducer:L1EGammaCollectionBXVWithCuts')
+)
+
+ntuple_TTTracks = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTrackTrigger'),
+    TTTracks = cms.InputTag("TTTracksFromTracklet", "Level1TTTracks")
+)

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -5,6 +5,9 @@
   <use   name="MagneticField/Engine"/>
   <use   name="MagneticField/Records"/>
   <use   name="L1Trigger/Phase2L1ParticleFlow"/>
+  <use   name="L1Trigger/L1TTrackMatch"/>
+  <use   name="Geometry/TrackerGeometryBuilder"/>
+
   <!-- <use   name="CommonTools/UtilAlgos"/>
   <use   name="SimDataFormats/CaloTest"/>
   <use   name="DataFormats/JetReco"/>

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -3,6 +3,7 @@
   <use   name="FastSimulation/BaseParticlePropagator"/>
   <use   name="MagneticField/Engine"/>
   <use   name="MagneticField/Records"/>
+  <use   name="L1Trigger/Phase2L1ParticleFlow"/>
   <!-- <use   name="CommonTools/UtilAlgos"/>
   <use   name="SimDataFormats/CaloTest"/>
   <use   name="DataFormats/JetReco"/>

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -1,0 +1,16 @@
+<library   name="L1TriggerL1CaloTriggerPlugins_test_ntuples" file="ntuples/*.cc">
+  <use   name="L1Trigger/L1THGCal"/>
+  <!-- <use   name="CommonTools/UtilAlgos"/>
+  <use   name="SimDataFormats/CaloTest"/>
+  <use   name="DataFormats/JetReco"/>
+  <use   name="Geometry/HcalTowerAlgo"/>
+  <use   name="SimDataFormats/PileupSummaryInfo"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+  <use   name="TrackPropagation/RungeKutta"/>
+  <use   name="FastSimulation/Event"/>
+  <use   name="FastSimulation/CaloGeometryTools"/>
+  <use   name="MagneticField/Engine"/>
+  <use   name="MagneticField/Records"/> -->
+  <use name="heppdt"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <library   name="L1TriggerL1CaloTriggerPlugins_test_ntuples" file="ntuples/*.cc">
   <use   name="L1Trigger/L1THGCal"/>
+  <use   name="L1Trigger/L1THGCalUtilities"/>
   <use   name="FastSimulation/BaseParticlePropagator"/>
   <use   name="MagneticField/Engine"/>
   <use   name="MagneticField/Records"/>

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -1,5 +1,8 @@
 <library   name="L1TriggerL1CaloTriggerPlugins_test_ntuples" file="ntuples/*.cc">
   <use   name="L1Trigger/L1THGCal"/>
+  <use   name="FastSimulation/BaseParticlePropagator"/>
+  <use   name="MagneticField/Engine"/>
+  <use   name="MagneticField/Records"/>
   <!-- <use   name="CommonTools/UtilAlgos"/>
   <use   name="SimDataFormats/CaloTest"/>
   <use   name="DataFormats/JetReco"/>

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgammaEE.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgammaEE.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/L1Trigger/interface/EGamma.h"
-#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+#include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 
 
 

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgammaEE.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgammaEE.cc
@@ -1,0 +1,93 @@
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+
+
+
+class L1TriggerNtupleEgammaEE : public HGCalTriggerNtupleBase
+{
+
+  public:
+    L1TriggerNtupleEgammaEE(const edm::ParameterSet& conf);
+    ~L1TriggerNtupleEgammaEE() override{};
+    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+
+  private:
+    void clear() final;
+    // HGCalTriggerTools triggerTools_;
+
+    edm::EDGetToken egamma_ee_token_;
+
+    int egammaEE_n_ ;
+    std::vector<float> egammaEE_pt_;
+    std::vector<float> egammaEE_energy_;
+    std::vector<float> egammaEE_eta_;
+    std::vector<float> egammaEE_phi_;
+    std::vector<float> egammaEE_hwQual_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+    L1TriggerNtupleEgammaEE,
+    "L1TriggerNtupleEgammaEE" );
+
+
+L1TriggerNtupleEgammaEE::
+L1TriggerNtupleEgammaEE(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf)
+{
+}
+
+void
+L1TriggerNtupleEgammaEE::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+  egamma_ee_token_ = collector.consumes<l1t::EGammaBxCollection>(conf.getParameter<edm::InputTag>("EgammaEE"));
+
+  tree.Branch("egammaEE_n",     &egammaEE_n_, "egammaEE_n/I");
+  tree.Branch("egammaEE_pt",     &egammaEE_pt_);
+  tree.Branch("egammaEE_energy", &egammaEE_energy_);
+  tree.Branch("egammaEE_eta",    &egammaEE_eta_);
+  tree.Branch("egammaEE_phi",    &egammaEE_phi_);
+  tree.Branch("egammaEE_hwQual", &egammaEE_hwQual_);
+
+}
+
+
+
+void
+L1TriggerNtupleEgammaEE::
+fill(const edm::Event& e, const edm::EventSetup& es)
+{
+
+  // retrieve towers
+  edm::Handle<l1t::EGammaBxCollection> egamma_ee_h;
+  e.getByToken(egamma_ee_token_, egamma_ee_h);
+  const l1t::EGammaBxCollection& egamma_ee_collection = *egamma_ee_h;
+
+
+  // triggerTools_.eventSetup(es);
+
+  clear();
+  for(auto egee_itr=egamma_ee_collection.begin(0); egee_itr!=egamma_ee_collection.end(0); egee_itr++) {
+    egammaEE_n_++;
+    // physical values
+    egammaEE_pt_.emplace_back(egee_itr->pt());
+    egammaEE_energy_.emplace_back(egee_itr->energy());
+    egammaEE_eta_.emplace_back(egee_itr->eta());
+    egammaEE_phi_.emplace_back(egee_itr->phi());
+    egammaEE_hwQual_.emplace_back(egee_itr->hwQual());
+  }
+}
+
+
+void
+L1TriggerNtupleEgammaEE::
+clear()
+{
+  egammaEE_n_ = 0;
+  egammaEE_pt_.clear();
+  egammaEE_energy_.clear();
+  egammaEE_eta_.clear();
+  egammaEE_phi_.clear();
+  egammaEE_hwQual_.clear();
+}

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
@@ -16,6 +16,7 @@ class L1TriggerNtupleTkElectrons : public HGCalTriggerNtupleBase
   private:
     void clear() final;
     // HGCalTriggerTools triggerTools_;
+    std::string branch_name_prefix_;
 
     edm::EDGetToken tkEle_token_;
 
@@ -44,14 +45,15 @@ L1TriggerNtupleTkElectrons::
 initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
 {
   tkEle_token_ = collector.consumes<l1t::L1TkElectronParticleCollection>(conf.getParameter<edm::InputTag>("TkElectrons"));
+  branch_name_prefix_ = conf.getUntrackedParameter<std::string>("BranchNamePrefix", "tkEle");
 
-  tree.Branch("tkEle_n",      &tkEle_n_, "tkEle_n/I");
-  tree.Branch("tkEle_pt",     &tkEle_pt_);
-  tree.Branch("tkEle_energy", &tkEle_energy_);
-  tree.Branch("tkEle_eta",    &tkEle_eta_);
-  tree.Branch("tkEle_phi",    &tkEle_phi_);
-  tree.Branch("tkEle_hwQual", &tkEle_hwQual_);
-  tree.Branch("tkEle_tkIso", &tkEle_tkIso_);
+  tree.Branch((branch_name_prefix_+"_n").c_str(),      &tkEle_n_, (branch_name_prefix_+"_n/I").c_str());
+  tree.Branch((branch_name_prefix_+"_pt").c_str(),     &tkEle_pt_);
+  tree.Branch((branch_name_prefix_+"_energy").c_str(), &tkEle_energy_);
+  tree.Branch((branch_name_prefix_+"_eta").c_str(),    &tkEle_eta_);
+  tree.Branch((branch_name_prefix_+"_phi").c_str(),    &tkEle_phi_);
+  tree.Branch((branch_name_prefix_+"_hwQual").c_str(), &tkEle_hwQual_);
+  tree.Branch((branch_name_prefix_+"_tkIso").c_str(), &tkEle_tkIso_);
 
 }
 

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
@@ -1,0 +1,96 @@
+#include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
+
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h"
+
+class L1TriggerNtupleTkElectrons : public HGCalTriggerNtupleBase
+{
+
+  public:
+    L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf);
+    ~L1TriggerNtupleTkElectrons() override{};
+    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+
+  private:
+    void clear() final;
+    // HGCalTriggerTools triggerTools_;
+
+    edm::EDGetToken tkEle_token_;
+
+    int                tkEle_n_ ;
+    std::vector<float> tkEle_pt_;
+    std::vector<float> tkEle_energy_;
+    std::vector<float> tkEle_eta_;
+    std::vector<float> tkEle_phi_;
+    std::vector<float> tkEle_hwQual_;
+    std::vector<float> tkEle_tkIso_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+    L1TriggerNtupleTkElectrons,
+    "L1TriggerNtupleTkElectrons" );
+
+
+L1TriggerNtupleTkElectrons::
+L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf)
+{
+}
+
+void
+L1TriggerNtupleTkElectrons::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+  tkEle_token_ = collector.consumes<l1t::L1TkElectronParticleCollection>(conf.getParameter<edm::InputTag>("TkElectrons"));
+
+  tree.Branch("tkEle_n",      &tkEle_n_, "tkEle_n/I");
+  tree.Branch("tkEle_pt",     &tkEle_pt_);
+  tree.Branch("tkEle_energy", &tkEle_energy_);
+  tree.Branch("tkEle_eta",    &tkEle_eta_);
+  tree.Branch("tkEle_phi",    &tkEle_phi_);
+  tree.Branch("tkEle_hwQual", &tkEle_hwQual_);
+  tree.Branch("tkEle_tkIso", &tkEle_tkIso_);
+
+}
+
+
+
+void
+L1TriggerNtupleTkElectrons::
+fill(const edm::Event& e, const edm::EventSetup& es)
+{
+
+  // retrieve towers
+  edm::Handle<l1t::L1TkElectronParticleCollection> tkEle_h;
+  e.getByToken(tkEle_token_, tkEle_h);
+  const l1t::L1TkElectronParticleCollection& tkEle_collection = *tkEle_h;
+
+
+  // triggerTools_.eventSetup(es);
+  clear();
+  for(auto tkele_itr: tkEle_collection) {
+    tkEle_n_++;
+    tkEle_pt_.emplace_back(tkele_itr.pt());
+    tkEle_energy_.emplace_back(tkele_itr.energy());
+    tkEle_eta_.emplace_back(tkele_itr.eta());
+    tkEle_phi_.emplace_back(tkele_itr.phi());
+    tkEle_hwQual_.emplace_back(tkele_itr.getEGRef()->hwQual());
+    tkEle_tkIso_.emplace_back(tkele_itr.getTrkIsol());
+  }
+}
+
+
+void
+L1TriggerNtupleTkElectrons::
+clear()
+{
+  tkEle_n_ = 0;
+  tkEle_pt_.clear();
+  tkEle_energy_.clear();
+  tkEle_eta_.clear();
+  tkEle_phi_.clear();
+  tkEle_hwQual_.clear();
+  tkEle_tkIso_.clear();
+}

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -1,4 +1,4 @@
-#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+#include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -1,0 +1,168 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "FastSimulation/BaseParticlePropagator/interface/BaseParticlePropagator.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+
+
+
+class L1TriggerNtupleTrackTrigger : public HGCalTriggerNtupleBase {
+
+  public:
+    L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf);
+    ~L1TriggerNtupleTrackTrigger() override{};
+    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+
+  private:
+    void clear() final;
+    // HGCalTriggerTools triggerTools_;
+    std::pair<float,float> propagateToCalo(const math::XYZTLorentzVector& iMom,
+                                           const math::XYZTLorentzVector& iVtx,
+                                           double iCharge,
+                                           double iBField);
+
+    edm::EDGetToken track_token_;
+
+    int l1track_n_ ;
+    std::vector<float> l1track_pt_;
+    // std::vector<float> l1track_energy_;
+    std::vector<float> l1track_eta_;
+    std::vector<float> l1track_phi_;
+    std::vector<float> l1track_chi2_;
+    std::vector<int> l1track_nStubs_;
+    std::vector<float> l1track_z0_;
+    std::vector<int> l1track_charge_;
+    std::vector<float> l1track_caloeta_;
+    std::vector<float> l1track_calophi_;
+
+    edm::ESWatcher<IdealMagneticFieldRecord> magfield_watcher_;
+    HGCalTriggerTools triggerTools_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+    L1TriggerNtupleTrackTrigger,
+    "L1TriggerNtupleTrackTrigger" );
+
+
+L1TriggerNtupleTrackTrigger::
+L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf)
+{
+}
+
+void
+L1TriggerNtupleTrackTrigger::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+  track_token_ = collector.consumes<std::vector<TTTrack< Ref_Phase2TrackerDigi_> > >(conf.getParameter<edm::InputTag>("TTTracks"));
+
+  tree.Branch("l1track_n",       &l1track_n_, "l1track_n/I");
+  tree.Branch("l1track_pt",      &l1track_pt_);
+  // tree.Branch("l1track_energy", &l1track_energy_);
+  tree.Branch("l1track_eta",     &l1track_eta_);
+  tree.Branch("l1track_phi",     &l1track_phi_);
+  tree.Branch("l1track_chi2",    &l1track_chi2_);
+  tree.Branch("l1track_nStubs",  &l1track_nStubs_);
+  tree.Branch("l1track_z0",      &l1track_z0_);
+  tree.Branch("l1track_charge",  &l1track_charge_);
+  tree.Branch("l1track_caloeta", &l1track_caloeta_);
+  tree.Branch("l1track_calophi", &l1track_calophi_);
+
+}
+
+
+
+void
+L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& es) {
+
+  // the L1Tracks
+  edm::Handle<std::vector< L1TTTrackType >> l1TTTrackHandle;
+  ev.getByToken(track_token_, l1TTTrackHandle);
+
+  float fBz = 0;
+  if(magfield_watcher_.check(es)) {
+    edm::ESHandle<MagneticField> magfield;
+    es.get<IdealMagneticFieldRecord>().get(magfield);
+    // aField_ = &(*magfield);
+    fBz = magfield->inTesla(GlobalPoint(0,0,0)).z();
+  }
+
+  triggerTools_.eventSetup(es);
+
+  clear();
+  for (auto trackIter = l1TTTrackHandle->begin(); trackIter != l1TTTrackHandle->end(); ++trackIter) {
+    l1track_n_++;
+    // NOTE: filter on fabs(eta) in EE to reduce the size of the collection
+    if(fabs(trackIter->getMomentum().eta()) < 1.3) continue;
+    // physical values
+
+    l1track_pt_.emplace_back(trackIter->getMomentum().perp());
+    // l1track_energy_.emplace_back(trackIter->energy());
+    l1track_eta_.emplace_back(trackIter->getMomentum().eta());
+    l1track_phi_.emplace_back(trackIter->getMomentum().phi());
+    l1track_chi2_.emplace_back(trackIter->getChi2());
+    l1track_nStubs_.emplace_back(trackIter->getStubRefs().size());
+    // FIXME: need to be configuratble?
+    int nParam_ = 4;
+    float z0   = trackIter->getPOCA(nParam_).z(); //cm
+    int charge = trackIter->getRInv() > 0 ? +1 : -1;
+
+    reco::Candidate::PolarLorentzVector p4p(trackIter->getMomentum().perp(),
+                                            trackIter->getMomentum().eta(),
+                                            trackIter->getMomentum().phi(), 0); // no mass ?
+    reco::Particle::LorentzVector p4(p4p.X(), p4p.Y(), p4p.Z(), p4p.E());
+    reco::Particle::Point vtx(0.,0.,z0);
+
+    auto caloetaphi = propagateToCalo(p4, math::XYZTLorentzVector(0.,0.,z0,0.), charge, fBz);
+    l1track_z0_.emplace_back(z0);
+    l1track_charge_.emplace_back(charge);
+    l1track_caloeta_.emplace_back(caloetaphi.first);
+    l1track_calophi_.emplace_back(caloetaphi.second);
+  }
+}
+
+
+void
+L1TriggerNtupleTrackTrigger::clear() {
+  l1track_n_ = 0;
+  l1track_pt_.clear();
+  // l1track_energy_.clear();
+  l1track_eta_.clear();
+  l1track_phi_.clear();
+  l1track_chi2_.clear();
+  l1track_nStubs_.clear();
+  l1track_z0_.clear();
+  l1track_charge_.clear();
+  l1track_caloeta_.clear();
+  l1track_calophi_.clear();
+
+}
+
+
+
+
+// #include "FastSimulation/Particle/interface/RawParticle.h"
+
+std::pair<float,float> L1TriggerNtupleTrackTrigger::propagateToCalo(const math::XYZTLorentzVector& iMom,
+                                                                    const math::XYZTLorentzVector& iVtx,
+                                                                    double iCharge,
+                                                                    double iBField) {
+    BaseParticlePropagator particle = BaseParticlePropagator(RawParticle(iMom,iVtx),0.,0.,iBField);
+    particle.setCharge(iCharge);
+    // particle.propagateToEcalEntrance(false);
+    particle.setPropagationConditions(129.0 , triggerTools_.getLayerZ(1) , false);
+    particle.propagate();
+    // math::XYZVector point  = particle.vertex();
+    // math::XYZVector point = math::XYZVector(particle.vertex())+math::XYZTLorentzVector(particle.momentum()).Vect().Unit()*ecalShowerDepth;
+    return std::make_pair(particle.vertex().eta(), particle.vertex().phi());
+}

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -12,7 +12,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "FastSimulation/BaseParticlePropagator/interface/BaseParticlePropagator.h"
+#include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -138,8 +138,8 @@ L1TkElectronTrackProducer::L1TkElectronTrackProducer(const edm::ParameterSet& iC
    DRmin = (float)iConfig.getParameter<double>("DRmin");
    DRmax = (float)iConfig.getParameter<double>("DRmax");
    DeltaZ = (float)iConfig.getParameter<double>("DeltaZ");
-   maxChi2IsoTracks = iConfig.getUntrackedParameter<double>("maxChi2IsoTracks" , 9999999);
-   minNStubsIsoTracks = iConfig.getUntrackedParameter<int>("minNStubsIsoTracks", 0);
+   maxChi2IsoTracks = iConfig.getParameter<double>("maxChi2IsoTracks");
+   minNStubsIsoTracks = iConfig.getParameter<int>("minNStubsIsoTracks");
    // cut applied on the isolation (if this number is <= 0, no cut is applied)
    IsoCut = (float)iConfig.getParameter<double>("IsoCut");
    RelativeIsolation = iConfig.getParameter<bool>("RelativeIsolation");

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -110,7 +110,6 @@ class L1TkElectronTrackProducer : public edm::EDProducer {
         std::vector<double> dPhiCutoff;
         std::vector<double> dRCutoff;
         float dEtaCutoff;
-        bool debug;
 
         const edm::EDGetTokenT< EGammaBxCollection > egToken;
         const edm::EDGetTokenT< std::vector< TTTrack< Ref_Phase2TrackerDigi_ > > > trackToken;
@@ -152,10 +151,6 @@ L1TkElectronTrackProducer::L1TkElectronTrackProducer(const edm::ParameterSet& iC
    dPhiCutoff      = iConfig.getParameter< std::vector<double> >("TrackEGammaDeltaPhi");
    dRCutoff        = iConfig.getParameter< std::vector<double> >("TrackEGammaDeltaR");
    dEtaCutoff      = (float)iConfig.getParameter<double>("TrackEGammaDeltaEta");
-
-   debug = iConfig.getUntrackedParameter<bool>("debug", false);
-
-   if(debug) std::cout << "CONSTRUCTOR: " << maxChi2IsoTracks << " , " << minNStubsIsoTracks << std::endl;
 
    produces<L1TkElectronParticleCollection>(label);
 }
@@ -233,7 +228,6 @@ L1TkElectronTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
       itr++;
     }
     if (itrack >= 0)  {
-      if(debug) std::cout << "  Matched to track: " << itrack << std::endl;
       edm::Ptr< L1TTTrackType > matchedL1TrackPtr(L1TTTrackHandle, itrack);
 
       const math::XYZTLorentzVector P4 = egIter -> p4() ;
@@ -261,8 +255,6 @@ L1TkElectronTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
 	if (trkisol <= IsoCut) result -> push_back( trkEm );
       }
 
-    } else {
-      if(debug) std::cout << " not matched!" << std::endl;
     }
 
   } // end loop over EGamma objects
@@ -329,19 +321,13 @@ L1TkElectronTrackProducer::isolation(const edm::Handle<L1TTTrackCollectionType> 
   edm::Ptr< L1TTTrackType > matchedTrkPtr (trkHandle, match_index) ;
   L1TTTrackCollectionType::const_iterator trackIter;
 
-  if(debug) std::cout << "# of tracks: " << trkHandle->size() << " matched idx: " << match_index << std::endl;
   float sumPt = 0.0;
   int itr = 0;
   for (trackIter = trkHandle->begin(); trackIter != trkHandle->end(); ++trackIter) {
-    if(debug) std::cout << " -- itr: " << itr << std::endl;
     if (itr++ != match_index) {
-      if(debug) std::cout << "   chi2: " << trackIter->getChi2() << " (" << maxChi2IsoTracks << ")"
-                << " pt: " << trackIter->getMomentum().perp() << " (" << PTMINTRA << ")"
-                << " #stubs: " << trackIter->getStubRefs().size() << " (" << minNStubsIsoTracks << ")" << std::endl;
       if (trackIter->getChi2() > maxChi2IsoTracks ||
           trackIter->getMomentum().perp() <= PTMINTRA ||
           trackIter->getStubRefs().size() < minNStubsIsoTracks) {
-            if(debug) std::cout << "    rejecting this one! " << std::endl;
             continue;
           }
 
@@ -355,11 +341,9 @@ L1TkElectronTrackProducer::isolation(const edm::Handle<L1TTTrackCollectionType> 
 
       if (dR > DRmin && dR < DRmax && dZ < DeltaZ && trackIter->getMomentum().perp() > PTMINTRA) {
 	       sumPt += trackIter->getMomentum().perp();
-         if(debug) std::cout << " new sumPt: " << sumPt << std::endl;
       }
     }
   }
-  if(debug) std::cout << " return sumPt: " << sumPt << std::endl;
 
   return sumPt;
 }

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -61,6 +61,10 @@ L1TkElectronsHGC.L1EGammaInputTag = cms.InputTag("l1EGammaEEProducer","L1EGammaC
 L1TkElectronsHGC.IsoCut = cms.double(-0.1)
 
 L1TkIsoElectronsHGC=L1TkElectronsHGC.clone()
+L1TkIsoElectronsHGC.DRmax = cms.double(0.4)
+L1TkIsoElectronsHGC.DeltaZ = cms.double(1.0)
+L1TkIsoElectronsHGC.maxChi2IsoTracks = cms.double(100)
+L1TkIsoElectronsHGC.minNStubsIsoTracks = cms.int32(4)
 L1TkIsoElectronsHGC.IsoCut = cms.double(0.30)
 
 L1TkElectronsLooseHGC = L1TkElectronsHGC.clone()

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -25,6 +25,8 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
         PTMINTRA = cms.double( 2. ),	# in GeV
 	DRmin = cms.double( 0.03),
 	DRmax = cms.double( 0.2 ),
+        maxChi2IsoTracks = cms.double(1e10), # max chi2 cut for a track to be considered for isolation computation
+        minNStubsIsoTracks = cms.int32(0), # min cut on # of stubs for a track to be considered for isolation computation
 	DeltaZ = cms.double( 0.6 )    # in cm. Used for tracks to be used isolation calculation
 )
 L1TkIsoElectrons = L1TkElectrons.clone()


### PR DESCRIPTION
The PR implements some of the changes presented [EG Phase2 talk @ CIEMAT workshop](https://indico.cern.ch/event/791517/contributions/3341340/attachments/1818880/2975405/19-03-25_EGPerf_L1TWkshp_v1.pdf).

1. Brem recovery and cluster merging (will need further tuning once EG ID will be tuned for new geometry)
2. Hadron energy cleaning for HGC clusters passing EG ID.
3. Equip electron track matching producer to implement cuts on track quality: # of stubs and chi2
   
**NOTE I:** Point (1) and (2) will go in EG objects with `hwQual == 3` 

**NOTE II**: Since this version `hwQual > 2` will result in duplicated clusters, please require equality i.e `hwQual == 2` or `hwQual ==  3`.

**NOTE III**: the default configurations in the `process.L1simulation_step` have not yet been changed....stay tuned.

In parallel (but not very relevant for the menu performance studies) some of the EG analysis code is pushed in the integration branch to ease maintenance.




