### PR TITLE
Small fix to NNPFTau for MenuTree

### DIFF
--- a/L1Trigger/L1TCommon/test/rerun_PhaseIITreeProducer_MenuTree_106.py
+++ b/L1Trigger/L1TCommon/test/rerun_PhaseIITreeProducer_MenuTree_106.py
@@ -26,7 +26,6 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(100)
 )
-
 #process.Timing = cms.Service("Timing",
           #summaryOnly = cms.untracked.bool(False),
           #useJobReport = cms.untracked.bool(True)

--- a/L1Trigger/L1TCommon/test/rerun_PhaseIITreeProducer_MenuTree_106.py
+++ b/L1Trigger/L1TCommon/test/rerun_PhaseIITreeProducer_MenuTree_106.py
@@ -1,0 +1,131 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: repr --processName=REPR --python_filename=reprocess_test_10_5_0_pre1.py --no_exec -s L1 --datatier GEN-SIM-DIGI-RAW -n 2 --era Phase2 --eventcontent FEVTDEBUGHLT --filein root://cms-xrd-global.cern.ch//store/mc/PhaseIIMTDTDRAutumn18DR/DYToLL_M-50_14TeV_pythia8/FEVT/PU200_pilot_103X_upgrade2023_realistic_v2_ext4-v1/280000/FF5C31D5-D96E-5E48-B97F-61A0E00DF5C4.root --conditions 103X_upgrade2023_realistic_v2 --beamspot HLLHC14TeV --geometry Extended2023D28 --fileout file:step2_2ev_reprocess_slim.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('REPR',eras.Phase2C8_trigger)
+#process = cms.Process('REPR',eras.Phase2C4_timing_layer_bar)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+#process.Timing = cms.Service("Timing",
+          #summaryOnly = cms.untracked.bool(False),
+          #useJobReport = cms.untracked.bool(True)
+#)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+#'/store/mc/PhaseIITDRSpring19DR/BsToPhiPhi_4K_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/PU200_106X_upgrade2023_realistic_v3-v1/100000/FDA1645D-3E0C-D741-8BF9-37BB51695A3A.root',
+#'/store/mc/PhaseIITDRSpring19DR/Mu_FlatPt2to100-pythia8-gun/GEN-SIM-DIGI-RAW/PU200_106X_upgrade2023_realistic_v3-v2/70000/00251490-BA54-A943-8D8D-BECB717666B9.root'
+#'/store/mc/PhaseIITDRSpring19DR/QCD_Pt_0_1000_14TeV_TuneCUETP8M1/GEN-SIM-DIGI-RAW/PU200_106X_upgrade2023_realistic_v3-v2/40001/BC1962BA-32ED-5041-A661-F6B2C00197CA.root'
+#'/store/mc/PhaseIITDRSpring19DR/QCD_Pt_0_1000_14TeV_TuneCUETP8M1/GEN-SIM-DIGI-RAW/PU200_106X_upgrade2023_realistic_v3-v2/40001/06EDBCA3-D981-824A-A848-AC58EC99DF60.root'
+#'/store/mc/PhaseIITDRSpring19DR/VBF_HToInvisible_M125_TuneCP5_14TeV_powheg_pythia8/GEN-SIM-DIGI-RAW/PU200_106X_upgrade2023_realistic_v3-v1/270000/F98E8635-C98A-4641-9834-44F48B9D51AA.root'
+
+'/store/mc/PhaseIITDRSpring19DR/DarkSUSY_mH_125_mGammaD_20_cT_1000_TuneCP5_14TeV_pythia8/GEN-SIM-DIGI-RAW/PU200_106X_upgrade2023_realistic_v3-v2/30000/E826893E-2E54-524E-A467-137536257D90.root'
+
+),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('repr nevts:2'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:step2_2ev_reprocess_slim.root'),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, '103X_upgrade2023_realistic_v2', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+process.GlobalTag = GlobalTag(process.GlobalTag, '103X_upgrade2023_realistic_v2', '') 
+
+process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
+
+# Path and EndPath definitions
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+process.load("L1Trigger.L1TNtuples.l1PhaseIITreeProducer_cfi")
+
+
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('L1NtuplePhaseII_160.root')
+)
+
+
+# Schedule definition
+process.schedule = cms.Schedule(process.L1simulation_step,#process.extraCollectionsMenuTree,
+            process.runmenutree,process.endjob_step)#,process.FEVTDEBUGHLToutput_step)
+
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+
+# Customisation from command line
+
+from L1Trigger.Configuration.customiseUtils import L1TrackTriggerTracklet,L1TTurnOffHGCalTPs_v9
+process = L1TrackTriggerTracklet(process)
+#process = L1TTurnOffHGCalTPs_v9(process)
+
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string('ERROR'),
+    default = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000)
+    )
+)
+
+
+from L1Trigger.L1TMuonEndCap.customise_Phase2 import customise as customise_Phase2
+process = customise_Phase2(process)
+
+
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+
+

