### PR TITLE
Updated Track Word and a New Track Word Conversion Module

### DIFF
--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/Phase2TrackerDigi"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackerCommon"/>
+<use name="hls"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -414,11 +414,28 @@ void TTTrack<T>::setTrackWordBits() {
   // missing conversion of global phi to difference from sector center phi
 
   if (theChi2_Z_ < 0) {
-    setTrackWord(valid, theMomentum_, thePOCA_, theRInv_, theChi2_, 0, theStubPtConsistency_, theHitPattern_, mvaQuality, mvaOther);
+    setTrackWord(valid,
+                 theMomentum_,
+                 thePOCA_,
+                 theRInv_,
+                 theChi2_,
+                 0,
+                 theStubPtConsistency_,
+                 theHitPattern_,
+                 mvaQuality,
+                 mvaOther);
 
   } else {
-    setTrackWord(
-        valid, theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, mvaQuality, mvaOther);
+    setTrackWord(valid,
+                 theMomentum_,
+                 thePOCA_,
+                 theRInv_,
+                 theChi2_XY_,
+                 theChi2_Z_,
+                 theStubPtConsistency_,
+                 theHitPattern_,
+                 mvaQuality,
+                 mvaOther);
   }
   return;
 }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -407,16 +407,18 @@ void TTTrack<T>::setTrackWordBits() {
     return;
   }
 
-  unsigned int sparebits = 0;
+  unsigned int valid = true;
+  unsigned int mvaQuality = 0;
+  unsigned int mvaOther = 0;
 
   // missing conversion of global phi to difference from sector center phi
 
   if (theChi2_Z_ < 0) {
-    setTrackWord(theMomentum_, thePOCA_, theRInv_, theChi2_, 0, theStubPtConsistency_, theHitPattern_, sparebits);
+    setTrackWord(valid, theMomentum_, thePOCA_, theRInv_, theChi2_, 0, theStubPtConsistency_, theHitPattern_, mvaQuality, mvaOther);
 
   } else {
     setTrackWord(
-        theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, sparebits);
+        valid, theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, mvaQuality, mvaOther);
   }
   return;
 }
