### PR TITLE
Changed TkJetWord from a Struct to a Class

### DIFF
--- a/DataFormats/L1Trigger/interface/TkJetWord.h
+++ b/DataFormats/L1Trigger/interface/TkJetWord.h
@@ -5,94 +5,186 @@
 #include <ap_int.h>
 #include <cassert>
 #include <cmath>
+#include <bitset> 
+#include <string>
 
 namespace l1t {
 
-  typedef ap_ufixed<14, 12, AP_TRN, AP_SAT> pt_t;
-  typedef ap_int<10> eta_t;
-  typedef ap_int<10> phi_t;
-  typedef ap_int<12> glbeta_t;
-  typedef ap_int<11> glbphi_t;
-  typedef ap_int<10> z0_t;         // 40cm / 0.1
-  typedef ap_uint<5> nt_t; //number of tracks
-  typedef ap_uint<4> nx_t; //number of tracks with xbit = 1
+  class TkJetWord {
+  public:
+    // ----------constants, enums and typedefs ---------
+    int INTPHI_PI = 720;
+    int INTPHI_TWOPI = 2 * INTPHI_PI;
+    float INTPT_LSB = 0.25;
+    float ETAPHI_LSB = M_PI / INTPHI_PI;
+    float Z0_LSB = 0.05;
 
-  namespace Scales {
-    const int INTPHI_PI = 720;
-    const int INTPHI_TWOPI = 2 * INTPHI_PI;
-    constexpr float INTPT_LSB = 0.25;
-    constexpr float ETAPHI_LSB = M_PI / INTPHI_PI;
-    constexpr float Z0_LSB = 0.05;
-    inline float floatPt(pt_t pt) { return pt.to_float(); }
-    inline int intPt(pt_t pt) { return (ap_ufixed<16, 14>(pt)).to_int(); }
-    inline int intNt(nt_t nt) { return (ap_ufixed<7, 5>(nt)).to_int(); }
-    inline int intXt(nx_t xt) { return (ap_ufixed<6, 4>(xt)).to_int(); }
-    inline float floatEta(eta_t eta) { return eta.to_float() * ETAPHI_LSB; }
-    inline float floatPhi(phi_t phi) { return phi.to_float() * ETAPHI_LSB; }
-    inline float floatEta(glbeta_t eta) { return eta.to_float() * ETAPHI_LSB; }
-    inline float floatPhi(glbphi_t phi) { return phi.to_float() * ETAPHI_LSB; }
-    inline float floatZ0(z0_t z0) { return z0.to_float() * Z0_LSB; }
+    enum TkJetBitWidths {
+      kPtSize = 14,
+      kPtMagSize = 12,
+      kGlbEtaSize = 12,
+      kGlbPhiSize = 11,
+      kZ0Size = 10,
+      kNtSize = 5,
+      kXtSize = 4,
+      kUnassignedSize = 8,
+      kTkJetWordSize = kPtSize + kGlbEtaSize + kGlbPhiSize + kZ0Size + kNtSize + kXtSize + kUnassignedSize,
+    };
 
-    inline pt_t makePt(int pt) { return ap_ufixed<16, 14>(pt); }
-    inline nt_t makeNt(int nt) { return ap_ufixed<7, 5>(nt); }
-    inline nx_t makeXt(int xt) { return ap_ufixed<6, 4>(xt); }
-    inline pt_t makePtFromFloat(float pt) { return pt_t(0.25 * round(pt * 4)); }
-    inline z0_t makeZ0(float z0) { return z0_t(round(z0 / Z0_LSB)); }
+    enum TkJetBitLocations {
+      kPtLSB = 0,
+      kPtMSB = kPtLSB + TkJetBitWidths::kPtSize - 1,
+      kGlbEtaLSB = kPtMSB + 1,
+      kGlbEtaMSB = kGlbEtaLSB + TkJetBitWidths::kGlbEtaSize - 1,
+      kGlbPhiLSB = kGlbEtaMSB + 1,
+      kGlbPhiMSB = kGlbPhiLSB + TkJetBitWidths::kGlbPhiSize - 1,
+      kZ0LSB = kGlbPhiMSB + 1,
+      kZ0MSB = kZ0LSB + TkJetBitWidths::kZ0Size - 1,
+      kNtLSB = kZ0MSB + 1,
+      kNtMSB = kNtLSB + TkJetBitWidths::kNtSize - 1,
+      kXtLSB = kNtMSB + 1,
+      kXtMSB = kXtLSB + TkJetBitWidths::kXtSize - 1,
+      kUnassignedLSB = kXtMSB + 1,
+      kUnassignedMSB = kUnassignedLSB + TkJetBitWidths::kUnassignedSize - 1,
+    };
 
-    inline ap_uint<pt_t::width> ptToInt(pt_t pt) {
-      // note: this can be synthethized, e.g. when pT is used as intex in a LUT
-      ap_uint<pt_t::width> ret = 0;
-      ret(pt_t::width - 1, 0) = pt(pt_t::width - 1, 0);
+    typedef ap_ufixed<kPtSize, kPtMagSize, AP_TRN, AP_SAT> pt_t;
+    typedef ap_int<kGlbEtaSize> glbeta_t;
+    typedef ap_int<kGlbPhiSize> glbphi_t;
+    typedef ap_int<kZ0Size> z0_t;         // 40cm / 0.1
+    typedef ap_uint<kNtSize> nt_t; //number of tracks
+    typedef ap_uint<kXtSize> nx_t; //number of tracks with xbit = 1
+    typedef ap_uint<TkJetBitWidths::kUnassignedSize> tkjetunassigned_t;  // Unassigned bits
+    typedef std::bitset<TkJetBitWidths::kTkJetWordSize> tkjetword_bs_t;
+    typedef ap_uint<TkJetBitWidths::kTkJetWordSize> tkjetword_t;
+    
+  public:
+    // ----------Constructors --------------------------
+    TkJetWord() {}
+    TkJetWord(pt_t pt,
+              glbeta_t eta,
+              glbphi_t phi,
+              z0_t z0,
+              nt_t nt,
+              nx_t nx,
+              tkjetunassigned_t unassigned) {
+      std::string word = "";
+      word.append(TkJetBitWidths::kUnassignedSize - (unassigned.to_string().length()-2),'0');
+      word = word + (unassigned.to_string().substr(2,unassigned.to_string().length()-2));
+      word.append(TkJetBitWidths::kXtSize - (nx.to_string().length()-2),'0');
+      word = word + (nx.to_string().substr(2,nx.to_string().length()-2));
+      word.append(TkJetBitWidths::kNtSize - (nt.to_string().length()-2),'0');
+      word = word + (nt.to_string().substr(2,nt.to_string().length()-2));
+      word.append(TkJetBitWidths::kZ0Size - (z0.to_string().length()-2),'0');
+      word = word + (z0.to_string().substr(2,z0.to_string().length()-2));
+      word.append(TkJetBitWidths::kGlbPhiSize - (phi.to_string().length()-2),'0');
+      word = word + (phi.to_string().substr(2,phi.to_string().length()-2));
+      word.append(TkJetBitWidths::kGlbEtaSize - (eta.to_string().length()-2),'0');
+      word = word + (eta.to_string().substr(2,eta.to_string().length()-2));
+      ap_uint<kPtSize> pt_temp = pt << 2;
+      word.append(TkJetBitWidths::kPtSize - (pt_temp.to_string().length()-2),'0');
+      word = word + (pt_temp.to_string().substr(2,pt_temp.to_string().length()-2));
+
+      tkjetword_bs_t tmp (word);
+      tkJetWord_ = tmp;
+    }
+
+    ~TkJetWord() {}
+
+    // ----------copy constructor ----------------------
+    TkJetWord(const TkJetWord& word) { tkJetWord_ = word.tkJetWord_; }
+
+    // ----------operators -----------------------------
+    TkJetWord& operator=(const TkJetWord& word) {
+      tkJetWord_ = word.tkJetWord_;
+      return *this;
+    }
+
+    // ----------member functions (getters) ------------
+    // These functions return arbitarary precision words (lists of bits) for each quantity
+    pt_t ptWord() const {
+      pt_t ret;
+      ret.V = tkJetWord()(TkJetBitLocations::kPtMSB, TkJetBitLocations::kPtLSB);
       return ret;
     }
+    glbeta_t glbEtaWord() const {
+      glbeta_t ret;
+      ret.V = tkJetWord()(TkJetBitLocations::kGlbEtaMSB, TkJetBitLocations::kGlbEtaLSB);
+      return ret;
+    }
+    glbphi_t glbPhiWord() const {
+      glbphi_t ret;
+      ret.V = tkJetWord()(TkJetBitLocations::kGlbPhiMSB, TkJetBitLocations::kGlbPhiLSB);
+      return ret;
+    }
+    z0_t z0Word() const {
+      z0_t ret;
+      ret.V = tkJetWord()(TkJetBitLocations::kZ0MSB, TkJetBitLocations::kZ0LSB);
+      return ret;
+    }
+    nt_t ntWord() const {
+      nt_t ret;
+      ret.V = tkJetWord()(TkJetBitLocations::kNtMSB, TkJetBitLocations::kNtLSB);
+      return ret;
+    }
+    nx_t xtWord() const {
+      nx_t ret;
+      ret.V = tkJetWord()(TkJetBitLocations::kXtMSB, TkJetBitLocations::kXtLSB);
+      return ret;
+    }
+    tkjetunassigned_t unassignedWord() const {
+      return tkJetWord()(TkJetBitLocations::kUnassignedMSB, TkJetBitLocations::kUnassignedLSB);
+    }
+    tkjetword_t tkJetWord() const { return tkjetword_t(tkJetWord_.to_string().c_str(), 2); }
 
-    inline phi_t makePhi(float phi) { return round(phi / ETAPHI_LSB); }
-    inline eta_t makeEta(float eta) { return round(eta / ETAPHI_LSB); }
-    inline glbeta_t makeGlbEta(float eta) { return round(eta / ETAPHI_LSB); }
-    inline glbeta_t makeGlbEtaRoundEven(float eta) {
-      glbeta_t ghweta = round(eta / ETAPHI_LSB);
-      return (ghweta % 2) ? glbeta_t(ghweta + 1) : ghweta;
+    // These functions return the packed bits in integer format for each quantity
+    // Signed quantities have the sign enconded in the left-most bit.
+    unsigned int ptBits() const { return ptWord().to_uint(); }
+    unsigned int glbEtaBits() const { return glbEtaWord().to_uint(); }
+    unsigned int glbPhiBits() const { return glbPhiWord().to_uint(); }
+    unsigned int z0Bits() const { return z0Word().to_uint(); }
+    unsigned int ntBits() const { return ntWord().to_uint(); }
+    unsigned int xtBits() const { return xtWord().to_uint(); }
+    unsigned int unassignedBits() const { return unassignedWord().to_uint(); }
+
+    // These functions return the unpacked and converted values
+    // These functions return real numbers converted from the digitized quantities by unpacking the 64-bit vertex word
+    float pt() const { return ptWord().to_float(); }
+    float glbeta() const { return glbEtaWord().to_float() * ETAPHI_LSB; }
+    float glbphi() const { return glbPhiWord().to_float() * ETAPHI_LSB; }
+    float z0() const { return z0Word().to_float() * Z0_LSB; }
+    int nt() const { return (ap_ufixed<kNtSize+2, kNtSize>(ntWord())).to_int(); }
+    int xt() const { return (ap_ufixed<kXtSize+2, kXtSize>(xtWord())).to_int(); }
+    unsigned int unassigned() const { return unassignedWord().to_uint(); }
+
+    // ----------member functions (setters) ------------
+    void setTkJetWord(pt_t pt,
+                      glbeta_t eta,
+              	      glbphi_t phi,
+               	      z0_t z0,
+                      nt_t nt,
+                      nx_t nx,
+                      tkjetunassigned_t unassigned);
+
+  private:
+    // ----------private member functions --------------
+    double unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const {
+      int isign = 1;
+      unsigned int digitized_maximum = (1 << nBits) - 1;
+      if (bits & (1 << (nBits - 1))) {  // check the sign
+        isign = -1;
+        bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+      }
+      return (double(bits & digitized_maximum) + 0.5) * lsb * isign;
     }
 
-    inline glbphi_t makeGlbPhi(float phi) { return round(phi / ETAPHI_LSB); }
-
-    inline float maxAbsEta() { return ((1 << (eta_t::width - 1)) - 1) * ETAPHI_LSB; }
-    inline float maxAbsPhi() { return ((1 << (phi_t::width - 1)) - 1) * ETAPHI_LSB; }
-    inline float maxAbsGlbEta() { return ((1 << (glbeta_t::width - 1)) - 1) * ETAPHI_LSB; }
-    inline float maxAbsGlbPhi() { return ((1 << (glbphi_t::width - 1)) - 1) * ETAPHI_LSB; }
-  };  // namespace Scales
-
-
-  struct TkJetWord {
-    pt_t hwPt;
-    glbeta_t hwEta;
-    glbphi_t hwPhi;
-    z0_t hwZ0;
-    nt_t hwNt; //number of tracks
-    nx_t hwXt; //number of tracks with xbit=1
-
-    inline void clear() {
-      hwPt = 0;
-      hwEta = 0;
-      hwPhi = 0;
-      hwZ0 = 0;
-      hwNt = 0;
-      hwXt = 0;
-    }
-
-    int intPt() const { return Scales::intPt(hwPt); }
-    int intNTracks() const { return Scales::intNt(hwNt); }
-    int intNXTracks() const { return Scales::intXt(hwXt); }
-    float floatPt() const { return Scales::floatPt(hwPt); }
-    float floatEta() const { return Scales::floatEta(hwEta); }
-    float floatPhi() const { return Scales::floatPhi(hwPhi); }
-    float floatZ0() const { return Scales::floatZ0(hwZ0); }
-
+    // ----------member data ---------------------------
+    tkjetword_bs_t tkJetWord_;
   };
  
 
   typedef std::vector<l1t::TkJetWord> TkJetWordCollection;
   
-}  // namespace l1ct
+}  // namespace l1t
 
 #endif

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -273,13 +273,13 @@
   <class name="l1t::VertexWord" ClassVersion="10">
     <version ClassVersion="10" checksum="3779192820"/>
   </class>
-   <class name="std::vector<l1t::VertexWord>"/>
-   <class name="edm::Wrapper<std::vector<l1t::VertexWord> >"/>
-   <class name="l1t::VertexWord::VertexRef"/>
-   <class name="edm::Wrapper<l1t::VertexWord::VertexRef>"/>
+  <class name="std::vector<l1t::VertexWord>"/>
+  <class name="edm::Wrapper<std::vector<l1t::VertexWord> >"/>
+  <class name="l1t::VertexWord::VertexRef"/>
+  <class name="edm::Wrapper<l1t::VertexWord::VertexRef>"/>
 
-  <class name="l1t::TkJetWord" ClassVersion="10">
-    <version ClassVersion="10" checksum="2419111641"/>
+  <class name="l1t::TkJetWord" ClassVersion="11">
+    <version ClassVersion="11" checksum="3521396535"/>
   </class>
   <class name="std::vector<l1t::TkJetWord>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkJetWord> >"/>

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -231,14 +231,15 @@ void L1TrackJetEmulationProducer::produce(Event &iEvent, const EventSetup &iSetu
           continue;
         if (mzb.clusters[j].ntracks > 5000)
           continue;
-        l1t::glbeta_t jetEta = mzb.clusters[j].eta * convert::ETA_LSB_POW;
-        l1t::glbphi_t jetPhi = mzb.clusters[j].phi * convert::PHI_LSB_POW;
-        l1t::glbphi_t jetZ0 = mzb.zbincenter * convert::Z0_LSB_POW;
-        l1t::pt_t jetPt = mzb.clusters[j].pTtot;
-        l1t::nt_t totalntracks_ = mzb.clusters[j].ntracks;
-        l1t::nx_t totalxtracks_ = mzb.clusters[j].nxtracks;
+        l1t::TkJetWord::glbeta_t jetEta = mzb.clusters[j].eta * convert::ETA_LSB_POW;
+        l1t::TkJetWord::glbphi_t jetPhi = mzb.clusters[j].phi * convert::PHI_LSB_POW;
+        l1t::TkJetWord::z0_t jetZ0 = mzb.zbincenter * convert::Z0_LSB_POW;
+        l1t::TkJetWord::pt_t jetPt = mzb.clusters[j].pTtot;
+        l1t::TkJetWord::nt_t totalntracks_ = mzb.clusters[j].ntracks;
+        l1t::TkJetWord::nx_t totalxtracks_ = mzb.clusters[j].nxtracks;
+        l1t::TkJetWord::tkjetunassigned_t unassigned_ = 0;
 
-        struct l1t::TkJetWord trkJet = {jetPt, jetEta, jetPhi, jetZ0, totalntracks_, totalxtracks_};
+        l1t::TkJetWord trkJet(jetPt, jetEta, jetPhi, jetZ0, totalntracks_, totalxtracks_, unassigned_);
         //trkJet.setDispCounters(DispCounters);
         L1L1TrackJetProducer->push_back(trkJet);
       }
@@ -374,8 +375,8 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
     pt_intern E1 = 0;
     pt_intern E0 = 0;
     pt_intern E2 = 0;
-    l1t::nt_t ntrk1, ntrk2;
-    l1t::nx_t nxtrk1, nxtrk2;
+    l1t::TkJetWord::nt_t ntrk1, ntrk2;
+    l1t::TkJetWord::nx_t nxtrk1, nxtrk2;
     int used1, used2, used3, used4;
 
     for (phibin = 0; phibin < phiBins_; ++phibin) {  //Find eta-phibin with highest pT

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.h
@@ -62,8 +62,8 @@ namespace convert {
 //  Also used to store final cluster data for each zbin.
 struct EtaPhiBin {
   pt_intern pTtot;
-  l1t::nt_t ntracks;
-  l1t::nx_t nxtracks;
+  l1t::TkJetWord::nt_t ntracks;
+  l1t::TkJetWord::nx_t nxtracks;
   bool used;
   glbphi_intern phi;  //average phi value (halfway b/t min and max)
   glbeta_intern eta;  //average eta value

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2394,12 +2394,12 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     }	
     else if (TrackJetsEmulationHandle.isValid() && (Displaced=="Prompt" || Displaced=="Both")) {	
       for (jetemIter = TrackJetsEmulationHandle->begin(); jetemIter != TrackJetsEmulationHandle->end(); ++jetemIter) {	
-        m_trkjetem_ntracks->push_back(jetemIter->intNTracks());	
-        m_trkjetem_phi->push_back(jetemIter->floatPhi());	
-        m_trkjetem_eta->push_back(jetemIter->floatEta());	
-        m_trkjetem_pt->push_back(jetemIter->floatPt());
-        m_trkjetem_z->push_back(jetemIter->floatZ0());
-        m_trkjetem_nxtracks->push_back(jetemIter->intNXTracks());	
+        m_trkjetem_ntracks->push_back(jetemIter->nt());	
+        m_trkjetem_phi->push_back(jetemIter->glbphi());	
+        m_trkjetem_eta->push_back(jetemIter->glbeta());	
+        m_trkjetem_pt->push_back(jetemIter->pt());
+        m_trkjetem_z->push_back(jetemIter->z0());
+        m_trkjetem_nxtracks->push_back(jetemIter->xt());	
       }	
     }	
     if ( !TrackJetsExtendedEmulationHandle.isValid() && (Displaced=="Displaced" || Displaced=="Both") ) {	
@@ -2407,12 +2407,12 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     }	
     else if (TrackJetsExtendedEmulationHandle.isValid() && (Displaced=="Displaced" || Displaced=="Both")) {	
       for (jetemIter = TrackJetsExtendedEmulationHandle->begin(); jetemIter != TrackJetsExtendedEmulationHandle->end(); ++jetemIter) {	
-        m_trkjetemExt_ntracks->push_back(jetemIter->intNTracks());	
-        m_trkjetemExt_phi->push_back(jetemIter->floatPhi());	
-        m_trkjetemExt_eta->push_back(jetemIter->floatEta());	
-        m_trkjetemExt_pt->push_back(jetemIter->floatPt());
-        m_trkjetemExt_z->push_back(jetemIter->floatZ0());	
-        m_trkjetemExt_nxtracks->push_back(jetemIter->intNXTracks());	
+        m_trkjetemExt_ntracks->push_back(jetemIter->nt());	
+        m_trkjetemExt_phi->push_back(jetemIter->glbphi());	
+        m_trkjetemExt_eta->push_back(jetemIter->glbeta());	
+        m_trkjetemExt_pt->push_back(jetemIter->pt());
+        m_trkjetemExt_z->push_back(jetemIter->z0());	
+        m_trkjetemExt_nxtracks->push_back(jetemIter->xt());	
       }	
     }	
 	


### PR DESCRIPTION
**PR description:**

This PR does the following:

1.    Changes TkJetWord from a struct to a class.
2.    Changes the persistent data of TkJetWord such that it stores a single 64-bit word.
3.    Updates the L1TrackObjectNtupleMaker to reflect the changes in TkJetWord.
4.    Allows the track jets to be saved in EDM format.

**Future updates not included in this PR:**

1. In the future we will want the ability to write out text files which contain the emulation inputs and outputs, for comparison to the HLS/firmware code. However, this feature is not yet implemented.
2. We currently take the global phi of each track directly from TTTrack_TrackWord. Once GTT increases the precision of the local phi in TTTrack_TrackWord, we will update the emulator to calculate the global phi of each track from this local phi and the phi sector of each track.

**PR validation:**

This PR has been validated in the following ways:

1.    scram b code-checks
2.    We also created some validation plots to see that the code was behaving as expected.