### PR TITLE
Updated L1boosted objects

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -232,7 +232,15 @@ L1TCaloSummary::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
     string regionEta = activeRegionEtaPattern.to_string<char,std::string::traits_type,std::string::allocator_type>();
     string regionPhi = activeRegionPhiPattern.to_string<char,std::string::traits_type,std::string::allocator_type>();
-    if(abs(eta) < 2.5 && (regionEta == "010" || regionPhi == "010" || regionEta == "110" || regionPhi == "110" || regionEta == "011" || regionPhi == "011") ) bJetCands->push_back(L1JetParticle(math::PtEtaPhiMLorentzVector(pt, eta, phi, mass), L1JetParticle::kCentral));
+
+    bool centralHighest = object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[0] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[1] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[2] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[3] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[5] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[6] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[7] && object->boostedJetRegionET()[4] >= object->boostedJetRegionET()[8];
+
+    if(abs(eta) < 2.5 &&
+      ((regionEta == "101" && (regionPhi == "110" || regionPhi == "101" || regionPhi == "010")) ||
+      ((regionEta == "110" || regionEta == "101" || regionEta == "010") && regionPhi == "101") ||
+      (regionEta == "111" && (regionPhi == "110" || regionPhi == "010")) ||
+      ((regionEta == "110" || regionEta == "010") && regionPhi == "111") ||
+      ((regionEta == "010" || regionPhi == "010" || regionEta == "110" || regionPhi == "110" || regionEta == "011" || regionPhi == "011") && centralHighest))) bJetCands->push_back(L1JetParticle(math::PtEtaPhiMLorentzVector(pt, eta, phi, mass), L1JetParticle::kCentral));
   }
 
   iEvent.put(std::move(bJetCands), "Boosted");

--- a/L1Trigger/L1TCaloLayer1/python/uct2016EmulatorDigis_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/uct2016EmulatorDigis_cfi.py
@@ -44,7 +44,7 @@ pumLUT17p=  cms.vdouble(3.28, 2.64, 2.26, 2.23, 1.97, 1.89, 7.61, 2.27, 2.33, 2.
                                       tauIsolationFactor = cms.double(0.3),
                                       eGammaSeed = cms.uint32(5),
                                       eGammaIsolationFactor = cms.double(0.3),
-                                      boostedJetPtFactor = cms.double(1.2),
+                                      boostedJetPtFactor = cms.double(1.5),
                                       verbose = cms.bool(False),
                                       # See UCTLayer1.hh for firmware version
                                       firmwareVersion = cms.int32(1)

--- a/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.cc
@@ -342,22 +342,22 @@ bool UCTSummaryCard::processRegion(UCTRegionIndex center) {
   uint32_t pu3x3 = centralPU + northPU + nwPU + westPU + swPU + southPU + sePU + eastPU + nePU;
 
   // Jet - a 3x3 object with center greater than a seed and all neighbors
+  uint32_t jetET = et3x3;
 
   if(centralET >= northET && centralET >= nwET && centralET >= westET && centralET >= swET &&
      centralET >  southET && centralET >  seET && centralET >  eastET && centralET >  neET &&
      centralET > jetSeed) {
-    uint32_t jetET = et3x3;
     if(centralRegion) 
       centralJetObjs.push_back(new UCTObject(UCTObject::jet, jetET, hitCaloEta, hitCaloPhi, pu3x3, 0, et3x3));
     else
       forwardJetObjs.push_back(new UCTObject(UCTObject::jet, jetET, hitCaloEta, hitCaloPhi, pu3x3, 0, et3x3));
-
-    auto boostedJet = new UCTObject(UCTObject::jet, jetET, hitCaloEta, hitCaloPhi, pu3x3, 0, et3x3);
-    boostedJet->setNTaus(nTauLike);
-    boostedJet->setBoostedJetRegionET(boostedJetRegionET);
-    boostedJet->setBoostedJetRegionTauVeto(boostedJetRegionTauVeto);
-    boostedJetObjs.push_back(boostedJet);
   }
+
+  auto boostedJet = new UCTObject(UCTObject::jet, jetET, hitCaloEta, hitCaloPhi, pu3x3, 0, et3x3);
+  boostedJet->setNTaus(nTauLike);
+  boostedJet->setBoostedJetRegionET(boostedJetRegionET);
+  boostedJet->setBoostedJetRegionTauVeto(boostedJetRegionTauVeto);
+  boostedJetObjs.push_back(boostedJet);
 
   // tau Object - a single region or a 2-region sum, where the neighbor with lower ET is located using matching hit calo towers
     


### PR DESCRIPTION
#### PR description:

Updated pT scale factor and pattern requirements for the L1boosted jets.

#### PR validation:

Comparison of rates and efficiencies with existing stage-2 jet and HT seeds (BX=0) :
https://indico.cern.ch/event/1077285/#3-boosted-jets

####  if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport.

@gomber @drankincms @isobelojalvo