@@ -435,7 +437,7 @@ void TTTrack<T>::testTrackWordBits() {
   //std::cout << " eta " << rEta << " " << get_ieta() << std::endl;
   //std::cout << " Z0 " << rZ0 << " " << get_iz0() << std::endl;
   //std::cout << " D0 " << rD0 << " " << get_id0() << std::endl;
-  //std::cout << " Rinv " << theRInv_ << " " << get_iRinv() << std::endl;
+  //std::cout << " Rinv " << tehRInv_ << " " << get_iRinv() << std::endl;
   //std::cout << " chi2 " << theChi2_ << " " << get_ichi2() << std::endl;
 
   return;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -1,244 +1,294 @@
+#ifndef L1_TRACK_TRIGGER_TRACK_WORD_H
+#define L1_TRACK_TRIGGER_TRACK_WORD_H
+
 ////////
 //
 // class to store the 96-bit track word produced by the L1 Track Trigger.  Intended to be inherited by L1 TTTrack.
 // packing scheme given below.
 //
-// author: Mike Hildreth
-// date:   April 9, 2019
+// author:      Mike Hildreth
+// modified by: Alexx Perloff
+// created:     April 9, 2019
+// modified:    March 9, 2021
 //
 ///////
 
-#ifndef L1_TRACK_TRIGGER_TRACK_WORD_H
-#define L1_TRACK_TRIGGER_TRACK_WORD_H
-
-#include <iostream>
-#include <string>
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
+#include <ap_int.h>
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <string>
+#include <vector>
+
 class TTTrack_TrackWord {
 public:
-  // Constructors:
+  // ----------constants, enums and typedefs ---------
+  enum TrackBitWidths {
+    // The sizes of the track word components
+    kMVAOtherSize = 6,    // Space for two specialized MVA selections
+    kMVAQualitySize = 3,  // Width of track quality MVA
+    kHitPatternSize = 7,  // Width of the hit pattern for stubs
+    kBendChi2Size = 3,    // Width of the Bend-Chi2
+    kD0Size = 13,         // Width of D0
+    kChi2RZSize = 4,      // Width of Chi2 for r-z
+    kZ0Size = 12,         // Width of z-position (40cm / 0.1)
+    kTanlSize = 16,       // Width of tan(lambda)
+    kChi2RPhiSize = 4,    // Width of Chi2 for r-phi
+    kPhiSize = 12,        // Width of phi
+    kRinvSize = 15,       // Width of Rinv
+    kValidSize = 1,       // Valid bit
 
+    kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size + kChi2RZSize 
+                   + kD0Size + kBendChi2Size + kHitPatternSize + kMVAQualitySize + kMVAOtherSize,  // Width of the track word in bits
+  };
+
+  enum TrackBitLocations {
+    // The location of the least significant bit (LSB) and most significant bit (MSB) in the track word for different fields
+    kMVAOtherLSB = 0,
+    kMVAOtherMSB = kMVAOtherLSB + TrackBitWidths::kMVAOtherSize - 1,
+    kMVAQualityLSB = kMVAOtherMSB + 1,
+    kMVAQualityMSB = kMVAQualityLSB + TrackBitWidths::kMVAQualitySize - 1,
+    kHitPatternLSB = kMVAQualityMSB + 1,
+    kHitPatternMSB = kHitPatternLSB + TrackBitWidths::kHitPatternSize - 1,
+    kBendChi2LSB = kHitPatternMSB + 1,
+    kBendChi2MSB = kBendChi2LSB + TrackBitWidths::kBendChi2Size - 1,
+    kD0LSB = kBendChi2MSB + 1,
+    kD0MSB = kD0LSB + TrackBitWidths::kD0Size - 1,
+    kChi2RZLSB = kD0MSB + 1,
+    kChi2RZMSB = kChi2RZLSB + TrackBitWidths::kChi2RZSize - 1,
+    kZ0LSB = kChi2RZMSB + 1,
+    kZ0MSB = kZ0LSB + TrackBitWidths::kZ0Size - 1,
+    kTanlLSB = kZ0MSB + 1,
+    kTanlMSB = kTanlLSB + TrackBitWidths::kTanlSize - 1,
+    kChi2RPhiLSB = kTanlMSB + 1,
+    kChi2RPhiMSB = kChi2RPhiLSB + TrackBitWidths::kChi2RPhiSize - 1,
+    kPhiLSB = kChi2RPhiMSB + 1,
+    kPhiMSB = kPhiLSB + TrackBitWidths::kPhiSize - 1,
+    kRinvLSB = kPhiMSB + 1,
+    kRinvMSB = kRinvLSB + TrackBitWidths::kRinvSize - 1,
+    kValidLSB = kRinvMSB + 1,
+    kValidMSB = kValidLSB + TrackBitWidths::kValidSize - 1,
+  };
+
+  // Binning constants
+  static constexpr double minRinv = -0.006;
+  static constexpr double minPhi0 = -0.7853981696;  // relative to the center of the sector
+  static constexpr double minTanl = -8.;
+  static constexpr double minZ0 = -20.46912512;
+  static constexpr double minD0 = -16.;
+
+  static constexpr double stepRinv = (2. * std::abs(minRinv)) / (1 << TrackBitWidths::kRinvSize);
+  static constexpr double stepPhi0 = (2. * std::abs(minPhi0)) / (1 << TrackBitWidths::kPhiSize);
+  static constexpr double stepTanL = (1. / (1 << 12));
+  static constexpr double stepZ0 = (2. * std::abs(minZ0)) / (1 << TrackBitWidths::kZ0Size);
+  static constexpr double stepD0 = (1. / (1 << 8));
+
+  static constexpr std::array<double, 1 << TrackBitWidths::kChi2RPhiSize> chi2RPhiBins = {
+      {0., 0.25, 0.5, 1., 2., 3., 5., 7., 10., 20., 40., 100., 200., 500., 1000., 3000.}};
+  static constexpr std::array<double, 1 << TrackBitWidths::kChi2RZSize> chi2RZBins = {
+      {0., 0.25, 0.5, 1., 2., 3., 5., 7., 10., 20., 40., 100., 200., 500., 1000., 3000.}};
+  static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
+      {0., 0.5, 1.25, 2., 3., 5., 10., 50.}};
+
+  // Track flags
+  typedef ap_uint<TrackBitWidths::kValidSize> valid_t;  // valid bit
+
+  // Track parameters types
+  typedef ap_uint<TrackBitWidths::kRinvSize> rinv_t;  // Track Rinv
+  typedef ap_uint<TrackBitWidths::kPhiSize> phi_t;    // Track phi
+  typedef ap_uint<TrackBitWidths::kTanlSize> tanl_t;  // Track tan(l)
+  typedef ap_uint<TrackBitWidths::kZ0Size> z0_t;      // Track z
+  typedef ap_uint<TrackBitWidths::kD0Size> d0_t;      // D0
+
+  // Track quality types
+  typedef ap_uint<TrackBitWidths::kChi2RPhiSize> chi2rphi_t;      // Chi2 r-phi
+  typedef ap_uint<TrackBitWidths::kChi2RZSize> chi2rz_t;          // Chi2 r-z
+  typedef ap_uint<TrackBitWidths::kBendChi2Size> bendChi2_t;      // Bend-Chi2
+  typedef ap_uint<TrackBitWidths::kHitPatternSize> hit_t;         // Hit mask bits
+  typedef ap_uint<TrackBitWidths::kMVAQualitySize> qualityMVA_t;  // Track quality MVA
+  typedef ap_uint<TrackBitWidths::kMVAOtherSize> otherMVA_t;      // Specialized MVA selection
+
+  // Track word types
+  typedef ap_uint<TrackBitWidths::kTrackWordSize> tkword_t;  // Entire track word;
+
+public:
+  // ----------Constructors --------------------------
   TTTrack_TrackWord() {}
-  TTTrack_TrackWord(const GlobalVector& Momentum,
+  TTTrack_TrackWord(unsigned int valid,
+                    const GlobalVector& momentum,
                     const GlobalPoint& POCA,
-                    double Rinv,
-                    double Chi2,  // would be xy chisq if chi2Z is non-zero
-                    double Chi2Z,
-                    double BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
-
-  TTTrack_TrackWord(unsigned int Rinv,
+                    double rInv,
+                    double chi2RPhi,  // would be xy chisq if chi2Z is non-zero
+                    double chi2RZ,
+                    double bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
+  TTTrack_TrackWord(unsigned int valid,
+                    unsigned int rInv,
                     unsigned int phi0,
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int Chi2XY,  // would be total chisq if chi2Z is zero
-                    unsigned int Chi2Z,
-                    unsigned int BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
+                    unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                    unsigned int chi2RZ,
+                    unsigned int bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
 
-  void setTrackWord(const GlobalVector& Momentum,
-                    const GlobalPoint& POCA,
-                    double Rinv,
-                    double Chi2XY,  // would be total chisq if chi2Z is zero
-                    double Chi2Z,
-                    double BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
+  // ----------copy constructor ----------------------
+  TTTrack_TrackWord(const TTTrack_TrackWord& word) { trackWord_ = word.trackWord_; }
 
-  void setTrackWord(unsigned int Rinv,
-                    unsigned int phi0,
-                    unsigned int tanl,
-                    unsigned int z0,
-                    unsigned int d0,
-                    unsigned int Chi2XY,  // would be total chisq if chi2Z is zero
-                    unsigned int Chi2Z,
-                    unsigned int BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
-
-  // getters for unpacked and converted values.
-  // These functions return real numbers converted from the digitized quantities using the LSB defined for each.
-
-  float get_iRinv();
-  float get_iphi();
-  float get_itanl();
-  float get_iz0();
-  float get_id0();
-  float get_ichi2XY();
-  float get_ichi2Z();
-  float get_iBendChi2();
-
-  // separate functions for unpacking 96-bit track word
-
-  float unpack_iRinv();
-  float unpack_iphi();
-  float unpack_itanl();
-  float unpack_iz0();
-  float unpack_id0();
-  float unpack_ichi2XY();
-  float unpack_ichi2Z();
-  float unpack_iBendChi2();
-  unsigned int unpack_ispare();
-  unsigned int unpack_hitPattern();
-
-  // getters for packed bits.
-  // These functions return, literally, the packed bits in integer format for each quantity.
-  // Signed quantities have the sign enconded in the left-most bit.
-
-  unsigned int get_hitPattern();
-  unsigned int get_ispare();  // will need a converter(s) when spare bits are defined
-
-  unsigned int get_RinvBits();
-  unsigned int get_phiBits();
-  unsigned int get_tanlBits();
-  unsigned int get_z0Bits();
-  unsigned int get_d0Bits();
-  unsigned int get_chi2XYBits();
-  unsigned int get_chi2ZBits();
-  unsigned int get_BendChi2Bits();
-
-  // copy constructor
-
-  TTTrack_TrackWord(const TTTrack_TrackWord& word) {
-    initialize();
-
-    iRinv = word.iRinv;
-    iphi = word.iphi;
-    itanl = word.itanl;
-    iz0 = word.iz0;
-    id0 = word.id0;
-    ichi2XY = word.ichi2XY;
-    ichi2Z = word.ichi2Z;
-    iBendChi2 = word.iBendChi2;
-    ispare = word.ispare;
-    iHitPattern = word.iHitPattern;
-
-    // three 32-bit packed words
-    TrackWord1 = word.TrackWord1;
-    TrackWord2 = word.TrackWord2;
-    TrackWord3 = word.TrackWord3;
-  }
-
+  // ----------operators -----------------------------
   TTTrack_TrackWord& operator=(const TTTrack_TrackWord& word) {
-    initialize();
-    iRinv = word.iRinv;
-    iphi = word.iphi;
-    itanl = word.itanl;
-    iz0 = word.iz0;
-    id0 = word.id0;
-    ichi2XY = word.ichi2XY;
-    ichi2Z = word.ichi2Z;
-    iBendChi2 = word.iBendChi2;
-    ispare = word.ispare;
-    iHitPattern = word.iHitPattern;
-
-    // three 32-bit packed words
-    TrackWord1 = word.TrackWord1;
-    TrackWord2 = word.TrackWord2;
-    TrackWord3 = word.TrackWord3;
-
+    trackWord_ = word.trackWord_;
     return *this;
   }
 
+  // ----------member functions (getters) ------------
+  // These functions return arbitarary precision unsigned int words (lists of bits) for each quantity
+  // Signed quantities have the sign enconded in the left-most bit.
+  ap_uint<TrackBitWidths::kValidSize> getValidWord() const {
+    return trackWord_(TrackBitLocations::kValidMSB, TrackBitLocations::kValidLSB);
+  }
+  ap_uint<TrackBitWidths::kRinvSize> getRinvWord() const {
+    return trackWord_(TrackBitLocations::kRinvMSB, TrackBitLocations::kRinvLSB);
+  }
+  ap_uint<TrackBitWidths::kPhiSize> getPhiWord() const {
+    return trackWord_(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB);
+  }
+  ap_uint<TrackBitWidths::kTanlSize> getTanlWord() const {
+    return trackWord_(TrackBitLocations::kTanlMSB, TrackBitLocations::kTanlLSB);
+  }
+  ap_uint<TrackBitWidths::kZ0Size> getZ0Word() const {
+    return trackWord_(TrackBitLocations::kZ0MSB, TrackBitLocations::kZ0LSB);
+  }
+  ap_uint<TrackBitWidths::kD0Size> getD0Word() const {
+    return trackWord_(TrackBitLocations::kD0MSB, TrackBitLocations::kD0LSB);
+  }
+  ap_uint<TrackBitWidths::kChi2RPhiSize> getChi2RPhiWord() const {
+    return trackWord_(TrackBitLocations::kChi2RPhiMSB, TrackBitLocations::kChi2RPhiLSB);
+  }
+  ap_uint<TrackBitWidths::kChi2RZSize> getChi2RZWord() const {
+    return trackWord_(TrackBitLocations::kChi2RZMSB, TrackBitLocations::kChi2RZLSB);
+  }
+  ap_uint<TrackBitWidths::kBendChi2Size> getBendChi2Word() const {
+    return trackWord_(TrackBitLocations::kBendChi2MSB, TrackBitLocations::kBendChi2LSB);
+  }
+  ap_uint<TrackBitWidths::kHitPatternSize> getHitPatternWord() const {
+    return trackWord_(TrackBitLocations::kHitPatternMSB, TrackBitLocations::kHitPatternLSB);
+  }
+  ap_uint<TrackBitWidths::kMVAQualitySize> getMVAQualityWord() const {
+    return trackWord_(TrackBitLocations::kMVAQualityMSB, TrackBitLocations::kMVAQualityLSB);
+  }
+  ap_uint<TrackBitWidths::kMVAOtherSize> getMVAOtherWord() const {
+    return trackWord_(TrackBitLocations::kMVAOtherMSB, TrackBitLocations::kMVAOtherLSB);
+  }
+  ap_uint<TrackBitWidths::kTrackWordSize> getTrackWord() const { return trackWord_; }
+
+  // These functions return the packed bits in integer format for each quantity
+  // Signed quantities have the sign enconded in the left-most bit.
+  unsigned int getValidBits() const { return getValidWord().to_uint(); }
+  unsigned int getRinvBits() const { return getRinvWord().to_uint(); }
+  unsigned int getPhiBits() const { return getPhiWord().to_uint(); }
+  unsigned int getTanlBits() const { return getTanlWord().to_uint(); }
+  unsigned int getZ0Bits() const { return getZ0Word().to_uint(); }
+  unsigned int getD0Bits() const { return getD0Word().to_uint(); }
+  unsigned int getChi2RPhiBits() const { return getChi2RPhiWord().to_uint(); }
+  unsigned int getChi2RZBits() const { return getChi2RZWord().to_uint(); }
+  unsigned int getBendChi2Bits() const { return getBendChi2Word().to_uint(); }
+  unsigned int getHitPatternBits() const { return getHitPatternWord().to_uint(); }
+  unsigned int getMVAQualityBits() const { return getMVAQualityWord().to_uint(); }
+  unsigned int getMVAOtherBits() const { return getMVAOtherWord().to_uint(); }
+
+  // These functions return the unpacked and converted values
+  // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
+  bool getValid() const { return getValidWord().to_bool(); }
+  double getRinv() const { return unpackSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
+  double getPhi() const { return unpackSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepRinv); }
+  double getTanl() const { return unpackSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepRinv); }
+  double getZ0() const { return unpackSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepRinv); }
+  double getD0() const { return unpackSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepRinv); }
+  double getChi2RPhi() const { return chi2RPhiBins[getChi2RPhiBits()]; }
+  double getChi2RZ() const { return chi2RZBins[getChi2RZBits()]; }
+  double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
+  unsigned int getHitPattern() const { return getHitPatternBits(); }
+  unsigned int getMVAQuality() const { return getMVAQualityBits(); }
+  unsigned int getMVAOther() const { return getMVAOtherBits(); }
+
+  // ----------member functions (setters) ------------
+  void setTrackWord(unsigned int valid,
+                    const GlobalVector& momentum,
+                    const GlobalPoint& POCA,
+                    double rInv,
+                    double chi2RPhi,  // would be total chisq if chi2Z is zero
+                    double chi2RZ,
+                    double bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
+
+  void setTrackWord(unsigned int valid,
+                    unsigned int rInv,
+                    unsigned int phi0,
+                    unsigned int tanl,
+                    unsigned int z0,
+                    unsigned int d0,
+                    unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                    unsigned int chi2RZ,
+                    unsigned int bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
+
+  void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
+                    ap_uint<TrackBitWidths::kRinvSize> rInv,
+                    ap_uint<TrackBitWidths::kPhiSize> phi0,
+                    ap_uint<TrackBitWidths::kTanlSize> tanl,
+                    ap_uint<TrackBitWidths::kZ0Size> z0,
+                    ap_uint<TrackBitWidths::kD0Size> d0,
+                    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhi,  // would be total chisq if chi2Z is zero
+                    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
+                    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
+                    ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
+                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+                    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
+
 private:
-  void initialize();
+  // ----------private member functions --------------
+  unsigned int digitizeSignedValue(double value, unsigned int nBits, double lsb) const {
+    unsigned int digitized_value = std::floor(std::abs(value) / lsb);
+    unsigned int digitized_maximum = (1 << (nBits - 1)) - 1;  // The remove 1 bit from nBits to account for the sign
+    if (digitized_value > digitized_maximum)
+      digitized_value = digitized_maximum;
+    if (value < 0)
+      digitized_value = (1 << nBits) - digitized_value;  // two's complement encoding
+    return digitized_value;
+  }
 
-  unsigned int digitize_Signed(float var, unsigned int maxBit, unsigned int minBit, float lsb);
+  template <typename T>
+  constexpr unsigned int getBin(double value, const T& bins) const {
+    auto up = std::upper_bound(bins.begin(), bins.end(), value);
+    return (up - bins.begin() - 1);
+  }
 
-  float unpack_Signed(unsigned int bits, unsigned int nBits, float lsb);
+  double unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const {
+    int isign = 1;
+    unsigned int digitized_maximum = (1 << nBits) - 1;
+    if (bits & (1 << (nBits - 1))) {  // check the sign
+      isign = -1;
+      bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+    }
+    return (double(bits & digitized_maximum) + 0.5) * lsb * isign;
+  }
 
-  // individual data members (not packed into 96 bits)
-  unsigned int iRinv;
-  unsigned int iphi;
-  unsigned int itanl;
-  unsigned int iz0;
-  unsigned int id0;
-  unsigned int ichi2XY;
-  unsigned int ichi2Z;
-  unsigned int iBendChi2;
-  unsigned int ispare;
-  unsigned int iHitPattern;
-
-  // three 32-bit packed words
-
-  unsigned int TrackWord1;
-  unsigned int TrackWord2;
-  unsigned int TrackWord3;
-
-  // values of least significant bit for digitization
-
-  float valLSBCurv;
-  float valLSBPhi;
-  float valLSBTanl;
-  float valLSBZ0;
-  float valLSBD0;
-
-  float chi2Bins[16];
-  float chi2ZBins[16];
-  float Bchi2Bins[8];
-
-  unsigned int Nchi2;  // both chi2 have same packing
-  unsigned int NBchi2;
-
-  /* bits for packing: 
-  signed quantities (one bit for sign): 
-
-  q/R = 14+1 
-  phi = 11+1  (relative to sector center)
-  tanl = 15+1
-  z0  = 11+1
-  d0  = 12+1                                                                                                                                                      
-
-  unsigned:
-  chi2     = 4  (or chisqXY)
-  BendChi2 = 3
-  hitmask  = 7
-  chi2Z    = 4
-  Spare    = 10 
-
-  */
-
-  // signed quantities: total bits are these values plus one
-  const unsigned int NCurvBits = 14;
-  const unsigned int NPhiBits = 11;
-  const unsigned int NTanlBits = 15;
-  const unsigned int NZ0Bits = 11;
-  const unsigned int ND0Bits = 12;
-
-  // unsigned:
-  const unsigned int NChi2Bits = 4;
-  const unsigned int NBChi2Bits = 3;
-  const unsigned int NHitsBits = 7;
-  const unsigned int NSpareBits = 14;
-
-  // establish binning
-  const float maxCurv = 0.00855;  // 2 GeV pT Rinv is in cm
-  const float maxPhi = 1.026;     // relative to the center of the sector
-  const float maxTanl = 8.0;
-  const float maxZ0 = 30.;
-  const float maxD0 = 15.4;
-
-  // List of offsets and masks.  In principle, all of these could be derived from first
-  // principles given the number of bits. At some future time, we'll do this.
-
-  const unsigned int maskRinv = 0xFFFE0000;
-  const unsigned int maskPhi = 0xFFF00000;
-  const unsigned int maskTanL = 0xFFFF0000;
-  const unsigned int maskD0 = 0x000FFF80;
-  const unsigned int maskZ0 = 0x0000FFF0;
-  const unsigned int maskChi2XY = 0x0000000F;
-  const unsigned int maskChi2Z = 0x00003C00;
-  const unsigned int maskBendChi2 = 0x0001C000;
-  const unsigned int maskHitPat = 0x0000007F;
-  const unsigned int maskSpare = 0x000003FF;
-
-  const unsigned int nWordBits = 32;
-
-};  // end of class def
+  // ----------member data ---------------------------
+  tkword_t trackWord_;
+};
 
 #endif

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -182,8 +182,9 @@ public:
   }
   tkword_t getTrackWord() const { return tkword_t(trackWord_.to_string().c_str(), 2); }
 
-  // These functions return the packed bits in integer format for each quantity
-  // Signed quantities have the sign enconded in the left-most bit.
+  // These functions return the packed bits in unsigned integer format for each quantity
+  // Signed quantities have the sign enconded in the left-most bit of the pattern using
+  //   a two's complement representation
   unsigned int getValidBits() const { return getValidWord().to_uint(); }
   unsigned int getRinvBits() const { return getRinvWord().to_uint(); }
   unsigned int getPhiBits() const { return getPhiWord().to_uint(); }
@@ -201,10 +202,10 @@ public:
   // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
   bool getValid() const { return getValidWord().to_bool(); }
   double getRinv() const { return unpackSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
-  double getPhi() const { return unpackSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepRinv); }
-  double getTanl() const { return unpackSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepRinv); }
-  double getZ0() const { return unpackSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepRinv); }
-  double getD0() const { return unpackSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepRinv); }
+  double getPhi() const { return unpackSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); }
+  double getTanl() const { return unpackSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepTanL); }
+  double getZ0() const { return unpackSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepZ0); }
+  double getD0() const { return unpackSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepD0); }
   double getChi2RPhi() const { return chi2RPhiBins[getChi2RPhiBits()]; }
   double getChi2RZ() const { return chi2RZBins[getChi2RZBits()]; }
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bitset>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -42,8 +43,9 @@ public:
     kRinvSize = 15,       // Width of Rinv
     kValidSize = 1,       // Valid bit
 
