### PR TITLE
Better interface for muon track addresses in L1Tntuples

### DIFF
--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -10,6 +10,7 @@ namespace l1t {
       static void fillRegionalMuonCand(RegionalMuonCand&, uint64_t, int, tftype);
       static void generatePackedDataWords(const RegionalMuonCand&, uint32_t&, uint32_t&);
       static uint64_t generate64bitDataWord(const RegionalMuonCand&);
+      static int generateRawTrkAddress(const RegionalMuonCand&);
 
       static const unsigned ptMask_ = 0x1FF;
       static const unsigned ptShift_ = 0;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
@@ -30,7 +30,7 @@ namespace L1Analysis
       tfMuonWh.clear();
       tfMuonTrAdd.clear();
       tfMuonDecodedTrAdd.clear();
-      tfMuonRawTrAdd.clear();
+      tfMuonHwTrAdd.clear();
     }
 
     unsigned short int nTfMuons;
@@ -49,7 +49,7 @@ namespace L1Analysis
     std::vector<short int> tfMuonWh;
     std::vector<short int> tfMuonTrAdd;
     std::vector<std::map<std::string, int>> tfMuonDecodedTrAdd;
-    std::vector<int> tfMuonRawTrAdd;
+    std::vector<int> tfMuonHwTrAdd;
   };
 }
 #endif

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
@@ -3,6 +3,7 @@
 
 #include "L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h"
 #include <vector>
+#include <map>
 
 namespace L1Analysis
 {
@@ -28,6 +29,8 @@ namespace L1Analysis
       tfMuonBx.clear();
       tfMuonWh.clear();
       tfMuonTrAdd.clear();
+      tfMuonDecodedTrAdd.clear();
+      tfMuonRawTrAdd.clear();
     }
 
     unsigned short int nTfMuons;
@@ -45,7 +48,8 @@ namespace L1Analysis
     std::vector<short int> tfMuonBx;
     std::vector<short int> tfMuonWh;
     std::vector<short int> tfMuonTrAdd;
-    std::vector<short int> tfMuonRawTrAdd;
+    std::vector<std::map<std::string, int>> tfMuonDecodedTrAdd;
+    std::vector<int> tfMuonRawTrAdd;
   };
 }
 #endif

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
@@ -1,6 +1,7 @@
 #ifndef __L1Analysis_L1AnalysisL1UpgradeTfMuonDataFormat_H__
 #define __L1Analysis_L1AnalysisL1UpgradeTfMuonDataFormat_H__
 
+#include "L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h"
 #include <vector>
 
 namespace L1Analysis
@@ -9,7 +10,7 @@ namespace L1Analysis
   {
     L1AnalysisL1UpgradeTfMuonDataFormat(){ Reset();};
     ~L1AnalysisL1UpgradeTfMuonDataFormat(){};
-    
+
     void Reset()
     {
       nTfMuons = 0;
@@ -28,7 +29,7 @@ namespace L1Analysis
       tfMuonWh.clear();
       tfMuonTrAdd.clear();
     }
-   
+
     unsigned short int nTfMuons;
     std::vector<short int> tfMuonHwPt;
     std::vector<short int> tfMuonHwEta;
@@ -44,7 +45,7 @@ namespace L1Analysis
     std::vector<short int> tfMuonBx;
     std::vector<short int> tfMuonWh;
     std::vector<short int> tfMuonTrAdd;
-  }; 
+    std::vector<short int> tfMuonRawTrAdd;
+  };
 }
 #endif
-

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h
@@ -49,7 +49,7 @@ namespace L1Analysis
     std::vector<short int> tfMuonWh;
     std::vector<short int> tfMuonTrAdd;
     std::vector<std::map<std::string, int>> tfMuonDecodedTrAdd;
