### PR TITLE
Clean up header files in track and vertex data formats

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/DataFormats/L1Trigger/BuildFile.xml
+++ b/DataFormats/L1Trigger/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <use name="DataFormats/L1TrackTrigger"/>
 <use name="DataFormats/HcalDetId"/>
+<use name="hls"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1Trigger/interface/VertexWord.h
+++ b/DataFormats/L1Trigger/interface/VertexWord.h
@@ -14,7 +14,9 @@
 #include "DataFormats/L1Trigger/interface/Vertex.h"
 
 #include <ap_int.h>
+#include <ap_fixed.h>
 
+#include <bitset>
 #include <vector>
 
 namespace l1t {


### PR DESCRIPTION
#### PR description:

This PR doesn't change any behavior or the ability to compile the code. It makes explicit that the VertexWord is using specific headers and the hls library while also removing an unnecessary header file from the TTTrack_TrackWord data format. This does not affect the class version or the serialization of the data formats. This will make for cleaner code and stave off future problems.

#### PR validation:

I checked with a fresh release that these changes are able to compile. They are not complex and won't trigger anything in the code-format or code-check tests.