-    kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size + kChi2RZSize 
-                   + kD0Size + kBendChi2Size + kHitPatternSize + kMVAQualitySize + kMVAOtherSize,  // Width of the track word in bits
+    kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size + kChi2RZSize + kD0Size +
+                     kBendChi2Size + kHitPatternSize + kMVAQualitySize +
+                     kMVAOtherSize,  // Width of the track word in bits
   };
 
   enum TrackBitLocations {
@@ -113,7 +115,8 @@ public:
   typedef ap_uint<TrackBitWidths::kMVAOtherSize> otherMVA_t;      // Specialized MVA selection
 
   // Track word types
-  typedef ap_uint<TrackBitWidths::kTrackWordSize> tkword_t;  // Entire track word;
+  typedef std::bitset<TrackBitWidths::kTrackWordSize> tkword_bs_t;  // Entire track word;
+  typedef ap_uint<TrackBitWidths::kTrackWordSize> tkword_t;         // Entire track word;
 
 public:
   // ----------Constructors --------------------------
@@ -153,43 +156,31 @@ public:
   // ----------member functions (getters) ------------
   // These functions return arbitarary precision unsigned int words (lists of bits) for each quantity
   // Signed quantities have the sign enconded in the left-most bit.
-  ap_uint<TrackBitWidths::kValidSize> getValidWord() const {
-    return trackWord_(TrackBitLocations::kValidMSB, TrackBitLocations::kValidLSB);
+  valid_t getValidWord() const { return getTrackWord()(TrackBitLocations::kValidMSB, TrackBitLocations::kValidLSB); }
+  rinv_t getRinvWord() const { return getTrackWord()(TrackBitLocations::kRinvMSB, TrackBitLocations::kRinvLSB); }
+  phi_t getPhiWord() const { return getTrackWord()(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB); }
+  tanl_t getTanlWord() const { return getTrackWord()(TrackBitLocations::kTanlMSB, TrackBitLocations::kTanlLSB); }
+  z0_t getZ0Word() const { return getTrackWord()(TrackBitLocations::kZ0MSB, TrackBitLocations::kZ0LSB); }
+  d0_t getD0Word() const { return getTrackWord()(TrackBitLocations::kD0MSB, TrackBitLocations::kD0LSB); }
+  chi2rphi_t getChi2RPhiWord() const {
+    return getTrackWord()(TrackBitLocations::kChi2RPhiMSB, TrackBitLocations::kChi2RPhiLSB);
   }
-  ap_uint<TrackBitWidths::kRinvSize> getRinvWord() const {
-    return trackWord_(TrackBitLocations::kRinvMSB, TrackBitLocations::kRinvLSB);
+  chi2rz_t getChi2RZWord() const {
+    return getTrackWord()(TrackBitLocations::kChi2RZMSB, TrackBitLocations::kChi2RZLSB);
   }
-  ap_uint<TrackBitWidths::kPhiSize> getPhiWord() const {
-    return trackWord_(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB);
+  bendChi2_t getBendChi2Word() const {
+    return getTrackWord()(TrackBitLocations::kBendChi2MSB, TrackBitLocations::kBendChi2LSB);
   }
-  ap_uint<TrackBitWidths::kTanlSize> getTanlWord() const {
-    return trackWord_(TrackBitLocations::kTanlMSB, TrackBitLocations::kTanlLSB);
+  hit_t getHitPatternWord() const {
+    return getTrackWord()(TrackBitLocations::kHitPatternMSB, TrackBitLocations::kHitPatternLSB);
   }
-  ap_uint<TrackBitWidths::kZ0Size> getZ0Word() const {
-    return trackWord_(TrackBitLocations::kZ0MSB, TrackBitLocations::kZ0LSB);
+  qualityMVA_t getMVAQualityWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAQualityMSB, TrackBitLocations::kMVAQualityLSB);
   }
-  ap_uint<TrackBitWidths::kD0Size> getD0Word() const {
-    return trackWord_(TrackBitLocations::kD0MSB, TrackBitLocations::kD0LSB);
+  otherMVA_t getMVAOtherWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAOtherMSB, TrackBitLocations::kMVAOtherLSB);
   }
-  ap_uint<TrackBitWidths::kChi2RPhiSize> getChi2RPhiWord() const {
-    return trackWord_(TrackBitLocations::kChi2RPhiMSB, TrackBitLocations::kChi2RPhiLSB);
-  }
-  ap_uint<TrackBitWidths::kChi2RZSize> getChi2RZWord() const {
-    return trackWord_(TrackBitLocations::kChi2RZMSB, TrackBitLocations::kChi2RZLSB);
-  }
-  ap_uint<TrackBitWidths::kBendChi2Size> getBendChi2Word() const {
-    return trackWord_(TrackBitLocations::kBendChi2MSB, TrackBitLocations::kBendChi2LSB);
-  }
-  ap_uint<TrackBitWidths::kHitPatternSize> getHitPatternWord() const {
-    return trackWord_(TrackBitLocations::kHitPatternMSB, TrackBitLocations::kHitPatternLSB);
-  }
-  ap_uint<TrackBitWidths::kMVAQualitySize> getMVAQualityWord() const {
-    return trackWord_(TrackBitLocations::kMVAQualityMSB, TrackBitLocations::kMVAQualityLSB);
-  }
-  ap_uint<TrackBitWidths::kMVAOtherSize> getMVAOtherWord() const {
-    return trackWord_(TrackBitLocations::kMVAOtherMSB, TrackBitLocations::kMVAOtherLSB);
-  }
-  ap_uint<TrackBitWidths::kTrackWordSize> getTrackWord() const { return trackWord_; }
+  tkword_t getTrackWord() const { return tkword_t(trackWord_.to_string().c_str(), 2); }
 
   // These functions return the packed bits in integer format for each quantity
   // Signed quantities have the sign enconded in the left-most bit.
@@ -288,7 +279,7 @@ private:
   }
 
   // ----------member data ---------------------------
-  tkword_t trackWord_;
+  tkword_bs_t trackWord_;
 };
 
 #endif

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -131,51 +131,51 @@ void TTTrack_TrackWord::setTrackWord(
     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
   // pack the track word
   unsigned int offset = 0;
-  for (unsigned int b = offset; b < offset + TrackBitWidths::kValidSize; b++) {
-    trackWord_.set(b, valid[b - offset]);
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAOtherSize); b++) {
+    trackWord_.set(b, mvaOther[b - offset]);
   }
-  offset += TrackBitWidths::kValidSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kRinvSize); b++) {
-    trackWord_.set(b, rInv[b - offset]);
-  }
-  offset += TrackBitWidths::kRinvSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kPhiSize); b++) {
-    trackWord_.set(b, phi0[b - offset]);
-  }
-  offset += TrackBitWidths::kPhiSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kTanlSize); b++) {
-    trackWord_.set(b, tanl[b - offset]);
-  }
-  offset += TrackBitWidths::kTanlSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kZ0Size); b++) {
-    trackWord_.set(b, z0[b - offset]);
-  }
-  offset += TrackBitWidths::kZ0Size;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kD0Size); b++) {
-    trackWord_.set(b, d0[b - offset]);
-  }
-  offset += TrackBitWidths::kD0Size;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RPhiSize); b++) {
-    trackWord_.set(b, chi2RPhi[b - offset]);
-  }
-  offset += TrackBitWidths::kChi2RPhiSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RZSize); b++) {
-    trackWord_.set(b, chi2RZ[b - offset]);
-  }
-  offset += TrackBitWidths::kChi2RZSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kBendChi2Size); b++) {
-    trackWord_.set(b, bendChi2[b - offset]);
-  }
-  offset += TrackBitWidths::kBendChi2Size;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {
-    trackWord_.set(b, hitPattern[b - offset]);
-  }
-  offset += TrackBitWidths::kHitPatternSize;
+  offset += TrackBitWidths::kMVAOtherSize;
   for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
     trackWord_.set(b, mvaQuality[b - offset]);
   }
   offset += TrackBitWidths::kMVAQualitySize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAOtherSize); b++) {
-    trackWord_.set(b, mvaOther[b - offset]);
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {
+    trackWord_.set(b, hitPattern[b - offset]);
+  }
+  offset += TrackBitWidths::kHitPatternSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kBendChi2Size); b++) {
+    trackWord_.set(b, bendChi2[b - offset]);
+  }
+  offset += TrackBitWidths::kBendChi2Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kD0Size); b++) {
+    trackWord_.set(b, d0[b - offset]);
+  }
+  offset += TrackBitWidths::kD0Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RZSize); b++) {
+    trackWord_.set(b, chi2RZ[b - offset]);
+  }
+  offset += TrackBitWidths::kChi2RZSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kZ0Size); b++) {
+    trackWord_.set(b, z0[b - offset]);
+  }
+  offset += TrackBitWidths::kZ0Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kTanlSize); b++) {
+    trackWord_.set(b, tanl[b - offset]);
+  }
+  offset += TrackBitWidths::kTanlSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RPhiSize); b++) {
+    trackWord_.set(b, chi2RPhi[b - offset]);
+  }
+  offset += TrackBitWidths::kChi2RPhiSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kPhiSize); b++) {
+    trackWord_.set(b, phi0[b - offset]);
+  }
+  offset += TrackBitWidths::kPhiSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kRinvSize); b++) {
+    trackWord_.set(b, rInv[b - offset]);
+  }
+  offset += TrackBitWidths::kRinvSize;
+  for (unsigned int b = offset; b < offset + TrackBitWidths::kValidSize; b++) {
+    trackWord_.set(b, valid[b - offset]);
   }
 }

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -4,7 +4,9 @@
 // packing scheme given below.
 //
 // author: Mike Hildreth