-    std::vector<int> tfMuonHwTrAdd;
+    std::vector<short int> tfMuonHwTrAdd;
   };
 }
 #endif

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
@@ -26,6 +26,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
         l1upgradetfmuon_.tfMuonTrackFinderType.push_back(it->trackFinderType());
         l1upgradetfmuon_.tfMuonHwHF.push_back(it->hwHF());
         l1upgradetfmuon_.tfMuonBx.push_back(ibx);
+        std::map<std::string, int> decoded_track_address;
         if (it->trackFinderType() == l1t::tftype::bmtf) {
             int detSide = it->trackSubAddress(l1t::RegionalMuonCand::kWheelSide);
             int wheelNum = it->trackSubAddress(l1t::RegionalMuonCand::kWheelNum);
@@ -40,7 +41,28 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
             l1upgradetfmuon_.tfMuonTrAdd.push_back(stat2);
             l1upgradetfmuon_.tfMuonTrAdd.push_back(stat3);
             l1upgradetfmuon_.tfMuonTrAdd.push_back(stat4);
+
+            decoded_track_address["wheel"] = wheel;
+            decoded_track_address["station1"] = stat1;
+            decoded_track_address["station2"] = stat2;
+            decoded_track_address["station3"] = stat3;
+            decoded_track_address["station4"] = stat4;
+        } else if (it->trackFinderType() == l1t::omtf_neg || it->trackFinderType() == l1t::omtf_pos) {
+          decoded_track_address["kLayers"] = it->trackSubAddress(l1t::RegionalMuonCand::kLayers);
+          decoded_track_address["kWeight"] = it->trackSubAddress(l1t::RegionalMuonCand::kWeight);
+        } else if (it->trackFinderType() == l1t::emtf_neg || it->trackFinderType() == l1t::emtf_pos) {
+          decoded_track_address["kME1Seg"] = it->trackSubAddress(l1t::RegionalMuonCand::kME1Seg);
+          decoded_track_address["kME1Ch"] = it->trackSubAddress(l1t::RegionalMuonCand::kME1Ch);
+          decoded_track_address["kME2Seg"] = it->trackSubAddress(l1t::RegionalMuonCand::kME2Seg);
+          decoded_track_address["kME2Ch"] = it->trackSubAddress(l1t::RegionalMuonCand::kME2Ch);
+          decoded_track_address["kME3Seg"] = it->trackSubAddress(l1t::RegionalMuonCand::kME3Seg);
+          decoded_track_address["kME3Ch"] = it->trackSubAddress(l1t::RegionalMuonCand::kME3Ch);
+          decoded_track_address["kME4Seg"] = it->trackSubAddress(l1t::RegionalMuonCand::kME4Seg);
+          decoded_track_address["kME4Ch"] = it->trackSubAddress(l1t::RegionalMuonCand::kME4Ch);
+          decoded_track_address["kTrkNum"] = it->trackSubAddress(l1t::RegionalMuonCand::kTrkNum);
+          decoded_track_address["kBX"] = it->trackSubAddress(l1t::RegionalMuonCand::kBX);
         }
+        l1upgradetfmuon_.tfMuonDecodedTrAdd.push_back(decoded_track_address);
         l1upgradetfmuon_.tfMuonRawTrAdd.push_back(l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it));
 
         l1upgradetfmuon_.nTfMuons++;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
@@ -63,7 +63,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
           decoded_track_address["kBX"] = it->trackSubAddress(l1t::RegionalMuonCand::kBX);
         }
         l1upgradetfmuon_.tfMuonDecodedTrAdd.push_back(decoded_track_address);
