### PR TITLE
Add caloParams_2018_v1_3 (default for 2018 pp running)

### DIFF
--- a/L1Trigger/Configuration/python/customiseSettings.py
+++ b/L1Trigger/Configuration/python/customiseSettings.py
@@ -10,6 +10,10 @@ def L1TSettingsToCaloParams_2018_v1_4(process):
     process.load("L1Trigger.L1TCalorimeter.caloParams_2018_v1_4_cfi")
     return process
 
+def L1TSettingsToCaloParams_2018_v1_3(process):
+    process.load("L1Trigger.L1TCalorimeter.caloParams_2018_v1_3_cfi")
+    return process
+
 def L1TSettingsToCaloParams_2018_v1_2(process):
     process.load("L1Trigger.L1TCalorimeter.caloParams_2018_v1_2_cfi")
     return process


### PR DESCRIPTION
@rekovic , @bundocka ,

My understanding from Aaron is that caloParams_2018_v1_3 was used for most of 2018, but this setting was not available in customiseSettings.py.  I've added it here.

Best regards,
Andrew