-// date:   April 9, 2019
+// modified by: Alexx Perloff
+// created:     April 9, 2019
+// modified:    March 9, 2021
 //
 ///////
 
@@ -14,423 +16,166 @@
 #include <string>
 
 //Constructor - turn track parameters into 96-bit word
-
-TTTrack_TrackWord::TTTrack_TrackWord(const GlobalVector& Momentum,
+TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
+                                     const GlobalVector& momentum,
                                      const GlobalPoint& POCA,
-                                     double theRinv,
-                                     double theChi2XY,
-                                     double theChi2Z,
-                                     double theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare) {
-  setTrackWord(Momentum, POCA, theRinv, theChi2XY, theChi2Z, theBendChi2, theHitPattern, iSpare);
+                                     double rInv,
+                                     double chi2RPhi,  // would be xy chisq if chi2Z is non-zero
+                                     double chi2RZ,
+                                     double bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
+  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
 }
 
-TTTrack_TrackWord::TTTrack_TrackWord(unsigned int theRinv,
+TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
+                                     unsigned int rInv,
                                      unsigned int phi0,
                                      unsigned int tanl,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int theChi2XY,
-                                     unsigned int theChi2Z,
-                                     unsigned int theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare)
-    : iRinv(theRinv),
-      iphi(phi0),
-      itanl(tanl),
-      iz0(z0),
-      id0(d0),
-      ichi2XY(theChi2XY),      //revert to other packing?  Or will be unpacked wrong
-      ichi2Z(theChi2Z),        //revert to other packing?  Or will be unpacked wrong
-      iBendChi2(theBendChi2),  // revert to ogher packing? Or will be unpacked wrong
-      ispare(iSpare),
-      iHitPattern(theHitPattern) {
-  initialize();
+                                     unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                                     unsigned int chi2RZ,
+                                     unsigned int bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
+  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
 }
 
-// one for already-digitized values:
-
-void TTTrack_TrackWord::setTrackWord(unsigned int theRinv,
-                                     unsigned int phi0,
-                                     unsigned int tanl,
-                                     unsigned int z0,
-                                     unsigned int d0,
-                                     unsigned int theChi2XY,
-                                     unsigned int theChi2Z,
-                                     unsigned int theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare) {
-  iRinv = theRinv;
-  iphi = phi0;
-  itanl = tanl;
-  iz0 = z0;
-  id0 = d0;
-  ichi2XY = theChi2XY;      //revert to other packing?  Or will be unpacked wrong
-  ichi2Z = theChi2Z;        //revert to other packing?  Or will be unpacked wrong
-  iBendChi2 = theBendChi2;  // revert to ogher packing? Or will be unpacked wrong
-  ispare = iSpare;
-  iHitPattern = theHitPattern;
-
-  initialize();
-}
-
-// one for floats:
-void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
+// A setter for the floating point values
+void TTTrack_TrackWord::setTrackWord(unsigned int valid,
+                                     const GlobalVector& momentum,
                                      const GlobalPoint& POCA,
-                                     double theRinv,
-                                     double theChi2XY,
-                                     double theChi2Z,
-                                     double theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare) {
-  initialize();
-
+                                     double rInv,
+                                     double chi2RPhi,  // would be total chisq if chi2Z is zero
+                                     double chi2RZ,
+                                     double bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
   // first, derive quantities to be packed
-
-  float rPhi = Momentum.phi();  // this needs to be phi relative to center of sector ****
-  float rTanl = Momentum.z() / Momentum.perp();
+  float rPhi = momentum.phi();  // this needs to be phi relative to center of sector ****
+  float rTanl = momentum.z() / momentum.perp();
   float rZ0 = POCA.z();
   float rD0 = POCA.perp();
 
-  // bin, convert to integers, and pack
+  // bin and convert to integers
+  valid_t valid_ = valid;
+  rinv_t rInv_ = digitizeSignedValue(rInv, TrackBitWidths::kRinvSize, stepRinv);
+  phi_t phi0_ = digitizeSignedValue(rPhi, TrackBitWidths::kPhiSize, stepPhi0);
+  tanl_t tanl_ = digitizeSignedValue(rTanl, TrackBitWidths::kTanlSize, stepTanL);
+  z0_t z0_ = digitizeSignedValue(rZ0, TrackBitWidths::kZ0Size, stepZ0);
+  d0_t d0_ = digitizeSignedValue(rD0, TrackBitWidths::kD0Size, stepD0);
+  chi2rphi_t chi2RPhi_ = getBin(chi2RPhi, chi2RPhiBins);
+  chi2rz_t chi2RZ_ = getBin(chi2RZ, chi2RZBins);
+  bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
+  hit_t hitPattern_ = hitPattern;
+  qualityMVA_t mvaQuality_ = mvaQuality;
+  otherMVA_t mvaOther_ = mvaOther;
 
-  unsigned int seg1, seg2, seg3;
-  seg1 = 0;
-  seg2 = 0;
-  seg3 = 0;
+  // pack the track word
+  //trackWord = ( mvaOther_, mvaQuality_, hitPattern_, bendChi2_, chi2RZ_, chi2RPhi_, d0_, z0_, tanl_, phi0_, rInv_, valid_ );
+  setTrackWord(
+      valid_, rInv_, phi0_, tanl_, z0_, d0_, chi2RPhi_, chi2RZ_, bendChi2_, hitPattern_, mvaQuality_, mvaOther_);
+}
 
-  //tanl
+// A setter for already-digitized values
+void TTTrack_TrackWord::setTrackWord(unsigned int valid,
+                                     unsigned int rInv,
+                                     unsigned int phi0,
+                                     unsigned int tanl,
+                                     unsigned int z0,
+                                     unsigned int d0,
+                                     unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                                     unsigned int chi2RZ,
+                                     unsigned int bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
+  // bin and convert to integers
+  valid_t valid_ = valid;
+  rinv_t rInv_ = rInv;
+  phi_t phi0_ = phi0;
+  tanl_t tanl_ = tanl;
+  z0_t z0_ = z0;
+  d0_t d0_ = d0;
+  chi2rphi_t chi2RPhi_ = chi2RPhi;
+  chi2rz_t chi2RZ_ = chi2RZ;
+  bendChi2_t bendChi2_ = bendChi2;
+  hit_t hitPattern_ = hitPattern;
+  qualityMVA_t mvaQuality_ = mvaQuality;
+  otherMVA_t mvaOther_ = mvaOther;
 
-  itanl = digitize_Signed(rTanl, NTanlBits, 0, valLSBTanl);
+  // pack the track word
+  //trackWord = ( otherMVA_t(mvaOther), qualityMVA_t(mvaQuality), hit_t(hitPattern),
+  //              bendChi2_t(bendChi2), chi2rz_t(chi2RZ), chi2rphi_t(chi2RPhi),
+  //              d0_t(d0), z0_t(z0), tanl_t(tanl), phi_t(phi0), rinv_t(rInv), valid_t(valid) );
+  setTrackWord(
+      valid_, rInv_, phi0_, tanl_, z0_, d0_, chi2RPhi_, chi2RZ_, bendChi2_, hitPattern_, mvaQuality_, mvaOther_);
+}
 
-  //z0
-  iz0 = digitize_Signed(rZ0, NZ0Bits, 0, valLSBZ0);
-
-  //chi2 has non-linear bins
-
-  ichi2XY = 0;
-
-  for (unsigned int ibin = 0; ibin < Nchi2; ++ibin) {
-    ichi2XY = ibin;
-    if (theChi2XY < chi2Bins[ibin])
-      break;
+void TTTrack_TrackWord::setTrackWord(
+    ap_uint<TrackBitWidths::kValidSize> valid,
+    ap_uint<TrackBitWidths::kRinvSize> rInv,
+    ap_uint<TrackBitWidths::kPhiSize> phi0,
+    ap_uint<TrackBitWidths::kTanlSize> tanl,
+    ap_uint<TrackBitWidths::kZ0Size> z0,
+    ap_uint<TrackBitWidths::kD0Size> d0,
+    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhi,  // would be total chisq if chi2Z is zero
+    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
+    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
+    ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
+    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
+  // pack the track word
+  unsigned int offset = 0;
+  for (unsigned int b = offset; b < offset + TrackBitWidths::kValidSize; b++) {
+    trackWord_.set(b, valid[b - offset]);
   }
-
-  //chi2Z has non-linear bins
-
-  ichi2Z = 0;
-
-  for (unsigned int ibin = 0; ibin < Nchi2; ++ibin) {
-    ichi2Z = ibin;
-    if (theChi2Z < chi2ZBins[ibin])
-      break;
+  offset += TrackBitWidths::kValidSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kRinvSize); b++) {
+    trackWord_.set(b, rInv[b - offset]);
   }
-
-  //phi
-  iphi = digitize_Signed(rPhi, NPhiBits, 0, valLSBPhi);
-
-  //d0
-  id0 = digitize_Signed(rD0, ND0Bits, 0, valLSBD0);
-
-  //Rinv
-  iRinv = digitize_Signed(theRinv, NCurvBits, 0, valLSBCurv);
-
-  //bend chi2 - non-linear bins
-  iBendChi2 = 0;
-
-  for (unsigned int ibin = 0; ibin < NBchi2; ++ibin) {
-    iBendChi2 = ibin;
-    if (theBendChi2 < Bchi2Bins[ibin])
-      break;
+  offset += TrackBitWidths::kRinvSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kPhiSize); b++) {
+    trackWord_.set(b, phi0[b - offset]);
   }
