### PR TITLE
Enable TTTracks only in D41 or later

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -5,8 +5,13 @@ from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 from L1Trigger.TrackerDTC.ProducerED_cff import *
 from L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff import *
 
-L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer*L1PromptExtendedHybridTracksWithAssociators)
-#L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer*L1PromptExtendedHybridTracks)
+L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer)
 
+# Customisation to enable TTTracks in geometry D41 and later (corresponding to phase2_hgcalV10 or later). Includes the HGCAL L1 trigger
+_tttracks_l1tracktrigger = L1TrackTrigger.copy()
+_tttracks_l1tracktrigger.add(L1PromptExtendedHybridTracksWithAssociators)
+
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+phase2_hgcalV10.toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)


### PR DESCRIPTION
@rekovic @kpedro88

This is a possible workaround to enable TTTracks only in D41 or later, in order to avoid the crash with D35.
This workaround looks very ugly for the time being, I just wanted to propose a possible solution. 
This fix should be implemented by adding a new modifiers related to the version of the Tracker geometry, instead of using the HGCal geometry. (@kpedro88 what do you think?)

Just to be clear about how it works, looking at
https://github.com/cms-sw/cmssw/blob/master/Configuration/Geometry/python/dict2026Geometry.py

```
    ("O2","T6","C4","M2","F2","I5") : "D35",
    ("O3","T14","C8","M3","F2","I9") : "D41",
    ("O4","T15","C9","M4","F2","I10") : "D49",
```
T6   -> TiltedTracker404/tracker.xml -> causing error
T14 -> TiltedTracker613/tracker.xml
T15 -> TiltedTracker613_MB_2019_04/tracker.xml

There are no geometry-dependent era ("phase2_tracker, trackingPhase2PU140")

C4 -> eras: ..., phase2_hgcalV9
C8 -> eras: ..., phase2_hgcalV9, phase2_hgcalV10
C9 -> eras: ..., phase2_hgcalV9, phase2_hgcalV10, phase2_hgcalV11

So taking phase2_hgcalV10 we selects C8 or later, ie. we select D41 or later

This workaround is similar to https://github.com/cms-sw/cmssw/pull/30323/files#diff-6a37c45eab8a198fec5379e27216dbc3