### PR TITLE
uGT - emulate and cuts unconstrained pt and impact param  

### DIFF
--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -53,6 +53,10 @@ public:
 public:
   // typedef for a single object template
   struct ObjectParameter {
+    unsigned int unconstrainedPtHigh;
+    unsigned int unconstrainedPtLow;  
+    unsigned int impactParameterHigh; 
+    unsigned int impactParameterLow;  
     unsigned int ptHighThreshold;
     unsigned int ptLowThreshold;
     unsigned int indexHigh;
@@ -62,6 +66,7 @@ public:
     bool requestIso;
     unsigned int qualityLUT;
     unsigned int isolationLUT;
+    unsigned int impactParameterLUT; 
     unsigned long long etaRange;
     unsigned int phiHigh;
     unsigned int phiLow;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1068,6 +1068,10 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     relativeBx = object.getBxOffset();
 
     //  Loop over the cuts for this object
+    int upperUnconstrainedPtInd = -1; 
+    int lowerUnconstrainedPtInd = 0;  
+    int upperImpactParameterInd = -1; 
+    int lowerImpactParameterInd = 0;  
     int upperThresholdInd = -1;
     int lowerThresholdInd = 0;
     int upperIndexInd = -1;
@@ -1077,6 +1081,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     int cntPhi = 0;
     unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
     int isolationLUT = 0xF;   //default is to ignore unless specified.
+    int impactParameterLUT = 0xF;     //default is to ignore unless specified
     int charge = -1;          //default value is to ignore unless specified
     int qualityLUT = 0xFFFF;  //default is to ignore unless specified.
 
@@ -1085,6 +1090,18 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
       const esCut cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
+
+        case esCutType::UnconstrainedPt:
+	  lowerUnconstrainedPtInd = cut.getMinimum().index;
+	  upperUnconstrainedPtInd = cut.getMaximum().index;
+	  break;
+
+        case esCutType::ImpactParameter:
+	  lowerImpactParameterInd = cut.getMinimum().index;
+	  upperImpactParameterInd = cut.getMaximum().index;
+	  impactParameterLUT = l1tstr2int(cut.getData());
+	  break;
+
         case esCutType::Threshold:
           lowerThresholdInd = cut.getMinimum().index;
           upperThresholdInd = cut.getMaximum().index;
@@ -1151,6 +1168,12 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     }  //end loop over cuts
 
     // Set the parameter cuts
+    objParameter[cnt].unconstrainedPtHigh = upperUnconstrainedPtInd; 
+    objParameter[cnt].unconstrainedPtLow = lowerUnconstrainedPtInd;  
+    objParameter[cnt].impactParameterHigh = upperImpactParameterInd; 
+    objParameter[cnt].impactParameterLow = lowerImpactParameterInd;  
+    objParameter[cnt].impactParameterLUT = impactParameterLUT;  
+
     objParameter[cnt].ptHighThreshold = upperThresholdInd;
     objParameter[cnt].ptLowThreshold = lowerThresholdInd;
 

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -382,6 +382,12 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         << "\n\t hwQual     = 0x " << cand.hwQual() << "\n\t hwIso      = 0x " << cand.hwIso()
                         << std::dec << std::endl;
 
+  if (!checkThreshold(objPar.unconstrainedPtLow, objPar.unconstrainedPtHigh, cand.hwPtUnconstrained(), m_gtMuonTemplate->condGEq())) 
+    {
+      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold " << std::endl;
+      return false;
+    }
+
   if (!checkThreshold(objPar.ptLowThreshold, objPar.ptHighThreshold, cand.hwPt(), m_gtMuonTemplate->condGEq())) {
     LogDebug("L1TGlobal") << "\t\t Muon Failed checkThreshold " << std::endl;
     return false;
@@ -443,6 +449,18 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
   bool passIsoLUT = ((objPar.isolationLUT >> cand.hwIso()) & 1);
   if (!passIsoLUT) {
     LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed isolation requirement" << std::endl;
+    return false;
+  }
+
+  // check impact parameter ( bit check ) with impact parameter LUT
+  // sanity check on candidate impact parameter
+  if (cand.hwDXY() > 3) {
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
+    return false;
+  }
+  bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
+  if (!passImpactParameterLUT) {
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
     return false;
   }
 


### PR DESCRIPTION
#### PR description: uGT emulation and cuts of unconstrained pt and impact param

Fixed PR https://github.com/cms-l1t-offline/cmssw/pull/868 of  @cavana (Rick Cavanaugh).
In addition the code development is PRed to l1t-integration-CMSSW_11_2_0 as opposed to 11_0_2.

> The proposed features include the necessary modifications to the uGT Emulator to support cuts on Muon Unconstrained Pt and Muon Impact Parameter, as provided in the L1 Trigger Menu. This PR does not change any output and it does not depend on any externals.


#### PR validation:

>The validation tests that have been performed include (1) ensuring that the code compiles correctly and (2) running a modified "runTheMatrix" test workflow with parameter "11634.0", such that the modified workflow uses a custom L1T menu that contains cuts on the Muon Unconstrained Pt and the Muon Impact Parameter.

#### if this PR is a backport please specify the original PR:

> This PR is not a backport.