-
-  ispare = iSpare;
-
-  // spare bits
-  if (ispare > 0x3FFF)
-    ispare = 0x3FFF;
-
-  iHitPattern = theHitPattern;
-
-  //set bits
-  /*
-    Current packing scheme. Any changes here ripple everywhere!
-    
-    uint word1 = 16 (tanl) + 12 (z0) + 4 (chi2) = 32 bits
-    uint word2 = 12 (phi) + 13 (d0) + 7 (hitPattern) = 32 bits
-    uint word3 = 15 (pT) + 3 (bend chi2) + 14 (spare/TMVA) = 32 bits
-   */
-
-  //now pack bits; leave hardcoded for now as am example of how this could work
-
-  seg1 = (itanl << (nWordBits - (NTanlBits + 1)));          // extra bit or bits is for sign //16
-  seg2 = (iz0 << (nWordBits - (NTanlBits + NZ0Bits + 2)));  //4
-  seg3 = ichi2XY;
-
-  //set bits
-
-  TrackWord1 = seg1 + seg2 + seg3;
-  seg1 = 0;
-  seg2 = 0;
-  seg3 = 0;
-
-  //second 32-bit word
-  seg1 = (iphi << (nWordBits - (NPhiBits + 1)));           //20
-  seg2 = (id0 << (nWordBits - (NPhiBits + ND0Bits + 2)));  //7
-
-  //HitMask
-  seg3 = theHitPattern;
-
-  //set bits
-
-  TrackWord2 = seg1 + seg2 + seg3;
-  seg1 = 0;
-  seg2 = 0;
-  seg3 = 0;
-
-  //third 32-bit word
-
-  seg1 = (iRinv << (nWordBits - (NCurvBits + 1)));                            //17
-  seg2 = (iBendChi2 << (nWordBits - (NCurvBits + NBChi2Bits + 1)));           //14
-  seg3 = (ichi2Z << (nWordBits - (NCurvBits + NBChi2Bits + NChi2Bits + 1)));  //10
-  unsigned int seg4 = ispare;
-
-  TrackWord3 = seg1 + seg2 + seg3 + seg4;
-}
-// unpack
-
-float TTTrack_TrackWord::unpack_itanl() {
-  unsigned int bits = (TrackWord1 & maskTanL) >> (nWordBits - (NTanlBits + 1));  //16
-  float unpTanl = unpack_Signed(bits, NTanlBits, valLSBTanl);
-  return unpTanl;
-}
-
-float TTTrack_TrackWord::get_itanl() {
-  float unpTanl = unpack_Signed(itanl, NTanlBits, valLSBTanl);
-  return unpTanl;
-}
-
-unsigned int TTTrack_TrackWord::get_tanlBits() {
-  //unsigned int bits =  (TrackWord1 & 0xFFFF0000) >> 16;
-  return itanl;
-}
-
-float TTTrack_TrackWord::unpack_iz0() {
-  unsigned int bits = (TrackWord1 & maskZ0) >> (nWordBits - (NTanlBits + NZ0Bits + 2));  //4
-  float unpZ0 = unpack_Signed(bits, NZ0Bits, valLSBZ0);
-  return unpZ0;
-}
-
-float TTTrack_TrackWord::get_iz0() {
-  float unpZ0 = unpack_Signed(iz0, NZ0Bits, valLSBZ0);
-  return unpZ0;
-}
-
-unsigned int TTTrack_TrackWord::get_z0Bits() {
-  //unsigned int bits =   (TrackWord1 & 0x0000FFF0) >> 4;
-  return iz0;
-}
-
-float TTTrack_TrackWord::unpack_ichi2XY() {
-  unsigned int bits = (TrackWord1 & maskChi2XY);
-  float unpChi2 = chi2Bins[bits];
-  return unpChi2;
-}
-
-float TTTrack_TrackWord::get_ichi2XY() {
-  float unpChi2 = chi2Bins[ichi2XY];
-  return unpChi2;
-}
-
-unsigned int TTTrack_TrackWord::get_chi2XYBits() {
-  //unsigned int bits = (TrackWord1 & 0x0000000F);
-  return ichi2XY;
-}
-
-float TTTrack_TrackWord::unpack_iphi() {
-  unsigned int bits = (TrackWord2 & maskPhi) >> (nWordBits - (NPhiBits + 1));  //20
-  float unpPhi = unpack_Signed(bits, NPhiBits, valLSBPhi);
-  return unpPhi;
-}
-
-float TTTrack_TrackWord::get_iphi() {
-  float unpPhi = unpack_Signed(iphi, NPhiBits, valLSBPhi);
-  return unpPhi;
-}
-
-unsigned int TTTrack_TrackWord::get_phiBits() {
-  //unsigned int bits =   (TrackWord2 & 0xFFF00000) >> 20;
-  return iphi;
-}
-
-float TTTrack_TrackWord::unpack_id0() {
-  unsigned int bits = (TrackWord2 & maskD0) >> (nWordBits - (NPhiBits + ND0Bits + 2));  //7
-  float unpD0 = unpack_Signed(bits, ND0Bits, valLSBD0);
-  return unpD0;
-}
-
-float TTTrack_TrackWord::get_id0() {
-  float unpD0 = unpack_Signed(id0, ND0Bits, valLSBD0);
-  return unpD0;
-}
-
-unsigned int TTTrack_TrackWord::get_d0Bits() {
-  //  unsigned int bits =   (TrackWord2 & 0x000FFF80) >> 7;
-  return id0;
-}
-
-unsigned int TTTrack_TrackWord::unpack_hitPattern() {
-  unsigned int bits = (TrackWord2 & maskHitPat);
-  return bits;
-}
-
-unsigned int TTTrack_TrackWord::get_hitPattern() { return iHitPattern; }
-
-float TTTrack_TrackWord::unpack_iRinv() {
-  unsigned int bits = (TrackWord3 & maskRinv) >> (nWordBits - (NCurvBits + 1));  //17
-  float unpCurv = unpack_Signed(bits, NCurvBits, valLSBCurv);
-  return unpCurv;
-}
-
-float TTTrack_TrackWord::get_iRinv() {
-  float unpCurv = unpack_Signed(iRinv, NCurvBits, valLSBCurv);
-  return unpCurv;
-}
-
-float TTTrack_TrackWord::unpack_iBendChi2() {
-  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits + NBChi2Bits + 1));  //14
-  float unpBChi2 = Bchi2Bins[bits];
-  return unpBChi2;
-}
-
-float TTTrack_TrackWord::get_iBendChi2() {
-  float unpBChi2 = Bchi2Bins[iBendChi2];
-  return unpBChi2;
-}
-
-unsigned int TTTrack_TrackWord::get_BendChi2Bits() {
-  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits + NBChi2Bits + 1));  //14
-  return bits;
-}
-
-float TTTrack_TrackWord::unpack_ichi2Z() {
-  unsigned int bits = (TrackWord3 & maskChi2Z) >> (nWordBits - (NCurvBits + NBChi2Bits + NChi2Bits + 1));  //10
-  float unpChi2Z = chi2ZBins[bits];
-  return unpChi2Z;
-}
-
-float TTTrack_TrackWord::get_ichi2Z() {
-  float unpChi2Z = chi2ZBins[ichi2Z];
-  return unpChi2Z;
-}
-
-unsigned int TTTrack_TrackWord::unpack_ispare() {
-  unsigned int bits = (TrackWord3 & maskSpare);
-  return bits;
-}
-
-unsigned int TTTrack_TrackWord::get_ispare() { return ispare; }
-
-unsigned int TTTrack_TrackWord::digitize_Signed(float var, unsigned int maxBit, unsigned int minBit, float lsb) {
-  unsigned int nBits = (maxBit - minBit + 1);
-  unsigned int myVar = std::floor(fabs(var) / lsb);
-  unsigned int maxVal = (1 << (nBits - 1)) - 1;
-  if (myVar > maxVal)
-    myVar = maxVal;
-  if (var < 0)
-    myVar = (1 << nBits) - myVar;  // two's complement encoding
-  unsigned int seg = myVar;
-  return seg;
-}
-
-float TTTrack_TrackWord::unpack_Signed(unsigned int bits, unsigned int nBits, float lsb) {
-  int isign = 1;
-  unsigned int maxVal = (1 << nBits) - 1;
-  if (bits & (1 << nBits)) {  //check sign
-    isign = -1;
-    bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+  offset += TrackBitWidths::kPhiSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kTanlSize); b++) {
+    trackWord_.set(b, tanl[b - offset]);
   }
-  float unpacked = (float(bits & maxVal) + 0.5) * lsb;
-  unpacked = isign * unpacked;
-  return unpacked;
+  offset += TrackBitWidths::kTanlSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kZ0Size); b++) {
+    trackWord_.set(b, z0[b - offset]);
+  }
+  offset += TrackBitWidths::kZ0Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kD0Size); b++) {
+    trackWord_.set(b, d0[b - offset]);
+  }
+  offset += TrackBitWidths::kD0Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RPhiSize); b++) {
+    trackWord_.set(b, chi2RPhi[b - offset]);
+  }
+  offset += TrackBitWidths::kChi2RPhiSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RZSize); b++) {
+    trackWord_.set(b, chi2RZ[b - offset]);
+  }
+  offset += TrackBitWidths::kChi2RZSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kBendChi2Size); b++) {
+    trackWord_.set(b, bendChi2[b - offset]);
+  }
+  offset += TrackBitWidths::kBendChi2Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {
+    trackWord_.set(b, hitPattern[b - offset]);
+  }
+  offset += TrackBitWidths::kHitPatternSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
+    trackWord_.set(b, mvaQuality[b - offset]);
+  }
+  offset += TrackBitWidths::kMVAQualitySize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAOtherSize); b++) {
+    trackWord_.set(b, mvaOther[b - offset]);
+  }
 }
-
-void TTTrack_TrackWord::initialize() {
-  /* bits for packing, constants defined in TTTrack_TrackWord.h :
-
-  signed quantities (one bit for sign):
-  
-  q/R = 14+1
-  phi = 11+1  (relative to sector center)
-  tanl = 15+1
-  z0  = 11+1
-  d0  = 12+1
-
-  unsigned:
-
-  chi2     = 4
-  BendChi2 = 3
-  hitPattern  = 7
-  Spare    = 10
-  chi2Z    = 4
-
-  */
-
-  // define bits, 1<<N = 2^N
-
-  unsigned int CurvBins = (1 << NCurvBits);
-  unsigned int phiBins = (1 << NPhiBits);
-  unsigned int tanlBins = (1 << NTanlBits);
-  unsigned int z0Bins = (1 << NZ0Bits);
-  unsigned int d0Bins = (1 << ND0Bits);
-
-  Nchi2 = (1 << NChi2Bits);
-  NBchi2 = (1 << NBChi2Bits);
-
-  valLSBCurv = maxCurv / float(CurvBins);
-  valLSBPhi = maxPhi / float(phiBins);
-  valLSBTanl = maxTanl / float(tanlBins);
-  valLSBZ0 = maxZ0 / float(z0Bins);
-  valLSBD0 = maxD0 / float(d0Bins);
-
-  chi2Bins[0] = 0.25;
-  chi2Bins[1] = 0.5;
-  chi2Bins[2] = 1.0;
-  chi2Bins[3] = 2.;
-  chi2Bins[4] = 3.;
-  chi2Bins[5] = 5.;
-  chi2Bins[6] = 7.;
-  chi2Bins[7] = 10.;
-  chi2Bins[8] = 20.;
-  chi2Bins[9] = 40.;
-  chi2Bins[10] = 100.;
-  chi2Bins[11] = 200.;
-  chi2Bins[12] = 500.;
-  chi2Bins[13] = 1000.;
-  chi2Bins[14] = 3000.;
-
-  chi2ZBins[0] = 0.25;
-  chi2ZBins[1] = 0.5;
-  chi2ZBins[2] = 1.0;
-  chi2ZBins[3] = 2.;
-  chi2ZBins[4] = 3.;
-  chi2ZBins[5] = 5.;
-  chi2ZBins[6] = 7.;
-  chi2ZBins[7] = 10.;
-  chi2ZBins[8] = 20.;
-  chi2ZBins[9] = 40.;
-  chi2ZBins[10] = 100.;
-  chi2ZBins[11] = 200.;
-  chi2ZBins[12] = 500.;
-  chi2ZBins[13] = 1000.;
-  chi2ZBins[14] = 3000.;
-
-  Bchi2Bins[0] = 0.5;
-  Bchi2Bins[1] = 1.25;
-  Bchi2Bins[2] = 2.0;
-  Bchi2Bins[3] = 3.0;
-  Bchi2Bins[4] = 5.0;
-  Bchi2Bins[5] = 10.;
-  Bchi2Bins[6] = 50.;
-};

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -11,9 +11,6 @@
 ///////
 
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
-#include <iostream>
-#include <bitset>
-#include <string>
 
 //Constructor - turn track parameters into 96-bit word
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -20,12 +20,24 @@
   <class name="vector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