--- a/L1Trigger/L1TNtuples/src/L1AnalysisPhaseII.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisPhaseII.cc
@@ -706,7 +706,7 @@ void L1Analysis::L1AnalysisPhaseII::SetPFTaus(const edm::Handle< vector<l1t::L1P
 {
 
       for (unsigned int i=0; i<l1pfTaus->size() && l1extra_.nPFTaus<maxL1Extra; i++){
-                   if(l1pfTaus->at(i).pt()<10) continue;
+                   if(l1pfTaus->at(i).pt()<1) continue;
                    l1extra_.pfTauEt.push_back(l1pfTaus->at(i).pt());
                    l1extra_.pfTauEta.push_back(l1pfTaus->at(i).eta());
                    l1extra_.pfTauPhi.push_back(l1pfTaus->at(i).phi());
@@ -732,7 +732,7 @@ void L1Analysis::L1AnalysisPhaseII::SetHPSPFTaus(const edm::Handle<l1t::L1HPSPFT
 {     
 
       for (unsigned int i=0; i<l1HPSPFTaus->size() && l1extra_.nHPSTaus<maxL1Extra; i++){
-                   if(l1HPSPFTaus->at(i).pt()<10) continue;
+                   if(l1HPSPFTaus->at(i).pt()<1) continue;
                    l1extra_.hpsTauEt.push_back(l1HPSPFTaus->at(i).pt());
                    l1extra_.hpsTauEta.push_back(l1HPSPFTaus->at(i).eta());
                    l1extra_.hpsTauPhi.push_back(l1HPSPFTaus->at(i).phi());
@@ -751,7 +751,7 @@ void L1Analysis::L1AnalysisPhaseII::SetNNTaus(const edm::Handle< vector<l1t::PFT
 {
  
       for (unsigned int i=0; i<l1nnTaus->size() && l1extra_.nNNTaus<maxL1Extra; i++){
-                   if(l1nnTaus->at(i).pt()<10) continue;
+                   if(l1nnTaus->at(i).pt()<1) continue;
                    l1extra_.nnTauEt.push_back(l1nnTaus->at(i).pt());
                    l1extra_.nnTauEta.push_back(l1nnTaus->at(i).eta());
                    l1extra_.nnTauPhi.push_back(l1nnTaus->at(i).phi());
@@ -772,7 +772,7 @@ void L1Analysis::L1AnalysisPhaseII::SetNNTauPFs(const edm::Handle< vector<l1t::P
 {
 
       for (unsigned int i=0; i<l1nnTauPFs->size() && l1extra_.nNNTauPFs<maxL1Extra; i++){
-                   if(l1nnTauPFs->at(i).pt()<10) continue;
+                   if(l1nnTauPFs->at(i).pt()<1) continue;
                    l1extra_.nnTauPFEt.push_back(l1nnTauPFs->at(i).pt());
                    l1extra_.nnTauPFEta.push_back(l1nnTauPFs->at(i).eta());
                    l1extra_.nnTauPFPhi.push_back(l1nnTauPFs->at(i).phi());

--- a/L1Trigger/Phase2L1Taus/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1Taus/plugins/L1NNTauProducer.cc
@@ -66,7 +66,8 @@ void L1NNTauProducer::addTau(l1t::PFCandidate &iCand,const l1t::PFCandidateColle
       lTot += pVec;
       if(deltaR(iCand,l1PFCand) < fTauSize && (l1PFCand.id() == l1t::PFCandidate::Electron  || l1PFCand.id() == l1t::PFCandidate::ChargedHadron  || l1PFCand.id() == l1t::PFCandidate::Photon) ) {
 	lId++;
-	if( l1PFCand.id() == l1t::PFCandidate::Electron  || l1PFCand.id() == l1t::PFCandidate::ChargedHadron ) lCand += pVec;
+	//if( l1PFCand.id() == l1t::PFCandidate::Electron  || l1PFCand.id() == l1t::PFCandidate::ChargedHadron ) 
+      lCand += pVec;
       }
       pfTauCands.push_back(l1PFCand);
     }


### PR DESCRIPTION
Hi @rekovic  - we debugged the nntau performance in our menu trees - with @violatingcp and traced it down to a ) my pt cut > 10 GeV to trim the menu tree branches    b) the definition of pt in nnTau coming from sum of charged & electrons only. 

Both things are fixed in this PR (with Phil's OK for the change to NNTau). Please integrate.