### PR TITLE
Update SeedCone jets to use l1ctLayer1 puppi inputs by default

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/L1SeedConePFJetProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1SeedConePFJetProducer_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 L1SeedConePFJetProducer = cms.EDProducer("L1SeedConePFJetProducer",
-                           L1PFObjects = cms.InputTag("L1PFProducer","l1pfCandidates"),
+                           L1PFObjects = cms.InputTag("l1ctLayer1","Puppi"),
                            nJets       = cms.uint32(10),
                            coneSize    = cms.double(0.4),
                            HW          = cms.bool(False),
@@ -9,7 +9,7 @@ L1SeedConePFJetProducer = cms.EDProducer("L1SeedConePFJetProducer",
                          )
 
 L1SeedConePFJetEmulatorProducer = cms.EDProducer("L1SeedConePFJetProducer",
-                                   L1PFObjects = cms.InputTag("L1PFProducer","l1pfCandidates"),
+                                   L1PFObjects = cms.InputTag("l1ctLayer1","Puppi"),
                                    nJets       = cms.uint32(10),
                                    coneSize    = cms.double(0.4),
                                    HW          = cms.bool(True),

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfJetMet_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfJetMet_cff.py
@@ -14,9 +14,10 @@ ak4PFL1Calo    = _ak4PFJets.clone(src = 'l1pfCandidates:Calo')
 ak4PFL1PF      = _ak4PFJets.clone(src = 'l1pfCandidates:PF')
 ak4PFL1Puppi   = _ak4PFJets.clone(src = 'l1pfCandidates:Puppi')
 
-from L1Trigger.Phase2L1ParticleFlow.L1SeedConePFJetProducer_cfi import L1SeedConePFJetProducer
-scPFL1PF    = L1SeedConePFJetProducer.clone(L1PFObjects = 'l1pfCandidates:PF')
-scPFL1Puppi = L1SeedConePFJetProducer.clone(L1PFObjects = 'l1pfCandidates:Puppi')
+from L1Trigger.Phase2L1ParticleFlow.L1SeedConePFJetProducer_cfi import L1SeedConePFJetProducer, L1SeedConePFJetEmulatorProducer
+scPFL1PF            = L1SeedConePFJetProducer.clone(L1PFObjects = 'l1ctLayer1:PF')
+scPFL1Puppi         = L1SeedConePFJetProducer.clone()
+scPFL1PuppiEmulator = L1SeedConePFJetEmulatorProducer.clone()
 
 _correctedJets = cms.EDProducer("L1TCorrectedPFJetProducer", 
     jets = cms.InputTag("_tag_"),
@@ -37,7 +38,7 @@ ak4PFL1PuppiCorrected = _correctedJets.clone(jets = 'ak4PFL1Puppi', correctorDir
 l1PFJetsTask = cms.Task(
     ak4PFL1Calo, ak4PFL1PF, ak4PFL1Puppi,
     ak4PFL1CaloCorrected, ak4PFL1PFCorrected, ak4PFL1PuppiCorrected,
-    scPFL1PF, scPFL1Puppi
+    scPFL1PF, scPFL1Puppi, scPFL1PuppiEmulator
 )
 
 


### PR DESCRIPTION
Also run the SeedCone jets emulator as part of the `l1PFJetsTask`.