### PR TITLE
Track MET Emulation sync with f/w and code checks

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/Cordic.h
+++ b/L1Trigger/L1TTrackMatch/interface/Cordic.h
@@ -12,7 +12,7 @@
 **        : 
 */
 
-using namespace L1TkEtMissEmuAlgo;
+using namespace l1tmetemu;
 
 class Cordic {
 public:

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -16,60 +16,75 @@
 using namespace std;
 // Namespace that defines constants and types used by the EtMiss Emulation
 // Includes functions for writing LUTs and converting to integer representations
-namespace L1TkEtMissEmuAlgo {
+namespace l1tmetemu {
 
-  const unsigned int kGlobalPhiSize{11};
-  const unsigned int kGlobalPhiExtra{3};
+  const unsigned int kInternalVTXWidth{8};   //default 8   max 12
+  const unsigned int kInternalEtaWidth{10};  //default 10  max 16
+  const unsigned int kInternalPtWidth{15};   // default 14  max 14
+  const unsigned int kInternalPhiWidth{8};   //default 8  max  12
+
   // Extra bits needed by global phi to span full range
-  const unsigned int kEtExtra{8};
+  const unsigned int kGlobalPhiExtra{3};  // default 3
   // Extra room for Et sums
-
-  const unsigned int kMETSize{15};     // For output Magnitude
-  const unsigned int kMETPhiSize{14};  // For Output Phi
+  const unsigned int kEtExtra{10};  // default 8
 
   typedef ap_uint<3> nstub_t;
 
-  typedef ap_uint<kGlobalPhiSize + kGlobalPhiExtra> global_phi_t;
+  typedef ap_uint<kInternalPhiWidth + kGlobalPhiExtra> global_phi_t;
 
-  typedef ap_uint<TTTrack_TrackWord::TrackBitWidths::kRinvSize> pt_t;
-  typedef ap_uint<TTTrack_TrackWord::TrackBitWidths::kTanlSize> eta_t;
+  typedef ap_uint<kInternalPtWidth> pt_t;
+  typedef ap_uint<kInternalEtaWidth> eta_t;
+  typedef ap_uint<kInternalVTXWidth> z_t;
   // For internal Et representation, sums become larger than initial pt
   // representation
-  typedef ap_int<TTTrack_TrackWord::TrackBitWidths::kRinvSize + kEtExtra> Et_t;
+  typedef ap_int<kInternalPtWidth + kEtExtra> Et_t;
+
+  //Output format
+  const float kMaxMET{4096};  // 4 TeV
+  const float kMaxMETPhi{2 * M_PI};
+  const unsigned int kMETSize{15};     // For output Magnitude default 15
+  const unsigned int kMETPhiSize{14};  // For Output Phi default 14
 
   typedef ap_uint<kMETSize> MET_t;
   // Cordic means this is evaluated between 0 and 2Pi rather than -pi to pi so
   // unsigned
   typedef ap_uint<kMETPhiSize> METphi_t;
 
-  const unsigned int kGlobalPhiBins = 1 << kGlobalPhiSize;
+  const unsigned int kGlobalPhiBins = 1 << kInternalPhiWidth;
   const unsigned int kMETBins = 1 << kMETSize;
   const unsigned int kMETPhiBins = 1 << kMETPhiSize;
 
-  const unsigned int NEtaRegion{6};
-  const unsigned int NSector{9};
-  const unsigned int NQuadrants{4};
+  const unsigned int kNEtaRegion{6};
+  const unsigned int kNSector{9};
+  const unsigned int kNQuadrants{4};
 
-  const float maxTrackPt{1024};  // TODO calculate from GTTinput module
-  const float maxTrackEta{4};    // TODO calculate from GTTinput module
+  const float kMaxTrackZ0{-TTTrack_TrackWord::minZ0};
+  const float kMaxTrackPt{512};
+  const float kMaxTrackEta{4};
 
-  const double stepPt = (std::abs(maxTrackPt)) / (1 << TTTrack_TrackWord::TrackBitWidths::kRinvSize);
-  const double stepEta = (2 * std::abs(maxTrackEta)) / (1 << TTTrack_TrackWord::TrackBitWidths::kTanlSize);
+  //const int cordicScale{kMETPhiBins};
 
-  const float maxMET{4000};  // 4 TeV
-  const float maxMETPhi{2 * M_PI};
+  // Steps used to convert from track word floats to track MET integer representations
 
-  const double stepMET = (L1TkEtMissEmuAlgo::maxMET / L1TkEtMissEmuAlgo::kMETBins);
-  const double stepMETPhi = (L1TkEtMissEmuAlgo::maxMETPhi / L1TkEtMissEmuAlgo::kMETPhiBins);
+  const double kStepPt = (std::abs(kMaxTrackPt)) / (1 << kInternalPtWidth);
+  const double kStepEta = (2 * std::abs(kMaxTrackEta)) / (1 << kInternalEtaWidth);
+  const double kStepZ0 = (2 * std::abs(kMaxTrackZ0)) / (1 << kInternalVTXWidth);
 
-  const float EtaRegionBins[NEtaRegion + 1] = {0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4};
-  const float DeltaZBins[NEtaRegion] = {0.4, 0.6, 0.76, 1.0, 1.7, 2.2};
+  const double kStepPhi = (2 * -TTTrack_TrackWord::minPhi0) / (kGlobalPhiBins - 1);
+
+  const double kStepMET = (l1tmetemu::kMaxMET / l1tmetemu::kMETBins);
+  const double kStepMETPhi = (l1tmetemu::kMaxMETPhi / l1tmetemu::kMETPhiBins);
+
+  // Track to vertex eta regions
+  const float kEtaRegionBins[kNEtaRegion + 1] = {0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4};
+  // Track to vertex z thresholds
+  const float kDeltaZBins[kNEtaRegion] = {0.4, 0.6, 0.76, 1.0, 1.7, 2.2};
 
   // Enough symmetry in cos and sin between 0 and pi/2 to get all possible values
   // of cos and sin phi
-  const float maxCosLUTPhi{M_PI / 2};
+  const float kMaxCosLUTPhi{M_PI / 2};
 
-  const string LUTdir{"LUTs/"};
+  const string kLUTdir{"LUTs/"};
 
   // Simple struct used for ouput of cordic
   struct EtMiss {
@@ -79,7 +94,7 @@ namespace L1TkEtMissEmuAlgo {
 
   std::vector<global_phi_t> generateCosLUT(unsigned int size);
   std::vector<eta_t> generateEtaRegionLUT();
-  std::vector<TTTrack_TrackWord::z0_t> generateDeltaZLUT();
+  std::vector<z_t> generateDeltaZLUT();
 
   template <typename T>
   T digitizeSignedValue(double value, unsigned int nBits, double lsb) {
@@ -99,15 +114,17 @@ namespace L1TkEtMissEmuAlgo {
   }
 
   int unpackSignedValue(unsigned int bits, unsigned int nBits);
+  unsigned int transformSignedValue(unsigned int bits, unsigned int oldnBits, unsigned int newnBits);
 
+  //Ouput LUTs to file for use in FW
   template <typename T>
   void writeLUTtoFile(vector<T>(&LUT), const string& filename, const string& delimiter) {
-    int fail = system((string("mkdir -p ") + L1TkEtMissEmuAlgo::LUTdir).c_str());
+    int fail = system((string("mkdir -p ") + l1tmetemu::kLUTdir).c_str());
     if (fail)
       throw cms::Exception("BadDir") << __FILE__ << " " << __LINE__ << " could not create directory "
-                                     << L1TkEtMissEmuAlgo::LUTdir;
+                                     << l1tmetemu::kLUTdir;
 
-    const string fname = L1TkEtMissEmuAlgo::LUTdir + filename + ".tab";
+    const string fname = l1tmetemu::kLUTdir + filename + ".tab";
     ofstream outstream(fname);
     if (outstream.fail())
       throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
@@ -122,5 +139,5 @@ namespace L1TkEtMissEmuAlgo {
     outstream.close();
   }
 
-}  // namespace L1TkEtMissEmuAlgo
+}  // namespace l1tmetemu
 #endif

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuTrackTransform.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuTrackTransform.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-#include "DataFormats/L1Trigger/interface/Vertex.h"
+#include "DataFormats/L1Trigger/interface/VertexWord.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h"
 
@@ -11,28 +11,31 @@
 ** class  : L1TkEtMissEmuTrackTransform
 ** author : Christopher Brown
 ** date   : 19/02/2021
+** modified :16/06/2021
 ** brief  : Converts TTrack_trackword to internal Et word including vertex
 
 **        : 
 */
 
-using namespace L1TkEtMissEmuAlgo;
+using namespace l1tmetemu;
 
 // Internal Word used by EtMiss Emulation, producer expects this wordtype
 struct InternalEtWord {
-  TTTrack_TrackWord::z0_t pV;
-  TTTrack_TrackWord::z0_t z0;
+  z_t pV;
+  z_t z0;
 
   pt_t pt;
   eta_t eta;
   global_phi_t globalPhi;
   nstub_t nstubs;
 
+  TTTrack_TrackWord::hit_t Hitpattern;
   TTTrack_TrackWord::bendChi2_t bendChi2;
   TTTrack_TrackWord::chi2rphi_t chi2rphidof;
   TTTrack_TrackWord::chi2rz_t chi2rzdof;
 
-  unsigned int Sector;
+  unsigned int Sector;  //Phi sector
+  bool EtaSector;       //Positve or negative eta
 
   float phi;  // Used to debug cos phi LUT
 };
@@ -44,8 +47,9 @@ public:
 
   void generateLUTs();  // Generate internal LUTs needed for track transfrom
 
-  // Transform track and vertex
-  InternalEtWord transformTrack(TTTrack<Ref_Phase2TrackerDigi_>& track_ref, l1t::Vertex& PV);
+  // Transform track and vertex, allow for vertex word or vertex collections
+  template <class track, class vertex>
+  InternalEtWord transformTrack(track& track_ref, vertex& PV);
 
   // Converts local int phi to global int phi
   global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift);
@@ -71,5 +75,67 @@ private:
   bool GTTinput_ = false;
   bool VtxEmulator_ = false;
 };
+
+// Template to allow vertex word or vertex from vertex finder depending on simulation vs emulation
+template <class track, class vertex>
+InternalEtWord L1TkEtMissEmuTrackTransform::transformTrack(track& track_ref, vertex& PV) {
+  InternalEtWord Outword;
+
+  unsigned int temp_pt;
+  unsigned int temp_eta;
+
+  if (GTTinput_) {
+    if ((track_ref.getRinvWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1))) != 0) {
+      // Only Want Magnitude of Pt for sums so perform absolute value
+      temp_pt = abs((1 << (TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1)) - track_ref.getRinvWord());
+    } else {
+      temp_pt = track_ref.getRinvWord();
+    }
+    Outword.pt = transformSignedValue(temp_pt * 2, TTTrack_TrackWord::TrackBitWidths::kRinvSize, kInternalPtWidth);
+
+    if ((track_ref.getTanlWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize - 1))) != 0) {
+      // Only Want Magnitude of Eta for cuts and track to vertex association so
+      // perform absolute value
+      temp_eta = abs((1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize)) - track_ref.getTanlWord());
+    } else {
+      temp_eta = track_ref.getTanlWord();
+    }
+    Outword.eta = transformSignedValue(temp_eta, TTTrack_TrackWord::TrackBitWidths::kTanlSize, kInternalEtaWidth);
+
+  } else {
+    track_ref.setTrackWordBits();
+    // Change track word digitization to digitization expected by track MET
+    Outword.pt = digitizeSignedValue<TTTrack_TrackWord::rinv_t>(
+       track_ref.momentum().perp(), kInternalPtWidth, l1tmetemu::kStepPt);
+
+    Outword.eta = digitizeSignedValue<TTTrack_TrackWord::tanl_t>(
+        abs(track_ref.momentum().eta()), kInternalEtaWidth, l1tmetemu::kStepEta);
+  }
+
+  unsigned int temp_pv = digitizeSignedValue<TTTrack_TrackWord::z0_t>(
+      PV.z0(),
+      TTTrack_TrackWord::TrackBitWidths::kZ0Size,
+      TTTrack_TrackWord::stepZ0);  // Convert vertex to integer representation
+  Outword.chi2rphidof = track_ref.getChi2RPhiWord();
+  Outword.chi2rzdof = track_ref.getChi2RZWord();
+  Outword.bendChi2 = track_ref.getBendChi2Word();
+  Outword.nstubs = countNStub(track_ref.getHitPatternWord());
+  Outword.Hitpattern = track_ref.getHitPatternWord();
+
+  unsigned int Sector = track_ref.phiSector();
+  Outword.Sector = Sector;
+  Outword.EtaSector = (track_ref.getTanlWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize - 1)));
+  // convert to local phi
+  Outword.phi = track_ref.phi();
+  TTTrack_TrackWord::phi_t localPhi = floatGlobalPhiToSectorPhi(track_ref.phi(), Sector);
+  // Convert to global phi
+  Outword.globalPhi = localToGlobalPhi(localPhi, phiShift[Sector]);
+
+  //Rescale to internal representations
+  Outword.z0 = transformSignedValue(track_ref.getZ0Word(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, kInternalVTXWidth);
+  Outword.pV = transformSignedValue(temp_pv, TTTrack_TrackWord::TrackBitWidths::kZ0Size, kInternalVTXWidth);
+
+  return Outword;
+}
 
 #endif

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissProducer.cc
@@ -33,6 +33,9 @@ public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
 
