### PR TITLE
Adjustable Internal Precision for Track Jets Emulation & Error Fixes

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -326,17 +326,17 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
       ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize, AP_RND_CONV, AP_SAT> trketainput = 0;
       trketainput.V = L1TrkPtrs_[k]->getTrackWord()(
           TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlLSB);
-      ap_ufixed<64, 28> eta_conv = 1.0 / Convert::ETA_LSB; //conversion factor from input eta format to output format
+      ap_ufixed<32+ExtraBits::ETA_BITS, 8+ExtraBits::ETA_BITS> eta_conv = 1.0 / Convert::ETA_LSB; //conversion factor from input eta format to output format
       glbeta_intern trketa = eta_conv * trketainput;
 
       glbphi_intern trkphi = Convert::makeGlbPhi(L1TrkPtrs_[k]->momentum().phi()); //global phi of track in output format
 
       ap_int<TTTrack_TrackWord::TrackBitWidths::kZ0Size> inputTrkZ0 = L1TrkPtrs_[k]->getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kZ0MSB,
                                                                          TTTrack_TrackWord::TrackBitLocations::kZ0LSB);
-      ap_ufixed<64, 28> z0_conv = TTTrack_TrackWord::stepZ0 / Convert::Z0_LSB; //conversion factor from input z format to output format
+      ap_ufixed<32+ExtraBits::Z0_BITS, 1+ExtraBits::Z0_BITS> z0_conv = TTTrack_TrackWord::stepZ0 / Convert::Z0_LSB; //conversion factor from input z format to output format
       z0_intern trkZ = z0_conv * inputTrkZ0;
       
