### PR TITLE
Fixes to new EG standalone objects

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaEEProducer.cc
@@ -122,6 +122,8 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
       // we drop the Had component of the energy
       if(cl3d->hOverE() != -1) pt = cl3d->pt()/(1+cl3d->hOverE());
       reco::Candidate::PolarLorentzVector mom(pt, cl3d->eta(), cl3d->phi(), 0.);
+      reco::Candidate::PolarLorentzVector mom_eint(cl3d->iPt(l1t::HGCalMulticluster::EnergyInterpretation::EM), cl3d->eta(), cl3d->phi(), 0.);
+
       // cl3d->pt()/(1+cl3d->hOverE())
 
       // this is not yet used
@@ -150,6 +152,7 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
                     float pt_other = other_cl_ptr->pt();
                     if(other_cl_ptr->hOverE() != -1) pt_other = other_cl_ptr->pt()/(1+other_cl_ptr->hOverE());
                     mom+=reco::Candidate::PolarLorentzVector(pt_other, other_cl_ptr->eta(), other_cl_ptr->phi(), 0.);
+                    mom_eint+=reco::Candidate::PolarLorentzVector(other_cl_ptr->iPt(l1t::HGCalMulticluster::EnergyInterpretation::EM), other_cl_ptr->eta(), other_cl_ptr->phi(), 0.);
                     used_clusters.insert(other_cl_ptr);
                   }
                 }
@@ -165,6 +168,13 @@ void L1EGammaEEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
       eg.setHwQual(3);
       eg.setHwIso(1);
       l1EgammaBxCollection->push_back(0,eg);
+
+      l1t::EGamma eg_emint_brec=l1t::EGamma(reco::Candidate::PolarLorentzVector(mom_eint.pt(), mom_eint.eta(), mom_eint.phi(), 0.));
+      // l1t::EGamma eg(mom);
+      // FIXME: full duplication with HWqual 2
+      eg_emint_brec.setHwQual(5);
+      eg_emint_brec.setHwIso(1);
+      l1EgammaBxCollection->push_back(0,eg_emint_brec);
 
     }
 

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -108,7 +108,7 @@ histoThreshold_C3d_params.type_multicluster = cms.string('HistoThresholdC3d')
 energy_interpretations_em = cms.PSet(type = cms.string('HGCalTriggerClusterInterpretationEM'),
                                      # layer_containment_corrs = cms.vdouble(0., 0., 1.6144949, 0.92495334, 1.0820811, 0.9753549, 0.9742881, 1.0634482, 1.0599478, 0.9376349, 0.92587173, 0.8003076, 1.0417082, 1.7032381, 2.),
                                      layer_containment_corrs=cms.vdouble(0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.),
-                                     scale_correction_coeff = cms.vdouble(34.20, -12.59),
+                                     scale_correction_coeff = cms.vdouble(0, 0),
                                      dr_bylayer = cms.vdouble([0.015]*15)
                                      )
 


### PR DESCRIPTION
  * Rollback eta calibration until it is better understood for this version of the clusters.
  * Run Brem recovery using EM interpreted energy (`hwQual==5`)

