### PR TITLE
Produce multiple FastHisto vertices

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -69,6 +69,7 @@ private:
   float pTMax_;       // in GeV, saturation / truncation value
   int highPtTracks_;  // saturate or truncate
 
+  int nVtx_;         // the number of vertices to return
   int nStubsmin_;    // minimum number of stubs
   int nStubsPSmin_;  // minimum number of stubs in PS modules
 
@@ -116,6 +117,7 @@ L1TkFastVertexProducer::L1TkFastVertexProducer(const edm::ParameterSet& iConfig)
   pTMax_ = (float)iConfig.getParameter<double>("PTMAX");
   highPtTracks_ = iConfig.getParameter<int>("HighPtTracks");
 
+  nVtx_ = iConfig.getParameter<int>("nVtx");
   nStubsmin_ = iConfig.getParameter<int>("nStubsmin");
   nStubsPSmin_ = iConfig.getParameter<int>("nStubsPSmin");
   nBinning_ = iConfig.getParameter<int>("nBinning");
@@ -309,6 +311,7 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 
   float zvtx_sliding = -999;
   float sigma_max = -999;
+  int imax = -999;
   int nb = htmp.GetNbinsX();
   for (int i = 2; i <= nb - 1; i++) {
     float a0 = htmp.GetBinContent(i - 1);
@@ -317,6 +320,7 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
     float sigma = a0 + a1 + a2;
     if (sigma > sigma_max) {
       sigma_max = sigma;
+      imax = i;
       float z0 = htmp.GetBinCenter(i - 1);
       float z1 = htmp.GetBinCenter(i);
       float z2 = htmp.GetBinCenter(i + 1);
@@ -324,25 +328,30 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
     }
   }
 