-      ap_ufixed<32, 1> phi_conv = TTTrack_TrackWord::stepPhi0 / Convert::PHI_LSB;
+      ap_ufixed<32+ExtraBits::PHI_BITS, 1+ExtraBits::PHI_BITS> phi_conv = TTTrack_TrackWord::stepPhi0 / Convert::PHI_LSB;
       
       for (int i = 0; i < phiBins_; ++i) {
         for (int j = 0; j < etaBins_; ++j) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -231,8 +231,8 @@ void L1TrackJetEmulationProducer::produce(Event &iEvent, const EventSetup &iSetu
           continue;
         if (mzb.clusters[j].ntracks > 5000)
           continue;
-        l1t::glbeta_t jetEta = mzb.clusters[j].eta * Convert::ETAPHI_LSB_POW;
-        l1t::glbphi_t jetPhi = mzb.clusters[j].phi * Convert::ETAPHI_LSB_POW;
+        l1t::glbeta_t jetEta = mzb.clusters[j].eta * Convert::ETA_LSB_POW;
+        l1t::glbphi_t jetPhi = mzb.clusters[j].phi * Convert::PHI_LSB_POW;
         l1t::glbphi_t jetZ0 = mzb.zbincenter * Convert::Z0_LSB_POW;
         l1t::pt_t jetPt = mzb.clusters[j].pTtot;
         l1t::nt_t totalntracks_ = mzb.clusters[j].ntracks;
@@ -326,7 +326,7 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
       ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize, AP_RND_CONV, AP_SAT> trketainput = 0;
       trketainput.V = L1TrkPtrs_[k]->getTrackWord()(
           TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlLSB);
-      ap_ufixed<64, 28> eta_conv = 1.0 / Convert::ETAPHI_LSB; //conversion factor from input eta format to output format
+      ap_ufixed<64, 28> eta_conv = 1.0 / Convert::ETA_LSB; //conversion factor from input eta format to output format
       glbeta_intern trketa = eta_conv * trketainput;
 
       glbphi_intern trkphi = Convert::makeGlbPhi(L1TrkPtrs_[k]->momentum().phi()); //global phi of track in output format
@@ -336,7 +336,7 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
       ap_ufixed<64, 28> z0_conv = TTTrack_TrackWord::stepZ0 / Convert::Z0_LSB; //conversion factor from input z format to output format
       z0_intern trkZ = z0_conv * inputTrkZ0;
       
-      ap_ufixed<32, 1> phi_conv = TTTrack_TrackWord::stepPhi0 / Convert::ETAPHI_LSB;
+      ap_ufixed<32, 1> phi_conv = TTTrack_TrackWord::stepPhi0 / Convert::PHI_LSB;
       
       for (int i = 0; i < phiBins_; ++i) {
         for (int j = 0; j < etaBins_; ++j) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -90,9 +90,9 @@ private:
   int etaBins_;
   int phiBins_;
   double minTrkJetpT_;
-  l1t::z0_t zStep_;
-  l1t::glbeta_t etaStep_;
-  l1t::glbphi_t phiStep_;
+  z0_intern zStep_;
+  glbeta_intern etaStep_;
+  glbphi_intern phiStep_;
   bool displaced_;
   float d0CutNStubs4_;
   float d0CutNStubs5_;
@@ -138,9 +138,9 @@ tGeomToken_(esConsumes<TrackerGeometry,TrackerDigiGeometryRecord>(edm::ESInputTa
   nStubs4DisplacedBendTight_ = (float)iConfig.getParameter<double>("nStubs4Displacedbend_Tight");
   nStubs5DisplacedBendTight_ = (float)iConfig.getParameter<double>("nStubs5Displacedbend_Tight");
 
-  zStep_ = l1t::Scales::makeZ0(2.0 * trkZMax_ / zBins_);
-  etaStep_ = l1t::Scales::makeGlbEta(2.0 * trkEtaMax_ / etaBins_);  //etaStep is the width of an etabin
-  phiStep_ = l1t::Scales::makePhi(2.0 * M_PI / phiBins_);           ////phiStep is the width of a phibin
+  zStep_ = Convert::makeZ0(2.0 * trkZMax_ / zBins_);
+  etaStep_ = Convert::makeGlbEta(2.0 * trkEtaMax_ / etaBins_);  //etaStep is the width of an etabin
+  phiStep_ = Convert::makeGlbPhi(2.0 * M_PI / phiBins_);           ////phiStep is the width of a phibin
 
   if (displaced_)
     produces<l1t::TkJetWordCollection>("L1TrackJetsExtended");
@@ -225,15 +225,15 @@ void L1TrackJetEmulationProducer::produce(Event &iEvent, const EventSetup &iSetu
     if (mzb.clusters != nullptr) {
       for (int j = 0; j < mzb.nclust; ++j) {
         //FILL Two Layer Jets for Jet Collection
-        if (mzb.clusters[j].pTtot < l1t::Scales::makePtFromFloat(trkPtMin_))
+        if (mzb.clusters[j].pTtot < Convert::makePtFromFloat(trkPtMin_))
           continue;  //protects against reading bad memory
         if (mzb.clusters[j].ntracks < 1)
           continue;
         if (mzb.clusters[j].ntracks > 5000)
           continue;
-        l1t::glbeta_t jetEta = mzb.clusters[j].eta;
-        l1t::glbphi_t jetPhi = mzb.clusters[j].phi;
-        l1t::glbphi_t jetZ0 = mzb.zbincenter;
+        l1t::glbeta_t jetEta = mzb.clusters[j].eta * Convert::ETAPHI_LSB_POW;
+        l1t::glbphi_t jetPhi = mzb.clusters[j].phi * Convert::ETAPHI_LSB_POW;
+        l1t::glbphi_t jetZ0 = mzb.zbincenter * Convert::Z0_LSB_POW;
         l1t::pt_t jetPt = mzb.clusters[j].pTtot;
         l1t::nt_t totalntracks_ = mzb.clusters[j].ntracks;
         l1t::nx_t totalxtracks_ = mzb.clusters[j].nxtracks;
@@ -275,15 +275,15 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
   for (int z = 0; z < nz; ++z)
     all_zBins[z] = mzbtemp;
 
-  l1t::z0_t zmin = l1t::Scales::makeZ0(-1.0 * trkZMax_);
-  l1t::z0_t zmax = zmin + 2 * zStep_;
+  z0_intern zmin = Convert::makeZ0(-1.0 * trkZMax_);
+  z0_intern zmax = zmin + 2 * zStep_;
 
   EtaPhiBin epbins[phiBins_][etaBins_];  // create grid of phiBins
-  l1t::glbphi_t phi = l1t::Scales::makeGlbPhi(-1.0 * M_PI);
-  l1t::glbeta_t eta;
-  l1t::glbeta_t etamin, etamax, phimin, phimax;
+  glbphi_intern phi = Convert::makeGlbPhi(-1.0 * M_PI);
+  glbeta_intern eta;
+  glbeta_intern etamin, etamax, phimin, phimax;
   for (int i = 0; i < phiBins_; ++i) {
-    eta = l1t::Scales::makeGlbEta(-1.0 * trkEtaMax_);
+    eta = Convert::makeGlbEta(-1.0 * trkEtaMax_);
     for (int j = 0; j < etaBins_; ++j) {
       phimin = phi;
       phimax = phi + phiStep_;
@@ -321,35 +321,35 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
       ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize, AP_RND_CONV, AP_SAT> inputTrkPt = 0;
       inputTrkPt.V = L1TrkPtrs_[k]->getTrackWord()(
           TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
-      l1t::pt_t trkpt = inputTrkPt;
+      pt_intern trkpt = inputTrkPt;
 
       ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize, AP_RND_CONV, AP_SAT> trketainput = 0;
       trketainput.V = L1TrkPtrs_[k]->getTrackWord()(
           TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlLSB);
-      ap_ufixed<32, 8> eta_conv = 1.0 / l1t::Scales::ETAPHI_LSB; //conversion factor from input eta format to output format
-      l1t::glbeta_t trketa = eta_conv * trketainput;
+      ap_ufixed<64, 28> eta_conv = 1.0 / Convert::ETAPHI_LSB; //conversion factor from input eta format to output format
+      glbeta_intern trketa = eta_conv * trketainput;
 
-      l1t::glbphi_t trkphi = l1t::Scales::makeGlbPhi(L1TrkPtrs_[k]->momentum().phi()); //global phi of track in output format
+      glbphi_intern trkphi = Convert::makeGlbPhi(L1TrkPtrs_[k]->momentum().phi()); //global phi of track in output format
 
       ap_int<TTTrack_TrackWord::TrackBitWidths::kZ0Size> inputTrkZ0 = L1TrkPtrs_[k]->getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kZ0MSB,
                                                                          TTTrack_TrackWord::TrackBitLocations::kZ0LSB);
-      ap_ufixed<32, 1> z0_conv = TTTrack_TrackWord::stepZ0 / l1t::Scales::Z0_LSB; //conversion factor from input z format to output format
-      l1t::z0_t trkZ = z0_conv * inputTrkZ0;
+      ap_ufixed<64, 28> z0_conv = TTTrack_TrackWord::stepZ0 / Convert::Z0_LSB; //conversion factor from input z format to output format
+      z0_intern trkZ = z0_conv * inputTrkZ0;
       
-      ap_ufixed<32, 1> phi_conv = TTTrack_TrackWord::stepPhi0 / l1t::Scales::ETAPHI_LSB;
+      ap_ufixed<32, 1> phi_conv = TTTrack_TrackWord::stepPhi0 / Convert::ETAPHI_LSB;
       
       for (int i = 0; i < phiBins_; ++i) {
         for (int j = 0; j < etaBins_; ++j) {
           L2cluster[k] = epbins[i][j];
           if ((zmin <= trkZ && zmax >= trkZ) &&
-              ((epbins[i][j].eta - etaStep_ / 2 <= trketa && epbins[i][j].eta + etaStep_ / 2 >= trketa) &&
-               epbins[i][j].phi - phiStep_ / 2 <= trkphi && epbins[i][j].phi + phiStep_ / 2 >= trkphi &&
+              ((epbins[i][j].eta - etaStep_ / 2 < trketa && epbins[i][j].eta + etaStep_ / 2 >= trketa) &&
+               epbins[i][j].phi - phiStep_ / 2 < trkphi && epbins[i][j].phi + phiStep_ / 2 >= trkphi &&
                (zBinCount_[k] != 2))) {
             zBinCount_.at(k) = zBinCount_.at(k) + 1;
-            if (trkpt < l1t::Scales::makePtFromFloat(trkPtMax_))
+            if (trkpt < Convert::makePtFromFloat(trkPtMax_))
               epbins[i][j].pTtot += trkpt;
             else
-              epbins[i][j].pTtot += l1t::Scales::makePtFromFloat(trkPtMax_);
+              epbins[i][j].pTtot += Convert::makePtFromFloat(trkPtMax_);
             ++epbins[i][j].ntracks;
             //x-bit is currently not used in firmware, so we leave nxtracks = 0 for now
           }  // if right bin
@@ -366,14 +366,14 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
     
     //Create clusters array to hold output cluster data for Layer2; can't have more clusters than tracks.
     //Find eta-phibin with maxpT, make center of cluster, add neighbors if not already used.
-    l1t::pt_t hipT = 0;
+    pt_intern hipT = 0;
     int nclust = 0;
     int phibin = 0;
     int imax = -1;
     int index1;  //index of clusters array for each phislice
-    l1t::pt_t E1 = 0;
-    l1t::pt_t E0 = 0;
-    l1t::pt_t E2 = 0;
+    pt_intern E1 = 0;
+    pt_intern E0 = 0;
+    pt_intern E2 = 0;
     l1t::nt_t ntrk1, ntrk2;
     l1t::nx_t nxtrk1, nxtrk2;
     int used1, used2, used3, used4;
@@ -497,8 +497,8 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
         if (L2cluster[n].eta == L2cluster[m].eta &&
             ((L2cluster[n].phi - L2cluster[m].phi < 3 * phiStep_ / 2 &&
               L2cluster[m].phi - L2cluster[n].phi < 3 * phiStep_ / 2) ||
-             (L2cluster[n].phi - L2cluster[m].phi > 2 * l1t::Scales::makeGlbPhi(M_PI) - phiStep_ ||
-              L2cluster[m].phi - L2cluster[n].phi > 2 * l1t::Scales::makeGlbPhi(M_PI) - phiStep_))) {
+             (L2cluster[n].phi - L2cluster[m].phi > 2 * Convert::makeGlbPhi(M_PI) - phiStep_ ||
+              L2cluster[m].phi - L2cluster[n].phi > 2 * Convert::makeGlbPhi(M_PI) - phiStep_))) {
           if (L2cluster[n].pTtot > L2cluster[m].pTtot) {
             L2cluster[m].phi = L2cluster[n].phi;
           }
@@ -516,13 +516,13 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
     }  // end for (m) loop
     // sum up all pTs in this zbin to find ht
 
-    l1t::pt_t ht = 0;
+    pt_intern ht = 0;
     for (int k = 0; k < nclust; ++k) {
-      if (L2cluster[k].pTtot > l1t::Scales::makePtFromFloat(lowpTJetMinpT_) && L2cluster[k].ntracks < lowpTJetMinTrackMultiplicity_)
+      if (L2cluster[k].pTtot > Convert::makePtFromFloat(lowpTJetMinpT_) && L2cluster[k].ntracks < lowpTJetMinTrackMultiplicity_)
         continue;
-      if (L2cluster[k].pTtot > l1t::Scales::makePtFromFloat(highpTJetMinpT_) && L2cluster[k].ntracks < highpTJetMinTrackMultiplicity_)
+      if (L2cluster[k].pTtot > Convert::makePtFromFloat(highpTJetMinpT_) && L2cluster[k].ntracks < highpTJetMinTrackMultiplicity_)
         continue;
-      if (L2cluster[k].pTtot > l1t::Scales::makePtFromFloat(minTrkJetpT_))
+      if (L2cluster[k].pTtot > Convert::makePtFromFloat(minTrkJetpT_))
         ht += L2cluster[k].pTtot;
     }
     // if ht is larger than previous max, this is the new vertex zbin
@@ -571,7 +571,7 @@ EtaPhiBin *L1TrackJetEmulationProducer::L1_cluster(EtaPhiBin *phislice) {
     edm::LogWarning("L1TrackJetEmulationProducer") << "Clusters memory not assigned!\n";
 
   // Find eta-phibin with maxpT, make center of cluster, add neighbors if not already used
-  l1t::pt_t my_pt, left_pt, right_pt, right2pt;
+  pt_intern my_pt, left_pt, right_pt, right2pt;
   int nclust = 0;
   right2pt = 0;
   for (int etabin = 0; etabin < etaBins_; ++etabin) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
@@ -9,22 +9,70 @@
 
 using namespace std;
 
+namespace ExtraBits {
+  const int PT_BITS = 18;
+  const int ETAPHI_BITS = 20;
+  const int Z0_BITS = 22;
+}
+
+typedef ap_ufixed<32, 12, AP_TRN, AP_SAT> pt_intern;
+typedef ap_int<32> glbeta_intern;
+typedef ap_int<32> glbphi_intern;
+typedef ap_int<32> z0_intern;         // 40cm / 0.1
+
+namespace Convert {
+  const int INTPHI_PI = 720;
+  const int INTPHI_TWOPI = 2 * INTPHI_PI;
+  constexpr float INTPT_LSB_POW = pow(2.0,-2 - ExtraBits::PT_BITS);
+  constexpr float INTPT_LSB = INTPT_LSB_POW;
+  constexpr float ETAPHI_LSB_POW = pow(2.0,-1 * ExtraBits::ETAPHI_BITS);
+  constexpr float ETAPHI_LSB = M_PI / INTPHI_PI * ETAPHI_LSB_POW;
+  constexpr float Z0_LSB_POW = pow(2.0,-1 * ExtraBits::Z0_BITS);
+  constexpr float Z0_LSB = 0.05 * Z0_LSB_POW;
+  inline float floatPt(pt_intern pt) { return pt.to_float(); }
+  inline int intPt(pt_intern pt) { return (ap_ufixed<34, 14>(pt)).to_int(); }
+  inline float floatEta(glbeta_intern eta) { return eta.to_float() * ETAPHI_LSB; }
+  inline float floatPhi(glbphi_intern phi) { return phi.to_float() * ETAPHI_LSB; }
+  inline float floatZ0(z0_intern z0) { return z0.to_float() * Z0_LSB; }
+
+  inline pt_intern makePt(int pt) { return ap_ufixed<34, 14>(pt); }
+  inline pt_intern makePtFromFloat(float pt) { return pt_intern(INTPT_LSB_POW * round(pt / INTPT_LSB_POW)); }
+  inline z0_intern makeZ0(float z0) { return z0_intern(round(z0 / Z0_LSB)); }
+
+  inline ap_uint<pt_intern::width> ptToInt(pt_intern pt) {
+    // note: this can be synthethized, e.g. when pT is used as intex in a LUT
+    ap_uint<pt_intern::width> ret = 0;
+    ret(pt_intern::width - 1, 0) = pt(pt_intern::width - 1, 0);
+    return ret;
+  }
+
+  inline glbeta_intern makeGlbEta(float eta) { return round(eta / ETAPHI_LSB); }
+  inline glbeta_intern makeGlbEtaRoundEven(float eta) {
+    glbeta_intern ghweta = round(eta / ETAPHI_LSB);
+    return (ghweta % 2) ? glbeta_intern(ghweta + 1) : ghweta;
+  }
+
+  inline glbphi_intern makeGlbPhi(float phi) { return round(phi / ETAPHI_LSB); }
+
+};  // namespace Scales
+
+
 //Each individual box in the eta and phi dimension.
 //  Also used to store final cluster data for each zbin.
 struct EtaPhiBin {
-  l1t::pt_t pTtot;
+  pt_intern pTtot;
   l1t::nt_t ntracks;
   l1t::nx_t nxtracks;
   bool used;
-  l1t::glbphi_t phi;  //average phi value (halfway b/t min and max)
-  l1t::glbeta_t eta;  //average eta value
+  glbphi_intern phi;  //average phi value (halfway b/t min and max)
+  glbeta_intern eta;  //average eta value
 };
 
 //store important information for plots
 struct MaxZBin {
   int znum;    //Numbered from 0 to nzbins (16, 32, or 64) in order
   int nclust;  //number of clusters in this bin
-  l1t::z0_t zbincenter;
+  z0_intern zbincenter;
   EtaPhiBin *clusters;  //list of all the clusters in this bin
-  l1t::pt_t ht;         //sum of all cluster pTs--only the zbin with the maximum ht is stored
+  pt_intern ht;         //sum of all cluster pTs--only the zbin with the maximum ht is stored
 };

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
@@ -11,31 +11,34 @@ using namespace std;
 
 namespace ExtraBits {
   const int PT_BITS = 18;
-  const int ETAPHI_BITS = 20;
+  const int ETA_BITS = 20;
+  const int PHI_BITS = 21;
   const int Z0_BITS = 22;
 }
 
-typedef ap_ufixed<32, 12, AP_TRN, AP_SAT> pt_intern;
-typedef ap_int<32> glbeta_intern;
-typedef ap_int<32> glbphi_intern;
-typedef ap_int<32> z0_intern;         // 40cm / 0.1
+typedef ap_ufixed<14 + ExtraBits::PT_BITS, 12, AP_TRN, AP_SAT> pt_intern;
+typedef ap_int<12+ExtraBits::ETA_BITS> glbeta_intern;
+typedef ap_int<11+ExtraBits::PHI_BITS> glbphi_intern;
+typedef ap_int<10+ExtraBits::Z0_BITS> z0_intern;         // 40cm / 0.1
 
 namespace Convert {
   const int INTPHI_PI = 720;
   const int INTPHI_TWOPI = 2 * INTPHI_PI;
   constexpr float INTPT_LSB_POW = pow(2.0,-2 - ExtraBits::PT_BITS);
   constexpr float INTPT_LSB = INTPT_LSB_POW;
-  constexpr float ETAPHI_LSB_POW = pow(2.0,-1 * ExtraBits::ETAPHI_BITS);
-  constexpr float ETAPHI_LSB = M_PI / INTPHI_PI * ETAPHI_LSB_POW;
+  constexpr float ETA_LSB_POW = pow(2.0,-1 * ExtraBits::ETA_BITS);
+  constexpr float ETA_LSB = M_PI / INTPHI_PI * ETA_LSB_POW;
+  constexpr float PHI_LSB_POW = pow(2.0,-1 * ExtraBits::PHI_BITS);
+  constexpr float PHI_LSB = M_PI / INTPHI_PI * PHI_LSB_POW;
   constexpr float Z0_LSB_POW = pow(2.0,-1 * ExtraBits::Z0_BITS);
   constexpr float Z0_LSB = 0.05 * Z0_LSB_POW;
   inline float floatPt(pt_intern pt) { return pt.to_float(); }
-  inline int intPt(pt_intern pt) { return (ap_ufixed<34, 14>(pt)).to_int(); }
-  inline float floatEta(glbeta_intern eta) { return eta.to_float() * ETAPHI_LSB; }
-  inline float floatPhi(glbphi_intern phi) { return phi.to_float() * ETAPHI_LSB; }
+  inline int intPt(pt_intern pt) { return (ap_ufixed<16+ExtraBits::PT_BITS, 14>(pt)).to_int(); }
+  inline float floatEta(glbeta_intern eta) { return eta.to_float() * ETA_LSB; }
+  inline float floatPhi(glbphi_intern phi) { return phi.to_float() * PHI_LSB; }
   inline float floatZ0(z0_intern z0) { return z0.to_float() * Z0_LSB; }
 
-  inline pt_intern makePt(int pt) { return ap_ufixed<34, 14>(pt); }
+  inline pt_intern makePt(int pt) { return ap_ufixed<16+ExtraBits::PT_BITS, 14>(pt); }
   inline pt_intern makePtFromFloat(float pt) { return pt_intern(INTPT_LSB_POW * round(pt / INTPT_LSB_POW)); }
   inline z0_intern makeZ0(float z0) { return z0_intern(round(z0 / Z0_LSB)); }
 
@@ -46,13 +49,13 @@ namespace Convert {
     return ret;
   }
 
-  inline glbeta_intern makeGlbEta(float eta) { return round(eta / ETAPHI_LSB); }
+  inline glbeta_intern makeGlbEta(float eta) { return round(eta / ETA_LSB); }
   inline glbeta_intern makeGlbEtaRoundEven(float eta) {
-    glbeta_intern ghweta = round(eta / ETAPHI_LSB);
+    glbeta_intern ghweta = round(eta / ETA_LSB);
     return (ghweta % 2) ? glbeta_intern(ghweta + 1) : ghweta;
   }
 
-  inline glbphi_intern makeGlbPhi(float phi) { return round(phi / ETAPHI_LSB); }
+  inline glbphi_intern makeGlbPhi(float phi) { return round(phi / PHI_LSB); }
 
 };  // namespace Scales
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
@@ -9,36 +9,34 @@
 
 using namespace std;
 
-namespace ExtraBits {
-  const int PT_BITS = 18;
-  const int ETA_BITS = 20;
-  const int PHI_BITS = 21;
-  const int Z0_BITS = 22;
-}
+const int PT_EXTRABITS = 18;
+const int ETA_EXTRABITS = 20;
+const int PHI_EXTRABITS = 21;
+const int Z0_EXTRABITS = 22;
 
-typedef ap_ufixed<14 + ExtraBits::PT_BITS, 12, AP_TRN, AP_SAT> pt_intern;
-typedef ap_int<12+ExtraBits::ETA_BITS> glbeta_intern;
-typedef ap_int<11+ExtraBits::PHI_BITS> glbphi_intern;
-typedef ap_int<10+ExtraBits::Z0_BITS> z0_intern;         // 40cm / 0.1
+typedef ap_ufixed<14 + PT_EXTRABITS, 12, AP_TRN, AP_SAT> pt_intern;
+typedef ap_int<12+ETA_EXTRABITS> glbeta_intern;
+typedef ap_int<11+PHI_EXTRABITS> glbphi_intern;
+typedef ap_int<10+Z0_EXTRABITS> z0_intern;         // 40cm / 0.1
 
-namespace Convert {
+namespace convert {
   const int INTPHI_PI = 720;
   const int INTPHI_TWOPI = 2 * INTPHI_PI;
-  constexpr float INTPT_LSB_POW = pow(2.0,-2 - ExtraBits::PT_BITS);
+  constexpr float INTPT_LSB_POW = pow(2.0,-2 - PT_EXTRABITS);
   constexpr float INTPT_LSB = INTPT_LSB_POW;
-  constexpr float ETA_LSB_POW = pow(2.0,-1 * ExtraBits::ETA_BITS);
+  constexpr float ETA_LSB_POW = pow(2.0,-1 * ETA_EXTRABITS);
   constexpr float ETA_LSB = M_PI / INTPHI_PI * ETA_LSB_POW;
-  constexpr float PHI_LSB_POW = pow(2.0,-1 * ExtraBits::PHI_BITS);
+  constexpr float PHI_LSB_POW = pow(2.0,-1 * PHI_EXTRABITS);
   constexpr float PHI_LSB = M_PI / INTPHI_PI * PHI_LSB_POW;
-  constexpr float Z0_LSB_POW = pow(2.0,-1 * ExtraBits::Z0_BITS);
+  constexpr float Z0_LSB_POW = pow(2.0,-1 * Z0_EXTRABITS);
   constexpr float Z0_LSB = 0.05 * Z0_LSB_POW;
   inline float floatPt(pt_intern pt) { return pt.to_float(); }
-  inline int intPt(pt_intern pt) { return (ap_ufixed<16+ExtraBits::PT_BITS, 14>(pt)).to_int(); }
+  inline int intPt(pt_intern pt) { return (ap_ufixed<16+PT_EXTRABITS, 14>(pt)).to_int(); }
   inline float floatEta(glbeta_intern eta) { return eta.to_float() * ETA_LSB; }
   inline float floatPhi(glbphi_intern phi) { return phi.to_float() * PHI_LSB; }
   inline float floatZ0(z0_intern z0) { return z0.to_float() * Z0_LSB; }
 
-  inline pt_intern makePt(int pt) { return ap_ufixed<16+ExtraBits::PT_BITS, 14>(pt); }
+  inline pt_intern makePt(int pt) { return ap_ufixed<16+PT_EXTRABITS, 14>(pt); }
   inline pt_intern makePtFromFloat(float pt) { return pt_intern(INTPT_LSB_POW * round(pt / INTPT_LSB_POW)); }
   inline z0_intern makeZ0(float z0) { return z0_intern(round(z0 / Z0_LSB)); }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -241,7 +241,7 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
           float deta = L1TrkPtrs_[t]->momentum().eta() - jetEta;
           float dphi = L1TrkPtrs_[t]->momentum().phi() - jetPhi;
           float dZ = fabs(mzb.zbincenter - L1TrkPtrs_[t]->z0());
-          if (dZ < zStep_ && fabs(deta) < etaStep_ * 2.0 && fabs(dphi) < phiStep_ * 2.0) {
+          if (dZ <= zStep_ && fabs(deta) < etaStep_ * 2.0 && fabs(dphi) < phiStep_ * 2.0) {
             L1TrackAssocJet.push_back(L1TrkPtrs_[t]);
           }
         }


### PR DESCRIPTION
**PR description:**

This PR does the following:

1.    Makes the internal precision of the fixed point variables in the Track Jets Emulation easily adjustable.
2.    Fixes two small logic errors in the emulation and simulation.

**Future updates not included in this PR:**

1. In the future we will want the ability to write out text files which contain the emulation inputs and outputs, for comparison to the HLS/firmware code. However, this feature is not yet implemented.
2. We currently take the global phi of each track directly from TTTrack_TrackWord. Once GTT increases the precision of the local phi in TTTrack_TrackWord, we will update the emulator to calculate the global phi of each track from this local phi and the phi sector of each track.

**PR validation:**

This PR has been validated in the following ways:

1.    scram b code-checks
2.    We also created some validation plots to see that the code was behaving as expected.
