### PR TITLE
Protecting uGMT emulator from zero pT muons

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -451,21 +451,23 @@ L1TMuonProducer::splitAndConvertMuons(const edm::Handle<MicroGMTConfiguration::I
   int muIdx = 0;
   int currentLink = 0;
   for (size_t i = 0; i < in->size(bx); ++i, ++muIdx) {
-    int link = in->at(bx, i).link();
-    if (m_inputsToDisable.test(link) || m_maskedInputs.test(link)) continue; // only process if input link is enabled and not masked
-    if (currentLink != link) {
-      muIdx = 0;
-      currentLink = link;
-    }
-    int gPhi = MicroGMTConfiguration::calcGlobalPhi(in->at(bx, i).hwPhi(), in->at(bx, i).trackFinderType(), in->at(bx, i).processor());
-    int tfMuonIdx = 3 * (currentLink - 36) + muIdx;
-    std::shared_ptr<GMTInternalMuon> out = std::make_shared<GMTInternalMuon>(in->at(bx, i), gPhi, tfMuonIdx);
-    if(in->at(bx, i).hwEta() > 0) {
-      out_pos.push_back(out);
-      wedges_pos[in->at(bx, i).processor()].push_back(out);
-    } else {
-      out_neg.emplace_back(out);
-      wedges_neg[in->at(bx, i).processor()].push_back(out);
+    if(in->at(bx, i).hwPt() > 0) {
+      int link = in->at(bx, i).link();
+      if (m_inputsToDisable.test(link) || m_maskedInputs.test(link)) continue; // only process if input link is enabled and not masked
+      if (currentLink != link) {
+        muIdx = 0;
+        currentLink = link;
+      }
+      int gPhi = MicroGMTConfiguration::calcGlobalPhi(in->at(bx, i).hwPhi(), in->at(bx, i).trackFinderType(), in->at(bx, i).processor());
+      int tfMuonIdx = 3 * (currentLink - 36) + muIdx;
+      std::shared_ptr<GMTInternalMuon> out = std::make_shared<GMTInternalMuon>(in->at(bx, i), gPhi, tfMuonIdx);
+      if(in->at(bx, i).hwEta() > 0) {
+        out_pos.push_back(out);
+        wedges_pos[in->at(bx, i).processor()].push_back(out);
+      } else {
+        out_neg.emplace_back(out);
+        wedges_neg[in->at(bx, i).processor()].push_back(out);
+      }
     }
   }
   for (int i = 0; i < 6; ++i) {
@@ -488,20 +490,22 @@ L1TMuonProducer::convertMuons(const edm::Handle<MicroGMTConfiguration::InputColl
   int muIdx = 0;
   int currentLink = 0;
   for (size_t i = 0; i < in->size(bx); ++i, ++muIdx) {
-    int link = in->at(bx, i).link();
-    if (m_inputsToDisable.test(link) || m_maskedInputs.test(link)) continue; // only process if input link is enabled and not masked
-    if (currentLink != link) {
-      muIdx = 0;
-      currentLink = link;
+    if(in->at(bx, i).hwPt() > 0) {
+      int link = in->at(bx, i).link();
+      if (m_inputsToDisable.test(link) || m_maskedInputs.test(link)) continue; // only process if input link is enabled and not masked
+      if (currentLink != link) {
+        muIdx = 0;
+        currentLink = link;
+      }
+      int gPhi = MicroGMTConfiguration::calcGlobalPhi(in->at(bx, i).hwPhi(), in->at(bx, i).trackFinderType(), in->at(bx, i).processor());
+      int tfMuonIdx = 3 * (currentLink - 36) + muIdx;
+      std::shared_ptr<GMTInternalMuon> outMu = std::make_shared<GMTInternalMuon>(in->at(bx, i), gPhi, tfMuonIdx);
+      out.emplace_back(outMu);
+      wedges[in->at(bx, i).processor()].push_back(outMu);
     }
-    int gPhi = MicroGMTConfiguration::calcGlobalPhi(in->at(bx, i).hwPhi(), in->at(bx, i).trackFinderType(), in->at(bx, i).processor());
-    int tfMuonIdx = 3 * (currentLink - 36) + muIdx;
-    std::shared_ptr<GMTInternalMuon> outMu = std::make_shared<GMTInternalMuon>(in->at(bx, i), gPhi, tfMuonIdx);
-    out.emplace_back(outMu);
-    wedges[in->at(bx, i).processor()].push_back(outMu);
-  }
-  for (int i = 0; i < 12; ++i) {
-    if(wedges[i].size() > 3) edm::LogWarning("Input Mismatch") << " too many inputs per processor for barrel. Wedge " << i << ": Size " << wedges[i].size() << std::endl;
+    for (int i = 0; i < 12; ++i) {
+      if(wedges[i].size() > 3) edm::LogWarning("Input Mismatch") << " too many inputs per processor for barrel. Wedge " << i << ": Size " << wedges[i].size() << std::endl;
+    }
   }
 }
 
@@ -514,7 +518,7 @@ L1TMuonProducer::beginRun(edm::Run const& run, edm::EventSetup const& iSetup)
   microGMTParamsRcd.get(microGMTParamsHandle);
 
   std::unique_ptr<L1TMuonGlobalParams_PUBLIC> microGMTParams( new L1TMuonGlobalParams_PUBLIC( cast_to_L1TMuonGlobalParams_PUBLIC(*microGMTParamsHandle.product()) ) );
-  if( microGMTParams->pnodes_.empty() ){ 
+  if( microGMTParams->pnodes_.empty() ){
       edm::ESHandle<L1TMuonGlobalParams> o2oProtoHandle;
       iSetup.get<L1TMuonGlobalParamsO2ORcd>().get(o2oProtoHandle);
       microGMTParamsHelper = std::unique_ptr<L1TMuonGlobalParamsHelper>(new L1TMuonGlobalParamsHelper(*o2oProtoHandle.product()));


### PR DESCRIPTION
Hi,
(rebased #770 for 10_6_0)

muon data with pT = 0 is defined as 'no muon' according to the interface note. The uGMT firmware detects such data and discards it at the inputs, but the emulator seems to be susceptible to receiving muons with reasonable coordinates and quality but pT = 0. In such a case it can happen that a pT = 0 muon cancels out a proper one leading to a mismatch between firmware and emulator.

I've introduced a simple pT > 0 check in the L1TMuonProducer to make sure we only accept proper muons in our input.

@rekovic, please have a look.

Cheers,
Dinyar