-  <class name="TTTrack_TrackWord"/>
+  <class name="TTTrack_TrackWord" ClassVersion="4">
+   <version ClassVersion="4" checksum="399667712"/>
+   <version ClassVersion="3" checksum="4186150061"/>
+   <ioread sourceClass = "TTTrack_TrackWord" version="[-3]" targetClass="TTTrack_TrackWord"
+    source="unsigned int iRinv; unsigned int iphi; unsigned int itanl; unsigned int iz0; unsigned int id0; unsigned int ichi2XY; unsigned int ichi2Z; unsigned int iBendChi2; unsigned int ispare; unsigned int iHitPattern;" target="">
+    <![CDATA[
+      TTTrack_TrackWord tmp(1, onfile.iRinv, onfile.iphi, onfile.itanl, onfile.iz0, onfile.id0, onfile.ichi2XY, onfile.ichi2Z, onfile.iBendChi2, onfile.iHitPattern, 0, 0);
+      *newObj=tmp;
+    ]]>
+   </ioread>
+  </class>
   <class name="std::vector<TTTrack_TrackWord>"/>
   <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>
   <class name="edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="TTDTC"/>
   <class name="edm::Wrapper<TTDTC>"/>
   <class name="TTDTC::Streams"/>
+  <class name="ap_uint<96>"/>
+  <class name="edm::Wrapper<ap_uint<96> >"/>
 </lcgdict>
 

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -21,7 +21,7 @@
   <class name="vector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="TTTrack_TrackWord" ClassVersion="4">
-   <version ClassVersion="4" checksum="399667712"/>
+   <version ClassVersion="4" checksum="133238749"/>
    <version ClassVersion="3" checksum="4186150061"/>
    <ioread sourceClass = "TTTrack_TrackWord" version="[-3]" targetClass="TTTrack_TrackWord"
     source="unsigned int iRinv; unsigned int iphi; unsigned int itanl; unsigned int iz0; unsigned int id0; unsigned int ichi2XY; unsigned int ichi2Z; unsigned int iBendChi2; unsigned int ispare; unsigned int iHitPattern;" target="">
@@ -37,7 +37,5 @@
   <class name="TTDTC"/>
   <class name="edm::Wrapper<TTDTC>"/>
   <class name="TTDTC::Streams"/>
-  <class name="ap_uint<96>"/>
-  <class name="edm::Wrapper<ap_uint<96> >"/>
 </lcgdict>
 

--- a/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
@@ -1,17 +1,19 @@
 <library   file="*.cc" name="L1TrackTriggerPlugins">
+<use   name="CommonTools/BaseParticlePropagator"/>
+<use   name="CommonTools/UtilAlgos"/>
+<use   name="DataFormats/Common"/>
+<use   name="DataFormats/L1TrackTrigger"/>
 <use   name="Geometry/TrackerNumberingBuilder"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="MagneticField/Records"/>
 <use   name="L1Trigger/L1TTrackMatch"/>
-<use   name="SimGeneral/HepPDTRecord"/>
-<use   name="CommonTools/BaseParticlePropagator"/>
-<use   name="SimDataFormats/GeneratorProducts"/>
-<use   name="PhysicsTools/UtilAlgos"/>
-<use   name="CommonTools/UtilAlgos"/>
-<use   name="DataFormats/L1TrackTrigger"/>
 <use   name="L1Trigger/TrackTrigger"/>
+<use   name="PhysicsTools/UtilAlgos"/>
+<use   name="SimGeneral/HepPDTRecord"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="hls"/>
 <use   name="hepmc"/>
 <use   name="root"/>
 <flags   EDM_PLUGIN="1"/>

--- a/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
@@ -72,15 +72,11 @@ private:
   };
 
   static constexpr double kEtaErrThresh = 0.0485;  // error corresponding to 0.25 of a degree error in lambda
-  //static constexpr double kMinTanLambda = 0.;          // lowest value for Tan(lambda) for eta = 0
-  //static constexpr double kMaxTanLambda = 5.466229214; // highest value for Tan(lambda) for eta = 2.4
 
   static constexpr double kPTErrThresh = 5;                    // error threshold in percent
   static constexpr double kSynchrotron = (1.0 / (0.3 * 3.8));  // 1/(0.3*B) for 1/R to 1/pT conversion
-  //static constexpr double kMinRT = (200.0*(double)kSynchrotron);   // lowest possible value for R for 2 GeV (in cm)
-  //static constexpr double kMaxRT = (51200.0*(double)kSynchrotron); // highest value for R (in cm)
-  static constexpr unsigned int kPtLutSize = (int)pow(2, (int)kPTOutputSize);
-  static constexpr unsigned int kEtaLutSize = (int)pow(2, (int)kEtaOutputSize);
+  static constexpr unsigned int kPtLutSize = (1 << ConversionBitWidths::kPTOutputSize);
+  static constexpr unsigned int kEtaLutSize = (1 << ConversionBitWidths::kEtaOutputSize);
 
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1Track;
   typedef std::vector<L1Track> TTTrackCollection;