-  zvtx_sliding = -999;
-  sigma_max = -999;
-  for (int i = 2; i <= nb - 1; i++) {
-    float a0 = htmp_weight.GetBinContent(i - 1);
-    float a1 = htmp_weight.GetBinContent(i);
-    float a2 = htmp_weight.GetBinContent(i + 1);
-    float sigma = a0 + a1 + a2;
-    if (sigma > sigma_max) {
-      sigma_max = sigma;
-      float z0 = htmp_weight.GetBinCenter(i - 1);
-      float z1 = htmp_weight.GetBinCenter(i);
-      float z2 = htmp_weight.GetBinCenter(i + 1);
-      zvtx_sliding = (a0 * z0 + a1 * z1 + a2 * z2) / sigma;
+  std::vector<int> found;
+  found.reserve(nVtx_);
+  for (int ivtx = 0; ivtx < nVtx_; ivtx++) {
+    zvtx_sliding = -999;
+    sigma_max = -999;
+    imax = -999;
+    for (int i = 2; i <= nb - 1; i++) {
+      float a0 = htmp_weight.GetBinContent(i - 1);
+      float a1 = htmp_weight.GetBinContent(i);
+      float a2 = htmp_weight.GetBinContent(i + 1);
+      float sigma = a0 + a1 + a2;
+      if ( (sigma > sigma_max) && (find(found.begin(),found.end(),i) == found.end()) ) {
+        sigma_max = sigma;
+        imax = i;
+        float z0 = htmp_weight.GetBinCenter(i - 1);
+        float z1 = htmp_weight.GetBinCenter(i);
+        float z2 = htmp_weight.GetBinCenter(i + 1);
+        zvtx_sliding = (a0 * z0 + a1 * z1 + a2 * z2) / sigma;
+      }
     }
+    found.push_back(imax);
+    TkPrimaryVertex vtx4(zvtx_sliding, sigma_max);
+    result->push_back(vtx4);    
   }
-
-  TkPrimaryVertex vtx4(zvtx_sliding, sigma_max);
-
-  result->push_back(vtx4);
 
   iEvent.put(std::move(result));
 }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -339,7 +339,7 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
       float a1 = htmp_weight.GetBinContent(i);
       float a2 = htmp_weight.GetBinContent(i + 1);
       float sigma = a0 + a1 + a2;
-      if ( (sigma > sigma_max) && (find(found.begin(),found.end(),i) == found.end()) ) {
+      if ((sigma > sigma_max) && (find(found.begin(), found.end(), i) == found.end())) {
         sigma_max = sigma;
         imax = i;
         float z0 = htmp_weight.GetBinCenter(i - 1);
@@ -350,7 +350,7 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
     }
     found.push_back(imax);
     TkPrimaryVertex vtx4(zvtx_sliding, sigma_max);
-    result->push_back(vtx4);    
+    result->push_back(vtx4);
   }
 
   iEvent.put(std::move(result));

--- a/L1Trigger/L1TTrackMatch/python/L1TkPrimaryVertexProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkPrimaryVertexProducer_cfi.py
@@ -11,6 +11,7 @@ L1TkPrimaryVertex = cms.EDProducer('L1TkFastVertexProducer',
      ZMAX = cms.double ( 25. ) ,        # in cm
      CHI2MAX = cms.double( 100. ),
      PTMINTRA = cms.double( 2.),        # PTMIN of L1Tracks, in GeV
+     nVtx = cms.int32( 1 ),              # number of vertices to return
      nStubsmin = cms.int32( 4 ) ,       # minimum number of stubs
      nStubsPSmin = cms.int32( 3 ),       # minimum number of stubs in PS modules 
      nBinning = cms.int32( 601 ),        # number of bins for the temp histo (from -30 cm to + 30 cm)

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackObjectNtupleMaker.cc
@@ -194,7 +194,8 @@ private:
   // primary vertex
   // std::vector<float>* m_pv_L1recotruesumpt;
   // std::vector<float>* m_pv_L1recosumpt;
-  std::vector<float>* m_pv_L1reco;
+  std::vector<float>* m_pv_L1reco_z0;
+  std::vector<float>* m_pv_L1reco_sum;
   // std::vector<float>* m_pv_L1TP;
   // std::vector<float>* m_pv_L1TPsumpt;
   std::vector<float>* m_pv_MC;
@@ -615,7 +616,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
 
   // m_pv_L1recotruesumpt = new std::vector<float>;
   // m_pv_L1recosumpt = new std::vector<float>;
-  m_pv_L1reco = new std::vector<float>;
+  m_pv_L1reco_z0 = new std::vector<float>;
+  m_pv_L1reco_sum = new std::vector<float>;
   // m_pv_L1TP = new std::vector<float>;
   // m_pv_L1TPsumpt = new std::vector<float>;
   m_pv_MC = new std::vector<float>;
@@ -828,7 +830,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
   if (SaveTrackJets) {
     // eventTree->Branch("pv_L1recotruesumpt", &m_pv_L1recotruesumpt);
     // eventTree->Branch("pv_L1recosumpt", &m_pv_L1recosumpt);
-    eventTree->Branch("pv_L1reco", &m_pv_L1reco);
+    eventTree->Branch("pv_L1reco_z0", &m_pv_L1reco_z0);
+    eventTree->Branch("pv_L1reco_sum", &m_pv_L1reco_sum);
     // eventTree->Branch("pv_L1TP", &m_pv_L1TP);
     // eventTree->Branch("pv_L1TPsumpt", &m_pv_L1TPsumpt);
     eventTree->Branch("MC_lep", &m_MC_lep);
@@ -1080,7 +1083,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
 
       // m_pv_L1recotruesumpt->clear();
       // m_pv_L1recosumpt->clear();
-      m_pv_L1reco->clear();
+      m_pv_L1reco_z0->clear();
+      m_pv_L1reco_sum->clear();
       // m_pv_L1TPsumpt->clear();
       // m_pv_L1TP->clear();
       m_pv_MC->clear();
@@ -1130,6 +1134,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     //Vertex
     edm::Handle< l1t::TkPrimaryVertexCollection >L1TkPrimaryVertexHandle;
     iEvent.getByToken(L1VertexToken_, L1TkPrimaryVertexHandle);
+    std::vector< l1t::TkPrimaryVertex >::const_iterator vtxIter;
 
     // Track jets
     edm::Handle< std::vector<l1t::TkJet> > TrackFastJetsHandle;
@@ -2244,7 +2249,10 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       }
 
       if (L1TkPrimaryVertexHandle.isValid()) {
-        m_pv_L1reco->push_back(L1TkPrimaryVertexHandle->begin()->zvertex());
+         for (vtxIter = L1TkPrimaryVertexHandle->begin(); vtxIter != L1TkPrimaryVertexHandle->end(); ++vtxIter) {
+            m_pv_L1reco_z0->push_back(vtxIter->zvertex());
+            m_pv_L1reco_sum->push_back(vtxIter->sum());
+         }
       }
       else {
         edm::LogWarning("DataNotFound")<< "\nWarning: L1TkPrimaryVertexHandle not found in the event"<< std::endl;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackObjectNtupleMaker_cfg.py
@@ -111,6 +111,7 @@ elif (L1TRKALGO == 'HYBRID_PROMPTANDDISP'):
 # Primary vertex
 ############################################################
 process.load("L1Trigger.L1TTrackMatch.L1TkPrimaryVertexProducer_cfi")
+process.L1TkPrimaryVertex.nVtx = cms.int32 (5)
 process.pPV = cms.Path(process.L1TkPrimaryVertex)
 
 


### PR DESCRIPTION
#### PR description:

Allow the L1TkPrimaryVertexProducer to return the top N histogram bins (vertices) instead of just the leading vertex. N is now a configurable parameter. This PR also allows a person to save N vertex Z0 and sum into the L1TrackObjectNtupleMaker tree.

#### PR validation:

I first created an L1TrackObjectNtuple using the cms-l1t-offline/cmssw/phase2-l1t-integration-CMSSW_11_1_3 branch. I then proceeded to make two more ntuples, one only saving the leading vertex and one saving the top 5 vertices. In all of the ntuples the leading vertex Z0 was the same. In the updated ntuples, the leading sums were also the same. Finally, the sums for the top 5 vertices were monotonically decreasing, indicating that the code was indeed itentifying the highest pT vertex and proceeding in order of likelihood of being the hard scatter vertex.
