### PR TITLE
Fix empty BMTF Ntuples while re-emulating L1 for Run3

### DIFF
--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -213,6 +213,16 @@ def L1TReEmulFromRAW(process):
         DTThetaDigi_Source = 'simDtTriggerPrimitiveDigis'
     )
 
+    run3_GEM.toModify(process.simKBmtfStubs,
+        srcPhi   = 'bmtfDigis',
+        srcTheta = 'bmtfDigis'
+    )
+
+    run3_GEM.toModify(process.simBmtfDigis,
+        DTDigi_Source       = 'bmtfDigis',
+        DTDigi_Theta_Source = 'bmtfDigis'
+    )
+
     print("# L1TReEmul sequence:  ")
     print("# {0}".format(process.L1TReEmul))
     print("# {0}".format(process.schedule))


### PR DESCRIPTION
#### PR description:
This PR changes `simTwinmuxDigis` to `bmtfDigis` for Run3 BMTF re-emulation.
It solves temporarily the issue with the empty L1TNtuples for the BMTF branch of the L1System.

The issue is discussed here #886, this fix cannot be considered permanent and **NEEDS TO BE REVISITED**.