--- a/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
@@ -1,0 +1,534 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1GTTInputProducer
+//
+/**\class L1GTTInputProducer L1GTTInputProducer.cc L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+
+ Description: Takes in L1TTracks and outputs the same tracks, but with modifications to the underlying track word.
+   The modifications convert from Rinv --> pt and tanL --> eta.
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Alexx Perloff
+//         Created:  Sat, 20 Feb 2021 17:02:00 GMT
+//
+//
+
+// user include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+// Vivado HLS includes
+#include <ap_fixed.h>
+#include <ap_int.h>
+
+// system include files
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <string>
+#include <sstream>
+#include <vector>
+
+//
+// class declaration
+//
+
+class L1GTTInputProducer : public edm::global::EDProducer<> {
+public:
+  explicit L1GTTInputProducer(const edm::ParameterSet&);
+  ~L1GTTInputProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  // ----------constants, enums and typedefs ---------
+  static constexpr unsigned int Npars4 = 4;
+  static constexpr unsigned int Npars5 = 5;
+  enum ConversionBitWidths {
+    kEtaMagSize = 3,     // eta output magnitude size; MAG + FRAC should be <= kEtaInputSize
+    kEtaFracSize = 5,    // eta output fraction size; MAG + FRAC should be <= kEtaInputSize
+    kEtaInputSize = 16,  // size of tan(lambda)
+
+    kPTMagSize = 7,     // magnitude output size; MAG + FRAC should be <= kPTInputSize
+    kPTFracSize = 3,    // fraction output size; MAG + FRAC should be <= kPTInputSize
+    kPTInputSize = 15,  // size of 1/R
+
+    kEtaOutputSize = kEtaMagSize + kEtaFracSize,  // total bit width for eta
+    kPTOutputSize = kPTMagSize + kPTFracSize,     // total bit width for pT
+  };
+
+  static constexpr double kEtaErrThresh = 0.0485;  // error corresponding to 0.25 of a degree error in lambda
+  //static constexpr double kMinTanLambda = 0.;          // lowest value for Tan(lambda) for eta = 0
+  //static constexpr double kMaxTanLambda = 5.466229214; // highest value for Tan(lambda) for eta = 2.4
+
+  static constexpr double kPTErrThresh = 5;                    // error threshold in percent
+  static constexpr double kSynchrotron = (1.0 / (0.3 * 3.8));  // 1/(0.3*B) for 1/R to 1/pT conversion
+  //static constexpr double kMinRT = (200.0*(double)kSynchrotron);   // lowest possible value for R for 2 GeV (in cm)
+  //static constexpr double kMaxRT = (51200.0*(double)kSynchrotron); // highest value for R (in cm)
+  static constexpr unsigned int kPtLutSize = (int)pow(2, (int)kPTOutputSize);
+  static constexpr unsigned int kEtaLutSize = (int)pow(2, (int)kEtaOutputSize);
+
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1Track;
+  typedef std::vector<L1Track> TTTrackCollection;
+  typedef edm::View<L1Track> TTTrackCollectionView;
+  typedef ap_fixed<kEtaOutputSize, kEtaMagSize, AP_RND_CONV, AP_SAT> out_eta_t;
+  typedef TTTrack_TrackWord::tanl_t in_eta_t;
+  typedef ap_ufixed<kPTOutputSize, kPTMagSize, AP_RND_CONV, AP_SAT> out_pt_t;
+  typedef TTTrack_TrackWord::rinv_t in_pt_t;
+  typedef ap_uint<1> out_charge_t;
+
+  // ----------member functions ----------------------
+  void generate_eta_lut();
+  void generate_pt_lut();
+  bool getEtaBits(
+      const L1Track& track, out_eta_t& etaBits, double& expected, double& maxErrPerc, double& maxErrEpsilon) const;
+  bool getPtBits(const L1Track& track,
+                 out_pt_t& ptBits,
+                 out_charge_t& chargeBit,
+                 double& expected,
+                 double& maxErrPerc,
+                 double& maxErrEpsilon,
+                 double& minErrPerc,
+                 double& minExpected) const;
+  double indexTanLambda2Eta(unsigned int indexTanLambda) const;
+  double inverseRT2InversePT(unsigned int indexRT) const;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  template <typename T>
+  int sgn(T val) const {
+    return (T(0) < val) - (val < T(0));
+  }  // From https://stackoverflow.com/questions/1903954/is-there-a-standard-sign-function-signum-sgn-in-c-c
+  double unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const;
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TTTrackCollectionView> l1TracksToken_;
+  const std::string outputCollectionName_;
+  int debug_;
+  std::vector<out_pt_t> pt_lut_;
+  std::vector<out_eta_t> eta_lut_;
+};
+
+//
+// constructors and destructor
+//
+L1GTTInputProducer::L1GTTInputProducer(const edm::ParameterSet& iConfig)
+    : l1TracksToken_(consumes<TTTrackCollectionView>(iConfig.getParameter<edm::InputTag>("l1TracksInputTag"))),
+      outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      debug_(iConfig.getParameter<int>("debug")) {
+  // Generate the required luts
+  generate_eta_lut();
+  generate_pt_lut();
+
+  // Define EDM output to be written to file (if required)
+  produces<TTTrackCollection>(outputCollectionName_);
+  produces<std::vector<double>>("L1GTTInputTrackPtExpected");
+  produces<std::vector<double>>("L1GTTInputTrackEtaExpected");
+}
+
+L1GTTInputProducer::~L1GTTInputProducer() {}
+
+//
+// member functions
+//
+
+/**
+  generate_lut: calculate the lut and write it to a file
+  - argument:None
+  - return (void): None
+  - method:
+    1) iterates through all possibilities of the input value
+    2) finds values of eta from input values
+    3) stores the values of eta in an array (lut)
+    4) writes out the array into a file (eta_lut.h)
+*/
+void L1GTTInputProducer::generate_eta_lut() {
+  // initialize lut array
+  eta_lut_.reserve(kEtaLutSize);
+
+  // iterate through all values in the lut
+  for (unsigned int i = 0; i < kEtaLutSize; i++) {
+    // -1 to ignore sign bit for input
+    unsigned int index = ((i + 0.5) * pow(2, (int)(kEtaInputSize - kEtaOutputSize)));
+    double newValue = indexTanLambda2Eta(index);  // map out the index to the represented eta
+    out_eta_t out_eta = newValue;                 // cast it to fxp
+    eta_lut_[i] = out_eta;                        // add value for the lut
+  }
+
+  if (debug_ >= 3) {
+    edm::LogInfo log("L1GTTInputProducer");
+    log << "generate_eta_lut::The eta_lut_[" << kEtaLutSize << "] values are ... \n";
+    for (unsigned int i = 0; i < kEtaLutSize; i++) {
+      log << "\t" << i << "\t" << eta_lut_[i] << "\n";
+    }
+  }
+}
+
+void L1GTTInputProducer::generate_pt_lut() {
+  // initialize lut array
+  pt_lut_.reserve(kPtLutSize);  // generate lut
+
+  // iterate through all values in the lut
+  for (unsigned int i = 0; i < kPtLutSize; i++) {
+    unsigned int index = (i + 0.5) * pow(2, (int)(kPTInputSize - 1 - kPTOutputSize));
+    double newValue = inverseRT2InversePT(index);  //map out the index to the represented 1/pT
+    out_pt_t out_pt = 1.0 / newValue;              // take the reciprocal and cast as an AP fixed-point (1/pt ==> pt)
+    pt_lut_[i] = out_pt;                           // setting the i-th value for the lut
+  }
+
+  if (debug_ >= 3) {
+    edm::LogInfo log("L1GTTInputProducer");
+    log << "generate_pt_lut::The pt_lut_[" << kPtLutSize << "] values are ... \n";
+    for (unsigned int i = 0; i < kPtLutSize; i++) {
+      log << "\t" << i << "\t" << pt_lut_[i] << "\n";
+    }
+  }
+}
+
+double L1GTTInputProducer::unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const {
+  int isign = 1;
+  unsigned int digitized_maximum = (1 << nBits) - 1;
+  if (bits & (1 << (nBits - 1))) {  // check the sign
+    isign = -1;
+    bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+  }
+  return (double(bits & digitized_maximum) + 0.5) * lsb * isign;
+}
+
+/**
+    indexTanLambda2Eta: calculates eta from tan(lambda)
+    - argument:
+        indexTanLambda (int): the index representation for tan(lambda)
+    - formula:
+        f(x) = -1*ln(tan((pi/2-atan(x))/2)), where x = tan(lambda)
+    - return (double): eta
+*/
+double L1GTTInputProducer::indexTanLambda2Eta(unsigned int indexTanLambda) const {
+  double tanl = unpackSignedValue(indexTanLambda, kEtaInputSize, TTTrack_TrackWord::stepTanL);
+  double theta = (M_PI / 2.0) - atan(tanl);
+  double eta = -1.0 * log(tan(theta / 2.0));
+  if (debug_ >= 3) {
+    edm::LogInfo("L1GTTInputProducer") << "indexTanLambda2Eta::tanl index = " << indexTanLambda << "\n"
+                                       << "indexTanLambda2Eta::tanl value = " << tanl << "\n"
+                                       << "indexTanLambda2Eta::theta = " << theta << "\n"
+                                       << "indexTanLambda2Eta::eta = " << eta;
+  }
+  return eta;
+}
+
+/**
+  inverseRT2InversePT: calculates 1/pT from 1/rT
+  - argument:
+    indexRT (int): the index representation for 1/rT
+  - formula:
+      f(x) = 100.*(1/(0.3*3.8))*x , where x = 1/R
+  - return (double): 1/pT
+*/
+double L1GTTInputProducer::inverseRT2InversePT(unsigned int indexRT) const {
+  double inverseRT = unpackSignedValue(indexRT, kPTInputSize, TTTrack_TrackWord::stepRinv);
+  return 100.0 * kSynchrotron * inverseRT;  // multiply by 100 to convert from cm to m
+}
+
+bool L1GTTInputProducer::getEtaBits(
+    const L1Track& track, out_eta_t& etaBits, double& expected, double& maxErrPerc, double& maxErrEpsilon) const {
+  // Conver the input to an ap_uint
+  in_eta_t value = track.getTanlWord();
+
+  // Get the expected outcome (floating point)
+  out_eta_t maxValuePossible = pow(2, 15);  // saturate at max value possible for fxp
+  expected = indexTanLambda2Eta(value);     // expected value for eta
+  if (expected > maxValuePossible) {
+    expected = maxValuePossible;
+  }
+
+  // Converted value (emulation)
+  // Masking and shifting converts the efficient bit representation into an index
+  // Start by setting up the masks
+  in_eta_t indexTanLambda = value;
+  in_eta_t mask = ~0;                                                      // mask (all 1's)
+  bool sign = indexTanLambda.range(kEtaInputSize - 1, kEtaInputSize - 1);  // sign bit of indexTanLambda
+  mask *= sign;  // all 0's for positive numbers, all 1's for negative numbers
+
+  // Take the absolute value of indexTanLambda (2's complement)
+  indexTanLambda ^= mask;
+  indexTanLambda += sign;
+
+  // Find the value for eta, not |eta|
+  indexTanLambda =
+      indexTanLambda >>
+      (kEtaInputSize -
+       kEtaOutputSize);  // Don't subtract 1 because we now want to take into account the sign bit of the output
+  etaBits = eta_lut_[indexTanLambda];
+
+  // Reinacting the sign
+  out_eta_t maskOut;
+  maskOut.V = ~0;
+  maskOut *= sign;
+  etaBits ^= maskOut;
+  etaBits.V += sign;
+
+  // Compare the floating point calculation to the emulation
+  double delta = std::abs(expected - etaBits.to_double());
+  double perc_diff = (delta / std::abs(expected)) * 100.;  // calc percentage error
+  if (delta > maxErrEpsilon) {
+    maxErrPerc = perc_diff;
+    maxErrEpsilon = delta;
+  }
+
+  if (delta >= kEtaErrThresh) {
+    edm::LogError("L1GTTInputProducer") << "getEtaBits::MISMATCH!!!\n"
+                                        << "\tTTTrack tanL = " << track.tanL() << "\n"
+                                        << "\tTTTrack eta = " << track.momentum().eta() << "\n"
+                                        << "\tTTTrack_TrackWord = " << track.getTrackWord().to_string(2) << "\n"
+                                        << "\tTTTrack_TrackWord tanlWord = " << track.getTanlWord() << " ("
+                                        << track.getTanlWord().to_string(2) << ")\n"
+                                        << "\tin_eta_t value = " << value << " (" << value.to_string(2) << ")\n"
+                                        << "\tExpected value = " << expected << "\n"
+                                        << "\tCalculated eta = " << etaBits.to_double() << " (" << etaBits.to_string(2)
+                                        << ") @ index " << indexTanLambda << "\n"
+                                        << "\tDelta = " << delta << "\tpercentage error = " << perc_diff;
+    return true;
+  } else {
+    if (debug_ >= 2) {
+      edm::LogInfo("L1GTTInputProducer")
+          << "getEtaBits::SUCCESS (TTTrack, floating eta calculation, bitwise calculation, initial index, lut index) = "
+          << "(" << track.momentum().eta() << ", " << expected << ", " << etaBits << ", " << value << ", "
+          << indexTanLambda << ")";
+    }
+  }
+
+  return false;
+}
+
+bool L1GTTInputProducer::getPtBits(const L1Track& track,
+                                   out_pt_t& ptBits,
+                                   out_charge_t& chargeBit,
+                                   double& expected,
+                                   double& maxErrPerc,
+                                   double& maxErrEpsilon,
+                                   double& minErrPerc,
+                                   double& minExpected) const {
+  // Convert the input to an ap_uint
+  in_pt_t value = track.getRinvWord();
+  in_pt_t value_initial = value;
+
+  // Get the expected outcome (floating point)
+  out_pt_t maxValuePossible = pow(2, 16);       // saturate at max value possible for fxp
+  expected = 1.0 / inverseRT2InversePT(value);  // expected value for inverse
+  bool saturation = true;
+  if (std::abs(expected) > maxValuePossible) {
+    expected = maxValuePossible;
+  } else {
+    saturation = false;
+  }
+
+  // Converted value (emulation)
+  // Masking and shifting converts the efficient bit representation into an index
+  // Start by setting up the masks
+  in_pt_t mask = ~0;                                            // mask (all 1's)
+  bool sign = value.range(kPTInputSize - 1, kPTInputSize - 1);  // sign bit of value
+  mask *= sign;  // all 0's for positive numbers, all 1's for negative numbers
+
+  // Take the absolute value of value (2's complement)
+  value ^= mask;
+  value += sign;
+
+  // Shift the value so that the index changes when the LSB of the output changes
+  value = value >> (kPTInputSize - 1 - (kPTOutputSize));
+
+  // Get the pt from the LUT
+  ptBits = pt_lut_[value];
+
+  // Set the charge bit
+  chargeBit = sign;
+  double charge = 1. - (2 * chargeBit.to_uint());
+
+  // Compare the floating point calculation to the emulation
+  double delta = std::abs(expected - (charge * ptBits.to_double()));
+  double perc_diff = (delta / std::abs(expected)) * 100.;
+
+  if (delta > maxErrEpsilon) {
+    maxErrPerc = perc_diff;
+    maxErrEpsilon = delta;
+  } else if (delta < minExpected && !saturation && minErrPerc > 100.0) {
+    minErrPerc = perc_diff;
+    minExpected = expected;
+  }
+
+  if (std::abs(perc_diff) >= kPTErrThresh && !saturation) {
+    edm::LogError("L1GTTInputProducer") << "getPtBits::MISMATCH!!!\n"
+                                        << "\tTTTrack Rinv = " << track.rInv() << "\n"
+                                        << "\tTTTrack pt = " << track.momentum().transverse() << "\n"
+                                        << "\tTTTrack_TrackWord = " << track.getTrackWord().to_string(2) << "\n"
+                                        << "\tTTTrack_TrackWord RinvWord = " << track.getRinvWord() << " ("
+                                        << track.getRinvWord().to_string(2) << ")\n"
+                                        << "\tin_pt_t value = " << value_initial << " (" << value_initial.to_string(2)
+                                        << ")\n"
+                                        << "\tExpected value = " << expected << "\n"
+                                        << "\tCalculated pt = " << ptBits.to_double() << " (" << ptBits.to_string(2)
+                                        << ") @ index " << value << "\n"
+                                        << "\tcharge = " << charge << " (bit = " << chargeBit << ")\n"
+                                        << "\tDelta = " << delta << "\tpercentage error = " << perc_diff;
+    return true;
+  } else {
+    if (debug_ >= 2) {
+      edm::LogInfo("L1GTTInputProducer") << "getPtBits::SUCCESS (TTTrack, floating pt calculation, charge, bitwise "
+                                            "calculation, initial index, lut index) = "
+                                         << "(" << sgn(track.rInv()) * track.momentum().transverse() << ", " << expected
+                                         << ", " << charge << ", " << ptBits << ", " << value_initial << ", " << value
+                                         << ")";
+    }
+  }
+
+  return false;
+}
+
+// ------------ method called to produce the data  ------------
+void L1GTTInputProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto vTTTrackOutput = std::make_unique<TTTrackCollection>();
+  auto vPtOutput = std::make_unique<std::vector<double>>();
+  auto vEtaOutput = std::make_unique<std::vector<double>>();
+
+  edm::Handle<TTTrackCollectionView> l1TracksHandle;
+  iEvent.getByToken(l1TracksToken_, l1TracksHandle);
+
+  out_charge_t chargeBit = 0;
+  out_pt_t ptBits = 0;
+  out_eta_t etaBits = 0;
+  in_pt_t ptBitsShifted = 0;
+  in_eta_t etaBitsShifted = 0;
+  unsigned int error_pt_c = 0;        // error counter
+  unsigned int error_eta_c = 0;       // error counter
+  double expectedPt = 0.0;            // expected value of the pt
+  double expectedEta = 0.0;           // expected value of the eta
+  double maxErrPercPt = 0.0;          // stores the maximum error percentage
+  double maxErrPercEta = 0.0;         // stores the maximum error percentage
+  double maxErrEpsilonPt = 0.0;       // keeps track of epsilon for max error
+  double maxErrEpsilonEta = 0.0;      // keeps track of epsilon for max error
+  double minErrPercPt = 10000000.0;   // stores the maximum error percentage
+  double minExpectedPt = 10000000.0;  // keeps track of epsilon for max error
+
+  unsigned int nOutput = l1TracksHandle->size();
+  vTTTrackOutput->reserve(nOutput);
+  vPtOutput->reserve(nOutput);
+  vEtaOutput->reserve(nOutput);
+  for (const auto& track : *l1TracksHandle) {
+    if (!(track.nFitPars() == Npars4 || track.nFitPars() == Npars5)) {
+      throw cms::Exception("nFitPars unknown")
+          << "L1GTTInputProducer::produce method is called with numFitPars_ = " << track.nFitPars()
+          << ". The only possible values are 4/5.";
+    }
+
+    // Fill the vector of tracks
+    vTTTrackOutput->push_back(track);
+    auto& currentTrackRef = vTTTrackOutput->back();
+    if (debug_ >= 2) {
+      edm::LogInfo("L1GTTInputProducer") << "produce::word before anything "
+                                         << currentTrackRef.getTrackWord().to_string(2);
+    }
+
+    // Do an initial setting of the bits based on the floating point values
+    currentTrackRef.setTrackWordBits();
+    if (debug_ >= 2) {
+      edm::LogInfo("L1GTTInputProducer") << "produce::word after initial setting of the track word "
+                                         << currentTrackRef.getTrackWord().to_string(2);
+    }
+
+    // Do the conversions
+    error_pt_c += getPtBits(
+        currentTrackRef, ptBits, chargeBit, expectedPt, maxErrPercPt, maxErrEpsilonPt, minErrPercPt, minExpectedPt);
+    error_eta_c += getEtaBits(currentTrackRef, etaBits, expectedEta, maxErrPercEta, maxErrEpsilonEta);
+
+    // Assign the exat same bits to an ap_uint
+    ptBitsShifted = ptBits.range();
+    etaBitsShifted = etaBits.range();
+
+    // Shift the bits so that the decimal is in the right spot for the GTT software
+    ptBitsShifted = ptBitsShifted << 2;
+    etaBitsShifted = etaBitsShifted << 8;
+
+    // Set the MSB for the pt to the sign of the incoming word
+    ptBitsShifted.set(kPTInputSize - 1, chargeBit);
+
+    // Set the correct bits based on the converted quanteties and the existing track word components
+    currentTrackRef.setTrackWord(currentTrackRef.getValidWord(),
+                                 ptBitsShifted,
+                                 currentTrackRef.getPhiWord(),
+                                 etaBitsShifted,
+                                 currentTrackRef.getZ0Word(),
+                                 currentTrackRef.getD0Word(),
+                                 currentTrackRef.getChi2RPhiWord(),
+                                 currentTrackRef.getChi2RZWord(),
+                                 currentTrackRef.getBendChi2Word(),
+                                 currentTrackRef.getHitPatternWord(),
+                                 currentTrackRef.getMVAQualityWord(),
+                                 currentTrackRef.getMVAOtherWord());
+    if (debug_ >= 2) {
+      edm::LogInfo("L1GTTInputProducer") << "produce::charge after all conversions " << chargeBit << "\n"
+                                         << "produce::ptBits after all conversions " << ptBits.to_string(2) << " ("
+                                         << ptBitsShifted.to_string(2) << " = " << ptBitsShifted.to_uint() << ")\n"
+                                         << "produce::etaBits after all conversions " << etaBits.to_string(2) << " ("
+                                         << etaBitsShifted.to_string(2) << " = " << etaBitsShifted.to_uint() << ")\n"
+                                         << "produce::word after all conversions "
+                                         << vTTTrackOutput->back().getTrackWord().to_string(2);
+    }
+
+    // Fill the remaining outputs
+    vPtOutput->push_back(expectedPt);
+    vEtaOutput->push_back(expectedEta);
+  }
+
+  if (debug_ >= 1) {
+    edm::LogInfo("L1GTTInputProducer") << "\nNumber of converted tracks: " << nOutput << "\n\n"
+                                       << "q/r ==> pt conversion:\n"
+                                       << "\tError Threshold: " << kPTErrThresh << "%\n"
+                                       << "\tMax error: " << maxErrEpsilonPt
+                                       << " GeV difference with percentage: " << maxErrPercPt << "% @ "
+                                       << 100.0 * maxErrEpsilonPt / maxErrPercPt << " GeV"
+                                       << "\n"
+                                       << "\tError @ max range: " << minExpectedPt
+                                       << " GeV with precentage: " << minErrPercPt << "%"
+                                       << "\n"
+                                       << "\tTotal number of errors: " << error_pt_c << "\n\n"
+                                       << "tan(lambda) ==> eta conversion:\n"
+                                       << "\tError Threshold: " << kEtaErrThresh << "\n"
+                                       << "\tMax error: " << maxErrEpsilonEta << " with percentage: " << maxErrPercEta
+                                       << "% @ " << 100.0 * maxErrEpsilonEta / maxErrPercEta << "\n"
+                                       << "\tTotal number of errors: " << error_eta_c;
+  }
+
+  if (error_pt_c + error_eta_c) {
+    edm::LogError("L1GTTInputProducer") << "produce::" << error_pt_c << "/" << error_eta_c
+                                        << " pt/eta mismatches detected!!!";
+  }
+
+  // Put the outputs into the event
+  iEvent.put(std::move(vTTTrackOutput), outputCollectionName_);
+  iEvent.put(std::move(vPtOutput), "L1GTTInputTrackPtExpected");
+  iEvent.put(std::move(vEtaOutput), "L1GTTInputTrackEtaExpected");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1GTTInputProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // L1GTTInputProducer
+  edm::ParameterSetDescription desc;
+  desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
+  desc.add<edm::InputTag>("l1TracksInputTag", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
+  desc.add<std::string>("outputCollectionName", "Level1TTTracksConverted");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1GTTInputProducer);