+  typedef Vertex L1VertexType;
+  typedef VertexCollection L1VertexCollectionType;
+
   explicit L1TrackerEtMissProducer(const edm::ParameterSet&);
   ~L1TrackerEtMissProducer() override;
 
@@ -61,14 +64,13 @@ private:
   std::string L1ExtendedMetCollectionName;
 
   const edm::EDGetTokenT<VertexCollection> pvToken_;
-  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
+  const edm::EDGetTokenT<L1TTTrackCollectionType> trackToken_;
 };
 
 // constructor//
 L1TrackerEtMissProducer::L1TrackerEtMissProducer(const edm::ParameterSet& iConfig)
-    : pvToken_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))),
-      trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
-          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
+    : pvToken_(consumes<L1VertexCollectionType>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))),
+      trackToken_(consumes<L1TTTrackCollectionType>(iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
   maxZ0_ = (float)iConfig.getParameter<double>("maxZ0");
   deltaZ_ = (float)iConfig.getParameter<double>("deltaZ");
   chi2dofMax_ = (float)iConfig.getParameter<double>("chi2dofMax");
@@ -105,7 +107,7 @@ void L1TrackerEtMissProducer::produce(edm::Event& iEvent, const edm::EventSetup&
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle_);
   const TrackerTopology* tTopo = tTopoHandle_.product();
 
-  edm::Handle<VertexCollection> L1VertexHandle;
+  edm::Handle<L1VertexCollectionType> L1VertexHandle;
   iEvent.getByToken(pvToken_, L1VertexHandle);
 
   edm::Handle<L1TTTrackCollectionType> L1TTTrackHandle;
@@ -187,10 +189,6 @@ void L1TrackerEtMissProducer::produce(edm::Event& iEvent, const edm::EventSetup&
     if (nPS < nPSStubsMin_)
       continue;
 
-    // std::cout << "track: " << numtracks << "|" << pt << "|" << z0 << "|" <<
-    // eta <<
-    //"|" << nstubs << std::endl;
-
     numqualitytracks++;
 
     if (!displaced_) {  // if displaced, deltaZ = 3.0 cm, very loose
@@ -229,15 +227,18 @@ void L1TrackerEtMissProducer::produce(edm::Event& iEvent, const edm::EventSetup&
   math::XYZTLorentzVector missingEt(-sumPx, -sumPy, 0, et);
 
   if (debug_) {
-    std::cout << "====Global Pt====" << std::endl;
-    std::cout << "Px: " << sumPx << "| Py: " << sumPy << std::endl;
-    std::cout << "====MET===" << std::endl;
-    std::cout << "MET: " << et << "| Phi: " << etphi << std::endl;
+    edm::LogVerbatim("L1TrackerEtMissProducer") << "====Global Pt===="
+                                                << "\n"
+                                                << "Px: " << sumPx << "| Py: " << sumPy << "\n"
+                                                << "====MET==="
+                                                << "\n"
+                                                << "MET: " << et << "| Phi: " << etphi << "\n"
 
-    std::cout << "# Intial Tracks: " << numtracks << std::endl;
-    std::cout << "# Tracks after Quality Cuts: " << numqualitytracks << std::endl;
-    std::cout << "# Tracks Associated to Vertex: " << numassoctracks << std::endl;
-    std::cout << "========================================================" << std::endl;
+                                                << "# Intial Tracks: " << numtracks << "\n"
+                                                << "# Tracks after Quality Cuts: " << numqualitytracks << "\n"
+                                                << "# Tracks Associated to Vertex: " << numassoctracks << "\n"
+                                                << "========================================================"
+                                                << "\n";
   }
 
   int ibx = 0;

--- a/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissEmulatorProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissEmulatorProducer_cfi.py
@@ -16,11 +16,11 @@ L1TrackerEmuEtMiss = cms.EDProducer('L1TrackerEtMissEmulatorProducer',
     nStubsmin = cms.int32( 4 ),     # min number of stubs for the tracks
   
     nCordicSteps = cms.int32( 8 ), #Number of steps for cordic sqrt and phi computation
-    debug        = cms.int32( 0 ),  #0 - No Debug, 1 - LUT debug, 2 - Phi Debug, 3 - Z debug, 4 - Et Debug, 5 - Cordic Debug, 6 - Output
+    debug        = cms.int32( 0 ),  #0 - No Debug, 1 - LUT debug, 2 - Phi Debug, 3 - Z debug, 4 - Et Debug, 5 - Cordic Debug, 6 - Output, 7 - Every Selected Track
     writeLUTs    = cms.bool( False ),
 
-    useGTTinput  = cms.bool( False ),
-    useVertexEmulator = cms.bool( False )
+    useGTTinput  = cms.bool( True ),
+    useVertexEmulator = cms.bool( True )
 
 )
 

--- a/L1Trigger/L1TTrackMatch/src/Cordic.cc
+++ b/L1Trigger/L1TTrackMatch/src/Cordic.cc
@@ -3,7 +3,7 @@
 #include <cmath>
 #include <memory>
 
-using namespace L1TkEtMissEmuAlgo;
+using namespace l1tmetemu;
 
 Cordic::Cordic(int aPhiScale, int aMagnitudeBits, const int aSteps, bool debug, bool writeLUTs)
     : mPhiScale(aPhiScale),
@@ -106,8 +106,10 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
 
   // Cordic performs calculation in internal Et granularity, convert to final
   // granularity for Et word
-  ret_etmiss.Et = (int)(x * magNormalisationLUT[cordicSteps - 1] * maxTrackPt / maxMET) >>
-                  (mMagnitudeBits + TTTrack_TrackWord::TrackBitWidths::kRinvSize - kMETSize);
+
+  // emulate fw rounding with float division then floor
+  float tempMET = (float)(x * magNormalisationLUT[cordicSteps - 1] * kMaxTrackPt) / ((float)kMaxMET);
+  ret_etmiss.Et = (int)floor(tempMET) >> (mMagnitudeBits + TTTrack_TrackWord::TrackBitWidths::kRinvSize - kMETSize);
   ret_etmiss.Phi = phi;
   return ret_etmiss;
 }

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -1,33 +1,32 @@
 #include "L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h"
 
-namespace L1TkEtMissEmuAlgo {
+namespace l1tmetemu {
   std::vector<global_phi_t> generateCosLUT(unsigned int size) {  // Fill cosine LUT with integer values
     float phi = 0;
     std::vector<global_phi_t> cosLUT;
-    for (unsigned int LUT_idx = 0; LUT_idx <= size; LUT_idx++) {
-      cosLUT.push_back((global_phi_t)(cos(phi) * (kGlobalPhiBins - 1)));
-      phi += (2 * -TTTrack_TrackWord::minPhi0) / (kGlobalPhiBins - 1);
+    for (unsigned int LUT_idx = 0; LUT_idx < size; LUT_idx++) {
+      cosLUT.push_back((global_phi_t)(floor(cos(phi) * (kGlobalPhiBins - 1))));
+      phi += l1tmetemu::kStepPhi;
     }
+    cosLUT.push_back((global_phi_t)(0));  //Prevent overflow in last bin
     return cosLUT;
   }
 
   // Generate Eta LUT for track to vertex association
   std::vector<eta_t> generateEtaRegionLUT() {
     std::vector<eta_t> LUT;
-    for (unsigned int q = 0; q < NEtaRegion + 1; q++) {
+    for (unsigned int q = 0; q < kNEtaRegion + 1; q++) {
       LUT.push_back(digitizeSignedValue<eta_t>(
-          EtaRegionBins[q],
-          TTTrack_TrackWord::TrackBitWidths::kTanlSize,
-          2 * L1TkEtMissEmuAlgo::maxTrackEta / (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize))));
+          kEtaRegionBins[q], l1tmetemu::kInternalEtaWidth, l1tmetemu::kStepEta));
     }
     return LUT;
   }
 
-  std::vector<TTTrack_TrackWord::z0_t> generateDeltaZLUT() {
-    std::vector<TTTrack_TrackWord::z0_t> LUT;
-    for (unsigned int q = 0; q < NEtaRegion; q++) {
-      LUT.push_back(digitizeSignedValue<TTTrack_TrackWord::z0_t>(
-          DeltaZBins[q], TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0));
+  std::vector<z_t> generateDeltaZLUT() {
+    std::vector<z_t> LUT;
+    for (unsigned int q = 0; q < kNEtaRegion; q++) {
+      LUT.push_back(
+          digitizeSignedValue<z_t>(kDeltaZBins[q], l1tmetemu::kInternalVTXWidth, TTTrack_TrackWord::stepZ0));
     }
     return LUT;
   }
@@ -42,4 +41,24 @@ namespace L1TkEtMissEmuAlgo {
     return (int(bits & digitized_maximum)) * isign;
   }
 
-}  // namespace L1TkEtMissEmuAlgo
+  unsigned int transformSignedValue(unsigned int bits, unsigned int oldnBits, unsigned int newnBits) {
+    int isign = 1;
+    unsigned int olddigitized_maximum = (1 << oldnBits) - 1;
+    unsigned int newdigitized_maximum = (1 << newnBits) - 1;
+    if (bits & (1 << (oldnBits - 1))) {  // check the sign
+      isign = -1;
+      bits = (1 << (oldnBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+    }
+    unsigned int temp = (int(bits & olddigitized_maximum));
+
+    temp = round(temp / (1 << (oldnBits - newnBits)));
+
+    if (temp > newdigitized_maximum)
+      temp = newdigitized_maximum;
+    if (isign < 0)
+      temp = (1 << newnBits) - 1 - temp;  // two's complement encoding
+
+    return temp;
+  }
+
+}  // namespace l1tmetemu

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuTrackTransform.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuTrackTransform.cc
@@ -3,78 +3,20 @@
 #include <cmath>
 
 void L1TkEtMissEmuTrackTransform::generateLUTs() {
-  phiQuadrants = generatePhiSliceLUT(L1TkEtMissEmuAlgo::NQuadrants);
-  phiShift = generatePhiSliceLUT(L1TkEtMissEmuAlgo::NSector);
-}
-
-InternalEtWord L1TkEtMissEmuTrackTransform::transformTrack(TTTrack<Ref_Phase2TrackerDigi_>& track_ref,
-                                                           l1t::Vertex& PV) {
-  InternalEtWord Outword;
-
-  if (GTTinput_) {
-    if ((track_ref.getRinvWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1))) != 0) {
-      // Only Want Magnitude of Pt for sums so perform absolute value
-      Outword.pt = abs((1 << (TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1)) - track_ref.getRinvWord());
-    } else {
-      Outword.pt = track_ref.getRinvWord();
-    }
-
-    if ((track_ref.getTanlWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize - 1))) != 0) {
-      // Only Want Magnitude of Eta for cuts and track to vertex association so
-      // perform absolute value
-      Outword.eta = (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize)) - track_ref.getTanlWord();
-    } else {
-      Outword.eta = track_ref.getTanlWord();
-    }
-
-  } else {
-    track_ref.setTrackWordBits();
-    Outword.pt = digitizeSignedValue<pt_t>(
-        track_ref.momentum().perp(), TTTrack_TrackWord::TrackBitWidths::kRinvSize, L1TkEtMissEmuAlgo::stepPt);
-    Outword.eta = digitizeSignedValue<eta_t>(
-        abs(track_ref.momentum().eta()), TTTrack_TrackWord::TrackBitWidths::kTanlSize, L1TkEtMissEmuAlgo::stepEta);
-  }
-
-  if (VtxEmulator_) {
-    Outword.pV = PV.z0();  // Convert vertex TODO change to correct vertexing
-                           // emulation output
-  }
-
-  else {
-    Outword.pV = digitizeSignedValue<TTTrack_TrackWord::z0_t>(PV.z0(),
-                                                              TTTrack_TrackWord::TrackBitWidths::kZ0Size,
-                                                              TTTrack_TrackWord::stepZ0);  // Convert vertex
-  }
-
-  Outword.chi2rphidof = track_ref.getChi2RPhiWord();
-  Outword.chi2rzdof = track_ref.getChi2RZWord();
-  Outword.bendChi2 = track_ref.getBendChi2Word();
-  Outword.nstubs = countNStub(track_ref.getHitPatternWord());
-
-  unsigned int Sector = track_ref.phiSector();
-  Outword.Sector = Sector;
-  // convert to local phi
-  Outword.phi = track_ref.phi();
-  TTTrack_TrackWord::phi_t localPhi = floatGlobalPhiToSectorPhi(track_ref.phi(), Sector);
-  // Convert to global phi
-  Outword.globalPhi = localToGlobalPhi(localPhi, phiShift[Sector]);
-  Outword.z0 = track_ref.getZ0Word();
-
-  return Outword;
+  phiQuadrants = generatePhiSliceLUT(l1tmetemu::kNQuadrants);
+  phiShift = generatePhiSliceLUT(l1tmetemu::kNSector);
 }
 
 global_phi_t L1TkEtMissEmuTrackTransform::localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi,
                                                            global_phi_t sector_shift) {
-  int PhiShift = 1 << L1TkEtMissEmuAlgo::kGlobalPhiBins - 1;
-  int PhiMin = phiQuadrants.front();
+  int PhiMin = 0;
   int PhiMax = phiQuadrants.back();
-  int phiMultiplier = TTTrack_TrackWord::TrackBitWidths::kPhiSize - L1TkEtMissEmuAlgo::kGlobalPhiSize;
+  int phiMultiplier = TTTrack_TrackWord::TrackBitWidths::kPhiSize - l1tmetemu::kInternalPhiWidth;
 
-  int tempPhi = 0;
-  global_phi_t globalPhi = 0;
+  int tempPhi =
+      floor(unpackSignedValue(local_phi, TTTrack_TrackWord::TrackBitWidths::kPhiSize) / pow(2, phiMultiplier)) +
+      sector_shift;
 
-  tempPhi = (unpackSignedValue(local_phi, TTTrack_TrackWord::TrackBitWidths::kPhiSize) / pow(2, phiMultiplier)) +
-            sector_shift - PhiShift;
   if (tempPhi < PhiMin) {
     tempPhi = tempPhi + PhiMax;
   } else if (tempPhi > PhiMax) {
@@ -82,7 +24,7 @@ global_phi_t L1TkEtMissEmuTrackTransform::localToGlobalPhi(TTTrack_TrackWord::ph
   } else
     tempPhi = tempPhi;
 
-  globalPhi = global_phi_t(tempPhi);
+  global_phi_t globalPhi = global_phi_t(tempPhi);
 
   return globalPhi;
 }
@@ -124,8 +66,7 @@ std::vector<global_phi_t> L1TkEtMissEmuTrackTransform::generatePhiSliceLUT(unsig
   float sliceCentre = 0.0;
   std::vector<global_phi_t> phiLUT;
   for (unsigned int q = 0; q <= N; q++) {
-    phiLUT.push_back(
-        (global_phi_t)(sliceCentre / (-2 * TTTrack_TrackWord::minPhi0 / (L1TkEtMissEmuAlgo::kGlobalPhiBins - 1))));
+    phiLUT.push_back((global_phi_t)(sliceCentre / l1tmetemu::kStepPhi));
     sliceCentre += 2 * M_PI / N;
   }
   return phiLUT;


### PR DESCRIPTION
#### PR description:
This PR updates the track MET emulation code, updating and cleaning up various parts of the code. More details can be found here: https://indico.cern.ch/event/1049444/contributions/4409325/attachments/2267246/3849638/CB_TrackMETEmuFW.pdf

Significant changes include:
Updating Track MET emulator to use the GTTinput and Vertex emulators by default completing a GTT emulator chain, adding in VertexWord as an input to Track MET
Updates to code style and constants names 
#### PR validation:

Code & style checks have been performed as per https://twiki.cern.ch/twiki/bin/view/CMS/L1TrackCodeRules
