### PR TITLE
Make uGMT LUT dumps from condDB possible

### DIFF
--- a/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
+++ b/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import os
 
+# directory paths to code and external LUTs
 l1tgmt_basedir = "L1Trigger/L1TMuon/"
 lut_dir = os.path.join(l1tgmt_basedir, "data/microgmt_luts/")
 
@@ -15,29 +16,38 @@ gmtParamsSource = cms.ESSource(
 gmtParams = cms.ESProducer('L1TMuonGlobalParamsESProducer',
     # id for uGMT settings
     uGmtProcessorId = cms.string('ugmt_processor'),
+    # paths to external xml online config files
+    # for testing purposes or manual generation of conditions from a trigger key
     hwXmlFile = cms.string('L1Trigger/L1TMuon/data/o2o/ugmt/UGMT_HW.xml'),
     topCfgXmlFile = cms.string('L1Trigger/L1TMuon/data/o2o/ugmt/ugmt_top_config_p5.xml'),
     xmlCfgKey = cms.string('TestKey1'),
-    # get configuration from DB and ignore values below this one
+
+    # get configuration from OMDS xml files defined above
+    # if "True" parameters below this one are ignored
     configFromXml = cms.bool(False),
 
-    #fwVersion = cms.uint32(1),
+    # uGMT FW version to be set
+    # Format: 0xMMmmvvpp for major.minor.very_minor.patch
+    # E.g.: 2.1.0.patch1 translates to 0x02010001
     fwVersion = cms.uint32(0x4010000),
 
     # uGMT inputs to disable
     # disabled inputs are not used in the algo but are still in the readout
-    caloInputsDisable = cms.bool(False),
+    caloInputsDisable = cms.bool(False), # disables all 28 calo inputs
     bmtfInputsToDisable = cms.vuint32(0,0,0,0,0,0,0,0,0,0,0,0), # BMTF 0-11
     omtfInputsToDisable = cms.vuint32(0,0,0,0,0,0,0,0,0,0,0,0), # OMTF+0-5, OMTF-0-5
     emtfInputsToDisable = cms.vuint32(0,0,0,0,0,0,0,0,0,0,0,0), # EMTF+0-5, EMTF-0-5
 
     # masked inputs
     # masked inputs are not used in the algo and are not in the readout
-    caloInputsMasked = cms.bool(False),
+    caloInputsMasked = cms.bool(False), # masks all 28 calo inputs
     maskedBmtfInputs = cms.vuint32(0,0,0,0,0,0,0,0,0,0,0,0), # BMTF 0-11
     maskedOmtfInputs = cms.vuint32(0,0,0,0,0,0,0,0,0,0,0,0), # OMTF+0-5, OMTF-0-5
     maskedEmtfInputs = cms.vuint32(0,0,0,0,0,0,0,0,0,0,0,0), # EMTF+0-5, EMTF-0-5
 
+    # paths to external lookup tables
+    # The paths can be empty for MatchQual and SortRAnk LUTs, in which case
+    # the LUTs are generated on the fly by the parameters defined below.
     AbsIsoCheckMemLUTPath        = cms.string(os.path.join(lut_dir, 'AbsIsoCheckMem.txt')),
     RelIsoCheckMemLUTPath        = cms.string(os.path.join(lut_dir, 'RelIsoCheckMem.txt')),
     IdxSelMemPhiLUTPath          = cms.string(os.path.join(lut_dir, 'IdxSelMemPhi.txt')),
@@ -58,6 +68,8 @@ gmtParams = cms.ESProducer('L1TMuonGlobalParamsESProducer',
     FEtaExtrapolationLUTPath     = cms.string(os.path.join(lut_dir, 'EEtaExtrapolation_5eta_7pt_4out_0outshift_20170505.txt')),
     SortRankLUTPath              = cms.string(os.path.join(lut_dir, 'SortRank.txt')),
 
+    # parameters for MatchQual LUTs if no external LUT is defined
+    # If a path to an external LUT is defined these parameters have no effect
     FwdPosSingleMatchQualLUTMaxDR = cms.double(0.05),
     FwdPosSingleMatchQualLUTfEta  = cms.double(1),
     FwdPosSingleMatchQualLUTfPhi  = cms.double(1),
@@ -96,6 +108,8 @@ gmtParams = cms.ESProducer('L1TMuonGlobalParamsESProducer',
     FONegMatchQualLUTfEtaCoarse   = cms.double(1),
     FONegMatchQualLUTfPhi         = cms.double(3),
 
+    # parameters for SortRank LUT if no path to an external LUT is defined
+    # If a path to an external LUT is defined these parameters have no effect
     SortRankLUTPtFactor   = cms.uint32(1), # can be 0 or 1
     SortRankLUTQualFactor = cms.uint32(4), # can be 0 to 34
 )

--- a/L1Trigger/L1TMuon/test/dump_ugmt_luts.py
+++ b/L1Trigger/L1TMuon/test/dump_ugmt_luts.py
@@ -1,3 +1,7 @@
+# This can be used to generate uGMT LUTs from parameters in the fakeGmtParams_cff.py file
+# or dump LUTs from the conditions DB when given a record+tag+(optional)snapshotTime combination
+# The LUTs are dumped as .txt files in the lut_dump directory, which needs to be created before running.
+
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("L1MicroGMTEmulator")
@@ -8,7 +12,25 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1))
 
+## use this to produce LUTs from the config parameters in fakeGmtParams_cff
 process.load('L1Trigger.L1TMuon.fakeGmtParams_cff')
+
+## use this to extract LUTs from the CondDB record + tag + snapshotTime(optional)
+#from CondCore.CondDB.CondDB_cfi import CondDB
+#CondDB.connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+#process.l1ugmtdb = cms.ESSource("PoolDBESSource",
+#    CondDB,
+#    toGet   = cms.VPSet(
+#        cms.PSet(
+#            record = cms.string('L1TMuonGlobalParamsRcd'),
+#            tag = cms.string("L1TMuonGlobalParams_Stage2v0_hlt"),
+#            #tag = cms.string("L1TMuonGlobalParams_static_v91.12"),
+#            #tag = cms.string("L1TMuonGlobalParams_static_v94.6.1"),
+#            #tag = cms.string("L1TMuonGlobalParams_Stage2v0_2018_mc"),
+#            #snapshotTime = cms.string("2017-09-20 23:59:59.000")
+#        )
+#    )
+#)
 
 process.dumper = cms.EDAnalyzer("L1TMicroGMTLUTDumper",
     out_directory = cms.string("lut_dump"),


### PR DESCRIPTION
Add functionality to uGMT LUT dumper module configuration to fetch LUTs from condDB instead of from a python config file. This is useful if one wants to dump the uGMT LUTs that were used with a specific tag in the condDB.
This does not run in any workflow and is just for manual use.
The generation of LUTs from the python config file remains the default. The new functionality can be activated by uncommenting if the need arises.