--- a/L1Trigger/L1TTrackMatch/python/L1GTTInputProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1GTTInputProducer_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+L1GTTInputProducer = cms.EDProducer('L1GTTInputProducer',
+  l1TracksInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+  outputCollectionName = cms.string("Level1TTTracksConverted"),
+  debug = cms.int32(0) # Verbosity levels: 0, 1, 2, 3
+)

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -11,6 +11,7 @@ namespace l1tVertexFinder {
 
   enum class Algorithm {
     FastHisto,
+    FastHistoEmulation,
     FastHistoLooseAssociation,
     GapClustering,
     AgglomerativeHierarchical,

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -104,10 +104,12 @@ namespace l1tVertexFinder {
                                        const std::vector<unsigned int>& counts);
     /// DBSCAN algorithm
     void DBSCAN();
-    /// TDR histogramming algorithmn
-    void FastHistoLooseAssociation();
     /// Histogramming algorithm
     void FastHisto(const TrackerTopology* tTopo);
+    /// Histogramming algorithm (emulation)
+    void FastHistoEmulation();
+    /// TDR histogramming algorithmn
+    void FastHistoLooseAssociation();
     /// Gap Clustering Algorithm
     void GapClustering();
     /// High pT Vertex Algorithm

--- a/L1Trigger/VertexFinder/plugins/VertexProducer.cc
+++ b/L1Trigger/VertexFinder/plugins/VertexProducer.cc
@@ -14,6 +14,10 @@ VertexProducer::VertexProducer(const edm::ParameterSet& iConfig)
     case Algorithm::FastHisto:
       edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the FastHisto binning algorithm";
       break;
+    case Algorithm::FastHistoEmulation:
+      edm::LogInfo("VertexProducer")
+          << "VertexProducer::Finding vertices using the emulation version of the FastHisto binning algorithm";
+      break;
     case Algorithm::FastHistoLooseAssociation:
       edm::LogInfo("VertexProducer")
           << "VertexProducer::Finding vertices using the FastHistoLooseAssociation binning algorithm";
@@ -74,6 +78,9 @@ void VertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
       vf.FastHisto(tTopoHandle.product());
       break;
     }
+    case Algorithm::FastHistoEmulation:
+      vf.FastHistoEmulation();
+      break;
     case Algorithm::FastHistoLooseAssociation:
       vf.FastHistoLooseAssociation();
       break;

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -48,6 +48,7 @@ namespace l1tVertexFinder {
 
   const std::map<std::string, Algorithm> AlgoSettings::algoNameMap = {
       {"FastHisto", Algorithm::FastHisto},
+      {"FastHistoEmulation", Algorithm::FastHistoEmulation},
       {"FastHistoLooseAssociation", Algorithm::FastHistoLooseAssociation},
       {"GapClustering", Algorithm::GapClustering},
       {"Agglomerative", Algorithm::AgglomerativeHierarchical},

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -595,4 +595,6 @@ namespace l1tVertexFinder {
     pv_index_ = 0;
   }  // end of FastHisto
 
+  void VertexFinder::FastHistoEmulation() {}  // end of FastHistoEmulation
+
 }  // namespace l1tVertexFinder


### PR DESCRIPTION
#### PR description:

This PR does three things:
1. Rewrites the TTTrack_TrackWord class to be more user friendly and to correspond more closely with the latest definition being used by the L1Trigger firmware. This necessitates an update to the `classes_def.xml` file to keep track of the class versions and to allow for backwards compatibility. This new class depends on the **hls** external.
2. Adds a simulation and emulation for the firmware modules which take in a track from the track trigger and convert the `q/R` value to be `pt` and the `tan(lambda)` value to be `eta`.
3. Add a framework for the emulation of the vertexing firmware and a new emulation type for the vertex object. This PR doesn't actually implement the emulation, but this will come in a later PR.

#### PR validation:

The following checks have been run on this code:
1. `clang-tidy` and `clang-format` have been run. Also checked that the code can compile.
2. Created a ntuple using the VertexNtupler. This shows that the code can run and that the output of the simulation stays the same, as expected. It also shows that these updated `TTTracks` can be passed to the emulator.