### PR TITLE
Update MET emulator to L1CT puppi inputs

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/L1MetPfProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1MetPfProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 L1MetPfProducer = cms.EDProducer("L1MetPfProducer",
-                                 L1PFObjects = cms.InputTag("L1PFProducer","l1pfCandidates"),
-                                 maxCandidates = cms.int32(128),
+                                 L1PFObjects = cms.InputTag("l1ctLayer1","Puppi"),
+                                 maxCands = cms.int32(128),
 )


### PR DESCRIPTION
Now that the new Layer 1 correlator trigger inputs are available, the MET emulator can be updated to use them.

Impact of the difference was checked on ttbar and found to be negligible.

<img width="535" alt="comp" src="https://user-images.githubusercontent.com/7307466/122511342-b1e84780-cfcc-11eb-88d6-56e98f98d598.png">