-        l1upgradetfmuon_.tfMuonRawTrAdd.push_back(l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it));
+        l1upgradetfmuon_.tfMuonHwTrAdd.push_back(l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it));
 
         l1upgradetfmuon_.nTfMuons++;
       }

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
@@ -14,11 +14,10 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
   for (int ibx = muon.getFirstBX(); ibx <= muon.getLastBX(); ++ibx) {
     for (l1t::RegionalMuonCandBxCollection::const_iterator it = muon.begin(ibx); it != muon.end(ibx) && l1upgradetfmuon_.nTfMuons < maxL1UpgradeTfMuon; ++it){
       if (it->hwPt() > 0) {
-	
         l1upgradetfmuon_.tfMuonHwPt.push_back(it->hwPt());
         l1upgradetfmuon_.tfMuonHwEta.push_back(it->hwEta());
         l1upgradetfmuon_.tfMuonHwPhi.push_back(it->hwPhi());
-	l1upgradetfmuon_.tfMuonGlobalPhi.push_back(l1t::MicroGMTConfiguration::calcGlobalPhi(it->hwPhi(),it->trackFinderType(),it->processor()));	
+        l1upgradetfmuon_.tfMuonGlobalPhi.push_back(l1t::MicroGMTConfiguration::calcGlobalPhi(it->hwPhi(),it->trackFinderType(),it->processor()));
         l1upgradetfmuon_.tfMuonHwSign.push_back(it->hwSign());
         l1upgradetfmuon_.tfMuonHwSignValid.push_back(it->hwSignValid());
         l1upgradetfmuon_.tfMuonHwQual.push_back(it->hwQual());
@@ -27,19 +26,25 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
         l1upgradetfmuon_.tfMuonTrackFinderType.push_back(it->trackFinderType());
         l1upgradetfmuon_.tfMuonHwHF.push_back(it->hwHF());
         l1upgradetfmuon_.tfMuonBx.push_back(ibx);
-        std::map<int, int>  trAdd;
-        trAdd = it->trackAddress();
-        int wheel = pow(-1,trAdd[0]) * trAdd[1];
-        l1upgradetfmuon_.tfMuonWh.push_back(wheel);
-        l1upgradetfmuon_.tfMuonTrAdd.push_back(trAdd[2]);
-        l1upgradetfmuon_.tfMuonTrAdd.push_back(trAdd[3]);
-        l1upgradetfmuon_.tfMuonTrAdd.push_back(trAdd[4]);
-        l1upgradetfmuon_.tfMuonTrAdd.push_back(trAdd[5]);
+        if (it->trackFinderType() == l1t::tftype::bmtf) {
+            int detSide = it->trackSubAddress(l1t::RegionalMuonCand::kWheelSide);
+            int wheelNum = it->trackSubAddress(l1t::RegionalMuonCand::kWheelNum);
+            int stat1 = it->trackSubAddress(l1t::RegionalMuonCand::kStat1);
+            int stat2 = it->trackSubAddress(l1t::RegionalMuonCand::kStat2);
+            int stat3 = it->trackSubAddress(l1t::RegionalMuonCand::kStat3);
+            int stat4 = it->trackSubAddress(l1t::RegionalMuonCand::kStat4);
 
+            int wheel = pow(-1,detSide) * wheelNum;
+            l1upgradetfmuon_.tfMuonWh.push_back(wheel);
+            l1upgradetfmuon_.tfMuonTrAdd.push_back(stat1);
+            l1upgradetfmuon_.tfMuonTrAdd.push_back(stat2);
+            l1upgradetfmuon_.tfMuonTrAdd.push_back(stat3);
+            l1upgradetfmuon_.tfMuonTrAdd.push_back(stat4);
+        }
+        l1upgradetfmuon_.tfMuonRawTrAdd.push_back(l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it));
 
         l1upgradetfmuon_.nTfMuons++;
       }
     }
   }
 }
-


### PR DESCRIPTION
Hi,

I noticed that the interface for the muon track addresses in the L1Tntuples was broken (for non-BMTF addresses) and clunky. This PR adds new fields, one contains the raw track address for use by experts the other stores the decoded track addresses with improved semantics.

@rekovic, please let me know if I should target a different branch, I wasn't sure if there's a more recent integration branch.

This probably is also of interest to @panoskatsoulis, @gkaratha, and @abrinke1.

Cheers,
Dinyar