### PR TITLE
uGT emulator code for hadronic shower triggers for Run-3

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -15,6 +15,7 @@ namespace l1t {
   ///    ObjNull catch all errors
   enum GlobalObject {
     gtMu,
+    gtMuShower,
     gtEG,
     gtJet,
     gtTau,

--- a/DataFormats/L1TGlobal/src/GlobalObject.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObject.cc
@@ -25,6 +25,7 @@ using namespace l1t;
 
 l1t::GlobalObject l1TGtObjectStringToEnum(const std::string& label) {
   static const l1t::L1TGtObjectStringToEnum l1TGtObjectStringToEnumMap[] = {{"Mu", gtMu},
+                                                                            {"MuShower", gtMuShower},
                                                                             {"EG", gtEG},
                                                                             {"Tau", gtTau},
                                                                             {"Jet", gtJet},
@@ -85,6 +86,10 @@ std::string l1t::l1TGtObjectEnumToString(const GlobalObject& gtObject) {
   switch (gtObject) {
     case gtMu: {
       gtObjectString = "Mu";
+    } break;
+
+    case gtMuShower: {
+      gtObjectString = "MuShower";
     } break;
 
     case gtEG: {

--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -18,12 +18,16 @@ namespace l1t {
     RegionalMuonShower(bool oneNominalInTime = false,
                        bool oneNominalOutOfTime = false,
                        bool twoLooseInTime = false,
-                       bool twoLooseOutOfTime = false);
+                       bool twoLooseOutOfTime = false,
+                       bool twoTightInTime = false,
+                       bool twoTightOutOfTime = false);
 
     ~RegionalMuonShower();
 
     void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
     void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
+    void setOneTightInTime(const bool bit) { isOneTightInTime_ = bit; }
+    void setOneTightOutOfTime(const bool bit) { isOneTightOutOfTime_ = bit; }
     void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
     void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
 
@@ -34,6 +38,8 @@ namespace l1t {
     bool isValid() const;
     bool isOneNominalInTime() const { return isOneNominalInTime_; }
     bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
+    bool isOneTightInTime() const { return isOneTightInTime_; }
+    bool isOneTightOutOfTime() const { return isOneTightOutOfTime_; }
     bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
     bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
 
@@ -50,6 +56,8 @@ namespace l1t {
     // in time and out-of-time qualities. only 2 bits each.
     bool isOneNominalInTime_;
     bool isOneNominalOutOfTime_;
+    bool isOneTightInTime_;
+    bool isOneTightOutOfTime_;
     bool isTwoLooseInTime_;
     bool isTwoLooseOutOfTime_;
     int endcap_;       //    +/-1.  For ME+ and ME-.

--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -19,8 +19,8 @@ namespace l1t {
                        bool oneNominalOutOfTime = false,
                        bool twoLooseInTime = false,
                        bool twoLooseOutOfTime = false,
-                       bool twoTightInTime = false,
-                       bool twoTightOutOfTime = false);
+                       bool oneTightInTime = false,
+                       bool oneTightOutOfTime = false);
 
     ~RegionalMuonShower();
 

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -3,11 +3,16 @@
 l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
                                             bool oneNominalOutOfTime,
                                             bool twoLooseInTime,
-                                            bool twoLooseOutOfTime)
+                                            bool twoLooseOutOfTime,
+                                            bool oneTightInTime,
+                                            bool oneTightOutOfTime
+                                            )
     : isOneNominalInTime_(oneNominalInTime),
       isOneNominalOutOfTime_(oneNominalOutOfTime),
-      isTwoLooseInTime_(twoLooseInTime),
-      isTwoLooseOutOfTime_(twoLooseOutOfTime),
+  isOneTightInTime_(oneTightInTime),
+  isOneTightOutOfTime_(oneTightOutOfTime),
+  isTwoLooseInTime_(twoLooseInTime),
+  isTwoLooseOutOfTime_(twoLooseOutOfTime),
       endcap_(0),
       sector_(0),
       link_(0) {}
@@ -15,10 +20,15 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return isOneNominalInTime_ or isTwoLooseInTime_ or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_;
+  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_
+          or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_ or isOneTightOutOfTime_);
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
-  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and isOneNominalOutOfTime_ == rhs.isOneNominalOutOfTime());
+  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and
+          isOneNominalInTime_ == rhs.isOneNominalInTime() and
+          isOneNominalInTime_ == rhs.isOneNominalInTime() and
+          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and
+          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime() and
+          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime());
 }

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -5,14 +5,13 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
                                             bool twoLooseInTime,
                                             bool twoLooseOutOfTime,
                                             bool oneTightInTime,
-                                            bool oneTightOutOfTime
-                                            )
+                                            bool oneTightOutOfTime)
     : isOneNominalInTime_(oneNominalInTime),
       isOneNominalOutOfTime_(oneNominalOutOfTime),
-  isOneTightInTime_(oneTightInTime),
-  isOneTightOutOfTime_(oneTightOutOfTime),
-  isTwoLooseInTime_(twoLooseInTime),
-  isTwoLooseOutOfTime_(twoLooseOutOfTime),
+      isOneTightInTime_(oneTightInTime),
+      isOneTightOutOfTime_(oneTightOutOfTime),
+      isTwoLooseInTime_(twoLooseInTime),
+      isTwoLooseOutOfTime_(twoLooseOutOfTime),
       endcap_(0),
       sector_(0),
       link_(0) {}
@@ -20,15 +19,12 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_
-          or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_ or isOneTightOutOfTime_);
+  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_ or isOneNominalOutOfTime_ or
+          isTwoLooseOutOfTime_ or isOneTightOutOfTime_);
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
-  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and
-          isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and
-          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime() and
-          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime());
+  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
+          isOneNominalInTime_ == rhs.isOneNominalInTime() and isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and
+          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime() and isOneTightOutOfTime_ == rhs.isOneTightOutOfTime());
 }

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -19,12 +19,10 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_ or isOneNominalOutOfTime_ or
-          isTwoLooseOutOfTime_ or isOneTightOutOfTime_);
+  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_);
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
   return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isOneNominalInTime_ == rhs.isOneNominalInTime() and isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and
-          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime() and isOneTightOutOfTime_ == rhs.isOneTightOutOfTime());
+          isOneTightInTime_ == rhs.isOneTightInTime());
 }

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -13,7 +13,8 @@
   <class name="l1t::RegionalMuonCandBxCollection"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
-  <class name="l1t::RegionalMuonShower" ClassVersion="10">
+  <class name="l1t::RegionalMuonShower" ClassVersion="11">
+    <version ClassVersion="11" checksum="376206249"/>
     <version ClassVersion="10" checksum="3501434665"/>
   </class>
   <class name="std::vector<l1t::RegionalMuonShower>"/>

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -54,26 +54,26 @@ namespace l1t {
       This is done separately for the in-time and out-of-time trigger data
     */
 
-    void setMus0(const bool bit) {mus0_ = bit;}
-    void setMus1(const bool bit) {mus1_ = bit;}
-    void setMusOutOfTime0(const bool bit) {musOutOfTime0_ = bit;}
-    void setMusOutOfTime1(const bool bit) {musOutOfTime1_ = bit;}
+    void setMus0(const bool bit) { mus0_ = bit; }
+    void setMus1(const bool bit) { mus1_ = bit; }
+    void setMusOutOfTime0(const bool bit) { musOutOfTime0_ = bit; }
+    void setMusOutOfTime1(const bool bit) { musOutOfTime1_ = bit; }
 
-    bool mus0() const {return mus0_;}
-    bool mus1() const {return mus1_;}
-    bool musOutOfTime0() const {return musOutOfTime0_;}
-    bool musOutOfTime1() const {return musOutOfTime1_;}
+    bool mus0() const { return mus0_; }
+    bool mus1() const { return mus1_; }
+    bool musOutOfTime0() const { return musOutOfTime0_; }
+    bool musOutOfTime1() const { return musOutOfTime1_; }
 
     // at least one bit must be valid
     bool isValid() const;
 
     // useful members for trigger performance studies
-    bool isOneNominalInTime() const {return mus0_;}
-    bool isOneNominalOutOfTime() const {return musOutOfTime0_;}
-    bool isTwoLooseInTime() const {return mus1_;}
-    bool isTwoLooseOutOfTime() const {return musOutOfTime1_;}
-    bool isOneTightInTime() const {return mus0_ and mus1_;}
-    bool isOneTightOutOfTime() const {return musOutOfTime0_ and musOutOfTime1_;}
+    bool isOneNominalInTime() const { return mus0_; }
+    bool isOneNominalOutOfTime() const { return musOutOfTime0_; }
+    bool isTwoLooseInTime() const { return mus1_; }
+    bool isTwoLooseOutOfTime() const { return musOutOfTime1_; }
+    bool isOneTightInTime() const { return mus0_ and mus1_; }
+    bool isOneTightOutOfTime() const { return musOutOfTime0_ and musOutOfTime1_; }
 
     virtual bool operator==(const l1t::MuonShower& rhs) const;
     virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -30,20 +30,50 @@ namespace l1t {
     MuonShower(bool oneNominalInTime = false,
                bool oneNominalOutOfTime = false,
                bool twoLooseInTime = false,
-               bool twoLooseOutOfTime = false);
+               bool twoLooseOutOfTime = false,
+               bool oneTightInTime = false,
+               bool oneTightOutOfTime = false);
 
     ~MuonShower() override;
 
-    void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
-    void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
-    void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
-    void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
+    /*
+      In CMSSW we consider 3 valid cases:
+      - 1 nominal shower (baseline trigger for physics at Run-3)
+      - 2 loose showers (to extend the physics reach)
+      - 1 tight shower (backup trigger)
 
+      In the uGT and UTM library, the hadronic shower trigger data is split
+      over 4 bits: 2 for in-time trigger data, 2 for out-of-time trigger data
+      - mus0, mus1 for in-time
+      - musOutOfTime0, musOutOfTime1 for out-of-time
+
+      The mapping for Run-3 is as follows:
+      - 1 nominal shower -> 0b01
+      - 2 loose showers -> 0b10
+      - 1 tight shower -> 0b11
+      This is done separately for the in-time and out-of-time trigger data
+    */
+
+    void setMus0(const bool bit) {mus0_ = bit;}
+    void setMus1(const bool bit) {mus1_ = bit;}
+    void setMusOutOfTime0(const bool bit) {musOutOfTime0_ = bit;}
+    void setMusOutOfTime1(const bool bit) {musOutOfTime1_ = bit;}
+
+    bool mus0() const {return mus0_;}
+    bool mus1() const {return mus1_;}
+    bool musOutOfTime0() const {return musOutOfTime0_;}
+    bool musOutOfTime1() const {return musOutOfTime1_;}
+
+    // at least one bit must be valid
     bool isValid() const;
-    bool isOneNominalInTime() const { return isOneNominalInTime_; }
-    bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
-    bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
-    bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
+
+    // useful members for trigger performance studies
+    bool isOneNominalInTime() const {return mus0_;}
+    bool isOneNominalOutOfTime() const {return musOutOfTime0_;}
+    bool isTwoLooseInTime() const {return mus1_;}
+    bool isTwoLooseOutOfTime() const {return musOutOfTime1_;}
+    bool isOneTightInTime() const {return mus0_ and mus1_;}
+    bool isOneTightOutOfTime() const {return musOutOfTime0_ and musOutOfTime1_;}
 
     virtual bool operator==(const l1t::MuonShower& rhs) const;
     virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };
@@ -51,10 +81,10 @@ namespace l1t {
   private:
     // Run-3 definitions as provided in DN-20-033
     // in time and out-of-time qualities. only 2 bits each.
-    bool isOneNominalInTime_;
-    bool isOneNominalOutOfTime_;
-    bool isTwoLooseInTime_;
-    bool isTwoLooseOutOfTime_;
+    bool mus0_;
+    bool mus1_;
+    bool musOutOfTime0_;
+    bool musOutOfTime1_;
   };
 
 }  // namespace l1t

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -39,19 +39,19 @@ namespace l1t {
     /*
       In CMSSW we consider 3 valid cases:
       - 1 nominal shower (baseline trigger for physics at Run-3)
-      - 2 loose showers (to extend the physics reach)
       - 1 tight shower (backup trigger)
+      - 2 loose showers (to extend the physics reach)
 
       In the uGT and UTM library, the hadronic shower trigger data is split
       over 4 bits: 2 for in-time trigger data, 2 for out-of-time trigger data
       - mus0, mus1 for in-time
       - musOutOfTime0, musOutOfTime1 for out-of-time
 
-      The mapping for Run-3 is as follows:
-      - 1 nominal shower -> 0b01
-      - 2 loose showers -> 0b10
-      - 1 tight shower -> 0b11
-      This is done separately for the in-time and out-of-time trigger data
+      The mapping for Run-3 startup is as follows:
+      - 1 nominal shower -> 0b01 (mus0)
+      - 1 tight shower -> 0b10 (mus1)
+
+      The 2 loose showers case would be mapped onto musOutOfTime0 and musOutOfTime1 later during Run-3
     */
 
     void setMus0(const bool bit) { mus0_ = bit; }
@@ -68,12 +68,15 @@ namespace l1t {
     bool isValid() const;
 
     // useful members for trigger performance studies
+    // needed at startup Run-3
     bool isOneNominalInTime() const { return mus0_; }
-    bool isOneNominalOutOfTime() const { return musOutOfTime0_; }
-    bool isTwoLooseInTime() const { return mus1_; }
-    bool isTwoLooseOutOfTime() const { return musOutOfTime1_; }
-    bool isOneTightInTime() const { return mus0_ and mus1_; }
-    bool isOneTightOutOfTime() const { return musOutOfTime0_ and musOutOfTime1_; }
+    bool isOneTightInTime() const { return mus1_; }
+    // to be developed during Run-3
+    bool isTwoLooseInTime() const { return false; }
+    // these options require more study
+    bool isOneNominalOutOfTime() const { return false; }
+    bool isTwoLooseOutOfTime() const { return false; }
+    bool isOneTightOutOfTime() const { return false; }
 
     virtual bool operator==(const l1t::MuonShower& rhs) const;
     virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -1,25 +1,24 @@
 #include "DataFormats/L1Trigger/interface/MuonShower.h"
 
-l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime, bool oneTightInTime, bool oneTightOutOfTime)
-  : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
-    // in this object it makes more sense to the different shower types to
-    // the 4 bits, so that the object easily interfaces with the uGT emulator
-    mus0_(oneNominalInTime or oneTightInTime),
-    mus1_(twoLooseInTime or oneTightInTime),
-    musOutOfTime0_(oneNominalOutOfTime or oneTightOutOfTime),
-    musOutOfTime1_(twoLooseOutOfTime or oneTightOutOfTime)
-{
-}
+l1t::MuonShower::MuonShower(bool oneNominalInTime,
+                            bool oneNominalOutOfTime,
+                            bool twoLooseInTime,
+                            bool twoLooseOutOfTime,
+                            bool oneTightInTime,
+                            bool oneTightOutOfTime)
+    : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
+      // in this object it makes more sense to the different shower types to
+      // the 4 bits, so that the object easily interfaces with the uGT emulator
+      mus0_(oneNominalInTime or oneTightInTime),
+      mus1_(twoLooseInTime or oneTightInTime),
+      musOutOfTime0_(oneNominalOutOfTime or oneTightOutOfTime),
+      musOutOfTime1_(twoLooseOutOfTime or oneTightOutOfTime) {}
 
 l1t::MuonShower::~MuonShower() {}
 
-bool l1t::MuonShower::isValid() const {
-  return mus0_ or mus1_ or musOutOfTime0_ or musOutOfTime1_;
-}
+bool l1t::MuonShower::isValid() const { return mus0_ or mus1_ or musOutOfTime0_ or musOutOfTime1_; }
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
-  return (mus0_ == rhs.mus0() and
-          mus1_ == rhs.mus1() and
-          musOutOfTime0_ == rhs.musOutOfTime0() and
+  return (mus0_ == rhs.mus0() and mus1_ == rhs.mus1() and musOutOfTime0_ == rhs.musOutOfTime0() and
           musOutOfTime1_ == rhs.musOutOfTime1());
 }

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -1,19 +1,25 @@
 #include "DataFormats/L1Trigger/interface/MuonShower.h"
 
-l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime)
-    : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
-      isOneNominalInTime_(oneNominalInTime),
-      isOneNominalOutOfTime_(oneNominalOutOfTime),
-      isTwoLooseInTime_(twoLooseInTime),
-      isTwoLooseOutOfTime_(twoLooseOutOfTime) {}
+l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime, bool oneTightInTime, bool oneTightOutOfTime)
+  : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
+    // in this object it makes more sense to the different shower types to
+    // the 4 bits, so that the object easily interfaces with the uGT emulator
+    mus0_(oneNominalInTime or oneTightInTime),
+    mus1_(twoLooseInTime or oneTightInTime),
+    musOutOfTime0_(oneNominalOutOfTime or oneTightOutOfTime),
+    musOutOfTime1_(twoLooseOutOfTime or oneTightOutOfTime)
+{
+}
 
 l1t::MuonShower::~MuonShower() {}
 
 bool l1t::MuonShower::isValid() const {
-  return isOneNominalInTime_ or isTwoLooseInTime_ or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_;
+  return mus0_ or mus1_ or musOutOfTime0_ or musOutOfTime1_;
 }
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
-  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and isOneNominalOutOfTime_ == rhs.isOneNominalOutOfTime());
+  return (mus0_ == rhs.mus0() and
+          mus1_ == rhs.mus1() and
+          musOutOfTime0_ == rhs.musOutOfTime0() and
+          musOutOfTime1_ == rhs.musOutOfTime1());
 }

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -9,10 +9,10 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime,
     : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
       // in this object it makes more sense to the different shower types to
       // the 4 bits, so that the object easily interfaces with the uGT emulator
-      mus0_(oneNominalInTime or oneTightInTime),
-      mus1_(twoLooseInTime or oneTightInTime),
-      musOutOfTime0_(oneNominalOutOfTime or oneTightOutOfTime),
-      musOutOfTime1_(twoLooseOutOfTime or oneTightOutOfTime) {}
+      mus0_(oneNominalInTime),
+      mus1_(oneTightInTime),
+      musOutOfTime0_(false),
+      musOutOfTime1_(false) {}
 
 l1t::MuonShower::~MuonShower() {}
 

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -103,7 +103,8 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="10">
+  <class name="l1t::MuonShower" ClassVersion="11">
+   <version ClassVersion="11" checksum="3610959089"/>
    <version ClassVersion="10" checksum="3869296059"/>
   </class>
   <class name="edm::Ptr<l1t::MuonShower>"/>

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -136,6 +136,7 @@ protected:
   unsigned showerMaxInTBin_;
   unsigned showerMinOutTBin_;
   unsigned showerMaxOutTBin_;
+  unsigned minLayersCentralTBin_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig, drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -190,6 +190,7 @@ protected:
   unsigned showerMaxInTBin_;
   unsigned showerMinOutTBin_;
   unsigned showerMaxOutTBin_;
+  unsigned minLayersCentralTBin_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig;  // only for test beam mode.

--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -25,53 +25,55 @@ showerPSet = cms.PSet(
             # ME1/1
             100, 100, 100,
             # ME1/2
-            54, 55, 61,
+            19, 38, 42,
             # ME1/3
-            20, 20, 30,
+            8, 11, 15,
             # ME2/1
-            35, 35, 35,
+            17, 33, 35,
             # ME2/2
-            29, 29, 35,
+            10, 20, 24,
             # ME3/1
-            35, 35, 40,
+            15, 31, 33,
             # ME3/2
-            24, 25, 30,
+            9, 18, 22,
             # ME4/1
-            36, 40, 40,
+            17, 34, 36,
             # ME4/2
-            26, 30, 30
+            11, 22, 26
         ),
         showerMinInTBin = cms.uint32(6),
         showerMaxInTBin = cms.uint32(8),
         showerMinOutTBin = cms.uint32(2),
         showerMaxOutTBin = cms.uint32(5),
+        minLayersCentralTBin = cms.uint32(5),
     ),
     ## settings for anode showers (counting CSCWireDigi)
     anodeShower = cms.PSet(
         ## {loose, nominal, tight} thresholds for hit counters
         showerThresholds = cms.vuint32(
             # ME1/1
-            104, 105, 107,
+            140, 140, 140,
             # ME1/2
-            92, 100, 102,
+            20, 41, 45,
             # ME1/3
-            32, 33, 48,
+            8, 12, 16,
             # ME2/1
-            133, 134, 136,
+            28, 56, 58,
             # ME2/2
-            83, 84, 86,
+            9, 18, 22,
             # ME3/1
-            130, 131, 133,
+            26, 55, 57,
             # ME3/2
-            74, 80, 87,
+            8, 16, 20,
             # ME4/1
-            127, 128, 130,
+            31, 62, 64,
             # ME4/2
-            88, 89, 94
+            13, 27, 31
         ),
         showerMinInTBin = cms.uint32(8),
-        showerMaxInTBin = cms.uint32(10),
+        showerMaxInTBin = cms.uint32(8),
         showerMinOutTBin = cms.uint32(4),
         showerMaxOutTBin = cms.uint32(7),
+        minLayersCentralTBin = cms.uint32(5),
     )
 )

--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -9,7 +9,11 @@ showerPSet = cms.PSet(
     ##    loose -> 'loose anode or loose cathode'
     ##    nominal -> 'nominal anode or nominal cathode'
     ##    tight -> 'tight anode or tight cathode'
-    source  = cms.uint32(0),
+    ## 3: cathode and anode showers
+    ##    loose -> 'loose anode and loose cathode'
+    ##    nominal -> 'nominal anode and nominal cathode'
+    ##    tight -> 'tight anode and tight cathode'
+    source  = cms.uint32(3),
 
     ## settings for cathode showers (counting CSCComparatorDigi)
     cathodeShower = cms.PSet(

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -180,7 +180,6 @@ void CSCAnodeLCTProcessor::clear() {
   }
   lct_list.clear();
   inTimeHMT_ = 0;
-  outTimeHMT_ = 0;
 }
 
 void CSCAnodeLCTProcessor::clear(const int wire, const int pattern) {
@@ -1340,7 +1339,6 @@ void CSCAnodeLCTProcessor::setWireContainer(CSCALCTDigi& alct, CSCALCTDigi::Wire
 void CSCAnodeLCTProcessor::encodeHighMultiplicityBits(
     const std::vector<int> wires[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIREGROUPS]) {
   inTimeHMT_ = 0;
-  outTimeHMT_ = 0;
 
   auto layerTime = [=](unsigned time) { return time == CSCConstants::LCT_CENTRAL_BX; };
 
@@ -1349,36 +1347,37 @@ void CSCAnodeLCTProcessor::encodeHighMultiplicityBits(
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     bool atLeastOneWGHit = false;
     for (int i_wire = 0; i_wire < CSCConstants::MAX_NUM_WIREGROUPS; i_wire++) {
+      // there is at least one wiregroup...
       if (!wires[i_layer][i_wire].empty()) {
         auto times = wires[i_layer][i_wire];
         int nLayerTime = std::count_if(times.begin(), times.end(), layerTime);
+        // ...for which at least one time bin was on for the central BX
         if (nLayerTime > 0) {
           atLeastOneWGHit = true;
           break;
         }
       }
     }
+    // add this layer to the number of layers hit
     if (atLeastOneWGHit) {
       nLayersWithHits++;
     }
   }
 
+  // require at least nLayersWithHits for the central time bin
   // do nothing if there are not enough layers with hits
   if (nLayersWithHits < minLayersCentralTBin_)
     return;
 
   // functions for in-time and out-of-time
   auto inTime = [=](unsigned time) { return time >= showerMinInTBin_ and time <= showerMaxInTBin_; };
-  auto outTime = [=](unsigned time) { return time >= showerMinOutTBin_ and time <= showerMaxOutTBin_; };
 
   // count the wires in-time and out-time
   unsigned hitsInTime = 0;
-  unsigned hitsOutTime = 0;
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     for (int i_wire = 0; i_wire < CSCConstants::MAX_NUM_WIREGROUPS; i_wire++) {
       auto times = wires[i_layer][i_wire];
       hitsInTime += std::count_if(times.begin(), times.end(), inTime);
-      hitsOutTime += std::count_if(times.begin(), times.end(), outTime);
     }
   }
 
@@ -1395,11 +1394,8 @@ void CSCAnodeLCTProcessor::encodeHighMultiplicityBits(
     if (hitsInTime >= station_thresholds[i]) {
       inTimeHMT_ = i + 1;
     }
-    if (hitsOutTime >= station_thresholds[i]) {
-      outTimeHMT_ = i + 1;
-    }
   }
 
   // create a new object
-  shower_ = CSCShowerDigi(inTimeHMT_, outTimeHMT_, theTrigChamber);
+  shower_ = CSCShowerDigi(inTimeHMT_, false, theTrigChamber);
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -550,38 +550,30 @@ void CSCMotherboard::encodeHighMultiplicityBits() {
   // get the high multiplicity
   // for anode this reflects what is already in the anode CSCShowerDigi object
   unsigned cathodeInTime = clctProc->getInTimeHMT();
-  unsigned cathodeOutTime = clctProc->getOutTimeHMT();
   unsigned anodeInTime = alctProc->getInTimeHMT();
-  unsigned anodeOutTime = alctProc->getOutTimeHMT();
 
   // assign the bits
   unsigned inTimeHMT_;
-  unsigned outTimeHMT_;
 
   // set the value according to source
   switch (showerSource_) {
     case 0:
       inTimeHMT_ = cathodeInTime;
-      outTimeHMT_ = cathodeOutTime;
       break;
     case 1:
       inTimeHMT_ = anodeInTime;
-      outTimeHMT_ = anodeOutTime;
       break;
     case 2:
       inTimeHMT_ = anodeInTime | cathodeInTime;
-      outTimeHMT_ = anodeOutTime | cathodeOutTime;
       break;
     case 3:
       inTimeHMT_ = anodeInTime & cathodeInTime;
-      outTimeHMT_ = anodeOutTime & cathodeOutTime;
       break;
     default:
       inTimeHMT_ = cathodeInTime;
-      outTimeHMT_ = cathodeOutTime;
       break;
   };
 
   // create a new object
-  shower_ = CSCShowerDigi(inTimeHMT_, outTimeHMT_, theTrigChamber);
+  shower_ = CSCShowerDigi(inTimeHMT_, false, theTrigChamber);
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -572,6 +572,10 @@ void CSCMotherboard::encodeHighMultiplicityBits() {
       inTimeHMT_ = anodeInTime | cathodeInTime;
       outTimeHMT_ = anodeOutTime | cathodeOutTime;
       break;
+    case 3:
+      inTimeHMT_ = anodeInTime & cathodeInTime;
+      outTimeHMT_ = anodeOutTime & cathodeOutTime;
+      break;
     default:
       inTimeHMT_ = cathodeInTime;
       outTimeHMT_ = cathodeOutTime;

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -25,6 +25,7 @@
 // Trigger Objects
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
@@ -77,11 +78,17 @@ namespace l1t {
                                const bool receiveMu,
                                const int nrL1Mu);
 
+    void receiveMuonShowerObjectData(edm::Event&,
+                                     const edm::EDGetTokenT<BXVector<l1t::MuonShower>>&,
+                                     const bool receiveMuShower,
+                                     const int nrL1MuShower);
+
     void receiveExternalData(edm::Event&, const edm::EDGetTokenT<BXVector<GlobalExtBlk>>&, const bool receiveExt);
 
     /// initialize the class (mainly reserve)
     void init(const int numberPhysTriggers,
               const int nrL1Mu,
+              const int nrL1MuShower,
               const int nrL1EG,
               const int nrL1Tau,
               const int nrL1Jet,
@@ -97,6 +104,7 @@ namespace l1t {
                 std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,  //GTO
                 const unsigned int numberPhysTriggers,
                 const int nrL1Mu,
+                const int nrL1MuShower,
                 const int nrL1EG,
                 const int nrL1Tau,
                 const int nrL1Jet);
@@ -122,6 +130,7 @@ namespace l1t {
     /// clear uGT
     void reset();
     void resetMu();
+    void resetMuonShower();
     void resetCalo();
     void resetExternal();
 
@@ -136,6 +145,9 @@ namespace l1t {
 
     /// return global muon trigger candidate
     inline const BXVector<const l1t::Muon*>* getCandL1Mu() const { return m_candL1Mu; }
+
+    /// return global muon trigger candidate
+    inline const BXVector<const l1t::MuonShower*>* getCandL1MuShower() const { return m_candL1MuShower; }
 
     /// pointer to EG data list
     inline const BXVector<const l1t::L1Candidate*>* getCandL1EG() const { return m_candL1EG; }
@@ -203,6 +215,7 @@ namespace l1t {
 
   private:
     BXVector<const l1t::Muon*>* m_candL1Mu;
+    BXVector<const l1t::MuonShower*>* m_candL1MuShower;
     BXVector<const l1t::L1Candidate*>* m_candL1EG;
     BXVector<const l1t::L1Candidate*>* m_candL1Tau;
     BXVector<const l1t::L1Candidate*>* m_candL1Jet;

--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -98,7 +98,8 @@ namespace l1t {
     CondCorrelation,
     CondExternal,
     CondCorrelationWithOverlapRemoval,
-    CondCorrelationThreeBody
+    CondCorrelationThreeBody,
+    CondMuonShower,
   };
 
   struct GtConditionCategoryStringToEnum {

--- a/L1Trigger/L1TGlobal/interface/MuonShowerCondition.h
+++ b/L1Trigger/L1TGlobal/interface/MuonShowerCondition.h
@@ -1,0 +1,81 @@
+#ifndef L1Trigger_L1TGlobal_MuonShowerCondition_h
+#define L1Trigger_L1TGlobal_MuonShowerCondition_h
+
+/**
+ * \class MuonShowerCondition
+ *
+ * Description: evaluation of a CondMuonShower condition.
+ */
+
+// system include files
+#include <iosfwd>
+#include <string>
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+// forward declarations
+class GlobalCondition;
+class MuonShowerTemplate;
+
+namespace l1t {
+
+  class GlobalBoard;
+
+  // class declaration
+  class MuonShowerCondition : public ConditionEvaluation {
+  public:
+    /// constructors
+    ///     default
+    MuonShowerCondition();
+
+    ///     from base template condition (from event setup usually)
+    MuonShowerCondition(const GlobalCondition*, const GlobalBoard*, const int nrL1MuShower);
+
+    // copy constructor
+    MuonShowerCondition(const MuonShowerCondition&);
+
+    // destructor
+    ~MuonShowerCondition() override;
+
+    // assign operator
+    MuonShowerCondition& operator=(const MuonShowerCondition&);
+
+    /// the core function to check if the condition matches
+    const bool evaluateCondition(const int bxEval) const override;
+
+    /// print condition
+    void print(std::ostream& myCout) const override;
+
+    ///   get / set the pointer to a Condition
+    inline const MuonShowerTemplate* gtMuonShowerTemplate() const { return m_gtMuonShowerTemplate; }
+
+    void setGtMuonShowerTemplate(const MuonShowerTemplate*);
+
+    ///   get / set the pointer to GTL
+    inline const GlobalBoard* gtGTL() const { return m_gtGTL; }
+
+    void setGtGTL(const GlobalBoard*);
+
+  private:
+    /// copy function for copy constructor and operator=
+    void copy(const MuonShowerCondition& cp);
+
+    /// load muon candidates
+    const l1t::MuonShower* getCandidate(const int bx, const int indexCand) const;
+
+    /// function to check a single object if it matches a condition
+    const bool checkObjectParameter(const int iCondition, const l1t::MuonShower& cand, const unsigned int index) const;
+
+    /// pointer to a MuonShowerTemplate
+    const MuonShowerTemplate* m_gtMuonShowerTemplate;
+
+    /// pointer to GTL, to be able to get the trigger objects
+    const GlobalBoard* m_gtGTL;
+  };
+
+}  // namespace l1t
+#endif

--- a/L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h
@@ -1,0 +1,74 @@
+#ifndef L1Trigger_L1TGlobal_MuonShowerTemplate_h
+#define L1Trigger_L1TGlobal_MuonShowerTemplate_h
+
+/**
+ * \class MuonShowerTemplate
+ *
+ *
+ * Description: L1 Global Trigger muon shower template.
+ *
+ * \author: Sven Dildick (Rice University)
+ *
+ */
+
+// system include files
+#include <string>
+#include <iosfwd>
+
+// user include files
+
+//   base class
+#include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
+
+// forward declarations
+
+// class declaration
+class MuonShowerTemplate : public GlobalCondition {
+public:
+  // constructor
+  MuonShowerTemplate();
+
+  // constructor
+  MuonShowerTemplate(const std::string&);
+
+  // constructor
+  MuonShowerTemplate(const std::string&, const l1t::GtConditionType&);
+
+  // copy constructor
+  MuonShowerTemplate(const MuonShowerTemplate&);
+
+  // destructor
+  ~MuonShowerTemplate() override;
+
+  // assign operator
+  MuonShowerTemplate& operator=(const MuonShowerTemplate&);
+
+  // typedef for a single object template
+  struct ObjectParameter {
+    bool MuonShower0;
+    bool MuonShower1;
+    bool MuonShowerOutOfTime0;
+    bool MuonShowerOutOfTime1;
+  };
+
+public:
+  inline const std::vector<ObjectParameter>* objectParameter() const { return &m_objectParameter; }
+
+  /// set functions
+  void setConditionParameter(const std::vector<ObjectParameter>& objParameter);
+
+  /// print the condition
+  void print(std::ostream& myCout) const override;
+
+  /// output stream operator
+  friend std::ostream& operator<<(std::ostream&, const MuonShowerTemplate&);
+
+private:
+  /// copy function for copy constructor and operator=
+  void copy(const MuonShowerTemplate& cp);
+
+  /// variables containing the parameters
+  std::vector<ObjectParameter> m_objectParameter;
+};
+
+#endif

--- a/L1Trigger/L1TGlobal/interface/TriggerMenu.h
+++ b/L1Trigger/L1TGlobal/interface/TriggerMenu.h
@@ -32,6 +32,7 @@
 #include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
 
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
@@ -53,6 +54,7 @@ public:
   TriggerMenu(const std::string&,
               const unsigned int numberConditionChips,
               const std::vector<std::vector<MuonTemplate> >&,
+              const std::vector<std::vector<MuonShowerTemplate> >&,
               const std::vector<std::vector<CaloTemplate> >&,
               const std::vector<std::vector<EnergySumTemplate> >&,
               const std::vector<std::vector<ExternalTemplate> >&,
@@ -108,6 +110,13 @@ public:
   inline const std::vector<std::vector<MuonTemplate> >& vecMuonTemplate() const { return m_vecMuonTemplate; }
 
   void setVecMuonTemplate(const std::vector<std::vector<MuonTemplate> >&);
+
+  //
+  inline const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTemplate() const {
+    return m_vecMuonShowerTemplate;
+  }
+
+  void setVecMuonShowerTemplate(const std::vector<std::vector<MuonShowerTemplate> >&);
 
   //
   inline const std::vector<std::vector<CaloTemplate> >& vecCaloTemplate() const { return m_vecCaloTemplate; }
@@ -218,6 +227,7 @@ private:
   /// vectors containing the conditions
   /// explicit, due to persistency...
   std::vector<std::vector<MuonTemplate> > m_vecMuonTemplate;
+  std::vector<std::vector<MuonShowerTemplate> > m_vecMuonShowerTemplate;
   std::vector<std::vector<CaloTemplate> > m_vecCaloTemplate;
   std::vector<std::vector<EnergySumTemplate> > m_vecEnergySumTemplate;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -68,6 +68,7 @@ private:
 
   // number of objects of each type
   int m_nrL1Mu;
+  int m_nrL1MuShower;
   int m_nrL1EG;
   int m_nrL1Tau;
 
@@ -119,7 +120,9 @@ private:
 
   /// input tag for muon collection from GMT
   edm::InputTag m_muInputTag;
+  edm::InputTag m_muShowerInputTag;
   edm::EDGetTokenT<BXVector<l1t::Muon>> m_muInputToken;
+  edm::EDGetTokenT<BXVector<l1t::MuonShower>> m_muShowerInputToken;
 
   /// input tag for calorimeter collections from GCT
   edm::InputTag m_egInputTag;
@@ -185,6 +188,9 @@ private:
   edm::ESGetToken<L1TGlobalParameters, L1TGlobalParametersRcd> m_l1GtStableParToken;
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1GtMenuToken;
   edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_l1GtPrescaleVetosToken;
+
+  // switch to load muon showers in the global board
+  bool m_useMuonShowers;
 };
 
 #endif /*L1TGlobalProducer_h*/

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -14,9 +14,9 @@
  *                - correlations with overlap object removal
  *                - displaced muons by R.Cavanaugh
  *
- * \new features: Elisa Fontanesi                                                      
- *                - extended for three-body correlation conditions                                         
- *                                                                
+ * \new features: Elisa Fontanesi
+ *                - extended for three-body correlation conditions
+ *
  * $Date$
  * $Revision$
  *
@@ -111,6 +111,11 @@ void l1t::TriggerMenuParser::setVecMuonTemplate(const std::vector<std::vector<Mu
   m_vecMuonTemplate = vecMuonTempl;
 }
 
+void l1t::TriggerMenuParser::setVecMuonShowerTemplate(
+    const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTempl) {
+  m_vecMuonShowerTemplate = vecMuonShowerTempl;
+}
+
 void l1t::TriggerMenuParser::setVecCaloTemplate(const std::vector<std::vector<CaloTemplate> >& vecCaloTempl) {
   m_vecCaloTemplate = vecCaloTempl;
 }
@@ -202,6 +207,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
   m_conditionMap.resize(m_numberConditionChips);
 
   m_vecMuonTemplate.resize(m_numberConditionChips);
+  m_vecMuonShowerTemplate.resize(m_numberConditionChips);
   m_vecCaloTemplate.resize(m_numberConditionChips);
   m_vecEnergySumTemplate.resize(m_numberConditionChips);
   m_vecExternalTemplate.resize(m_numberConditionChips);
@@ -299,6 +305,12 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
                    condition.getType() == esConditionType::TripleMuon ||
                    condition.getType() == esConditionType::QuadMuon) {
           parseMuon(condition, chipNr, false);
+
+        } else if (condition.getType() == esConditionType::MuonShower0 ||
+                   condition.getType() == esConditionType::MuonShower1 ||
+                   condition.getType() == esConditionType::MuonShowerOutOfTime0 ||
+                   condition.getType() == esConditionType::MuonShowerOutOfTime1) {
+          parseMuonShower(condition, chipNr, false);
 
           //parse Correlation Conditions
         } else if (condition.getType() == esConditionType::MuonMuonCorrelation ||
@@ -1516,6 +1528,89 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   (m_corMuonTemplate[chipNr]).push_back(muonCond);
 
   //
+  return true;
+}
+
+/**
+ * parseMuonShower Parse a muonShower condition and insert an entry to the conditions map
+ *
+ * @param node The corresponding node.
+ * @param name The name of the condition.
+ * @param chipNr The number of the chip this condition is located.
+ *
+ * @return "true" if succeeded, "false" if an error occurred.
+ *
+ */
+
+bool l1t::TriggerMenuParser::parseMuonShower(tmeventsetup::esCondition condMu,
+                                             unsigned int chipNr,
+                                             const bool corrFlag) {
+  using namespace tmeventsetup;
+
+  // get condition, particle name (must be muon) and type name
+  std::string condition = "muonShower";
+  std::string particle = "muonShower";  //l1t2string( condMu.objectType() );
+  std::string type = l1t2string(condMu.getType());
+  std::string name = l1t2string(condMu.getName());
+  // the number of muon shower objects is always 1
+  int nrObj = 1;
+
+  // condition type is always 1 particle, thus Type1s
+  GtConditionType cType = l1t::Type1s;
+
+  // edm::LogWarning("TriggerMenuParser") << "\n ****************************************** "
+  //                               << "\n      parseMuonShower  "
+  //                               << "\n condition = " << condition << "\n particle  = " << particle
+  //                               << "\n type      = " << type << "\n name      = " << name << std::endl;
+
+  // temporary storage of the parameters
+  std::vector<MuonShowerTemplate::ObjectParameter> objParameter(nrObj);
+
+  if (int(condMu.getObjects().size()) != nrObj) {
+    edm::LogError("TriggerMenuParser") << " condMu objects: nrObj = " << nrObj
+                                       << "condMu.getObjects().size() = " << condMu.getObjects().size() << std::endl;
+    return false;
+  }
+
+  // Get the muon shower object
+  esObject object = condMu.getObjects().at(0);
+  int relativeBx = object.getBxOffset();
+
+  if (condMu.getType() == esConditionType::MuonShower0) {
+    objParameter[0].MuonShower0 = true;
+  } else if (condMu.getType() == esConditionType::MuonShower1) {
+    objParameter[0].MuonShower1 = true;
+  } else if (condMu.getType() == esConditionType::MuonShowerOutOfTime0) {
+    objParameter[0].MuonShowerOutOfTime0 = true;
+  } else if (condMu.getType() == esConditionType::MuonShowerOutOfTime1) {
+    objParameter[0].MuonShowerOutOfTime1 = true;
+  }
+
+  // object types - all muons
+  std::vector<GlobalObject> objType(nrObj, gtMuShower);
+
+  // now create a new CondMuonition
+  MuonShowerTemplate muonShowerCond(name);
+  muonShowerCond.setCondType(cType);
+  muonShowerCond.setObjectType(objType);
+  muonShowerCond.setCondChipNr(chipNr);
+  muonShowerCond.setCondRelativeBx(relativeBx);
+
+  muonShowerCond.setConditionParameter(objParameter);
+
+  if (edm::isDebugEnabled()) {
+    std::ostringstream myCoutStream;
+    muonShowerCond.print(myCoutStream);
+  }
+
+  // insert condition into the map and into muon template vector
+  if (!insertConditionIntoMap(muonShowerCond, chipNr)) {
+    edm::LogError("TriggerMenuParser") << "    Error: duplicate condition (" << name << ")" << std::endl;
+    return false;
+  } else {
+    (m_vecMuonShowerTemplate[chipNr]).push_back(muonShowerCond);
+  }
+
   return true;
 }
 

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -17,9 +17,9 @@
  *                - correlations with overlap object removal
  * \author R. Cavanaugh
  *                - displaced muons
- * \author Elisa Fontanesi                                                                               
- *                - extended for three-body correlation conditions                                                               
- *                                                                  
+ * \author Elisa Fontanesi
+ *                - extended for three-body correlation conditions
+ *
  *
  * $Date$
  * $Revision$
@@ -33,6 +33,7 @@
 #include "L1Trigger/L1TGlobal/interface/TriggerMenuFwd.h"
 
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
@@ -123,6 +124,12 @@ namespace l1t {
     /// get / set the vectors containing the conditions
     inline const std::vector<std::vector<MuonTemplate> >& vecMuonTemplate() const { return m_vecMuonTemplate; }
     void setVecMuonTemplate(const std::vector<std::vector<MuonTemplate> >&);
+
+    //
+    inline const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTemplate() const {
+      return m_vecMuonShowerTemplate;
+    }
+    void setVecMuonShowerTemplate(const std::vector<std::vector<MuonShowerTemplate> >&);
 
     //
     inline const std::vector<std::vector<CaloTemplate> >& vecCaloTemplate() const { return m_vecCaloTemplate; }
@@ -266,6 +273,9 @@ namespace l1t {
 
     bool parseMuonCorr(const tmeventsetup::esObject* condMu, unsigned int chipNr = 0);
 
+    /// parse a muon shower condition
+    bool parseMuonShower(tmeventsetup::esCondition condMu, unsigned int chipNr = 0, const bool corrFlag = false);
+
     /// parse a calorimeter condition
     /*     bool parseCalo(XERCES_CPP_NAMESPACE::DOMNode* node, */
     /*             const std::string& name, unsigned int chipNr = 0, */
@@ -383,6 +393,7 @@ namespace l1t {
     /// vectors containing the conditions
     /// explicit, due to persistency...
     std::vector<std::vector<MuonTemplate> > m_vecMuonTemplate;
+    std::vector<std::vector<MuonShowerTemplate> > m_vecMuonShowerTemplate;
     std::vector<std::vector<CaloTemplate> > m_vecCaloTemplate;
     std::vector<std::vector<EnergySumTemplate> > m_vecEnergySumTemplate;
     std::vector<std::vector<ExternalTemplate> > m_vecExternalTemplate;

--- a/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
+++ b/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
@@ -4,32 +4,22 @@
 # All changes must be explicitly discussed with the L1T offline coordinator.
 #
 import FWCore.ParameterSet.Config as cms
-
-# cfi uGT emulator
-
-simGtStage2Digis = cms.EDProducer("L1TGlobalProducer",
-    MuonInputTag = cms.InputTag("simGmtStage2Digis"),
-    ExtInputTag = cms.InputTag("simGtExtFakeStage2Digis"),
-    EGammaInputTag = cms.InputTag("simCaloStage2Digis"),
-    TauInputTag = cms.InputTag("simCaloStage2Digis"),
-    JetInputTag = cms.InputTag("simCaloStage2Digis"),
-    EtSumInputTag = cms.InputTag("simCaloStage2Digis"),
-    AlgorithmTriggersUnmasked = cms.bool(True),    
-    AlgorithmTriggersUnprescaled = cms.bool(True),
-    GetPrescaleColumnFromData = cms.bool(False),
-    RequireMenuToMatchAlgoBlkInput = cms.bool(False),
-    AlgoBlkInputTag = cms.InputTag("gtStage2Digis")
-    # deprecated in Mike's version of producer:                              
-    #ProduceL1GtDaqRecord = cms.bool(True),
-    #GmtInputTag = cms.InputTag("gtInput"),
-    #extInputTag = cms.InputTag("gtInput"),
-    #caloInputTag = cms.InputTag("gtInput"),
-    #AlternativeNrBxBoardDaq = cms.uint32(0),
-    #WritePsbL1GtDaqRecord = cms.bool(True),
-    #TriggerMenuLuminosity = cms.string('startup'),
-    #PrescaleCSVFile = cms.string('prescale_L1TGlobal.csv'),
-    #PrescaleSet = cms.uint32(1),
-    #BstLengthBytes = cms.int32(-1),
-    #Verbosity = cms.untracked.int32(0)
+from L1Trigger.L1TGlobal.simGtStage2DigisDef_cfi import simGtStage2DigisDef
+simGtStage2Digis = simGtStage2DigisDef.clone(
+    MuonInputTag = "simGmtStage2Digis",
+    MuonShowerInputTag = "simGmtShowerDigis",
+    EGammaInputTag = "simCaloStage2Digis",
+    TauInputTag = "simCaloStage2Digis",
+    JetInputTag = "simCaloStage2Digis",
+    EtSumInputTag = "simCaloStage2Digis",
+    ExtInputTag = "simGtExtFakeStage2Digis",
+    AlgoBlkInputTag = "gtStage2Digis",
+    AlgorithmTriggersUnmasked = True,
+    AlgorithmTriggersUnprescaled = True,
+    GetPrescaleColumnFromData = False,
+    RequireMenuToMatchAlgoBlkInput = False,
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(simGtStage2Digis,
+                     useMuonShowers = False)

--- a/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
+++ b/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
@@ -22,4 +22,4 @@ simGtStage2Digis = simGtStage2DigisDef.clone(
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(simGtStage2Digis,
-                     useMuonShowers = False)
+                     useMuonShowers = cms.bool(True))

--- a/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
+++ b/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
@@ -1,14 +1,14 @@
 /**
  * \class AlgorithmEvaluation
- * 
- * 
+ *
+ *
  * Description: Evaluation of a L1 Global Trigger algorithm.
- * 
+ *
  * Implementation:
  *    <TODO: enter implementation details>
- *   
- * \author: Vasile Mihai Ghete   - HEPHY Vienna 
- * 
+ *
+ * \author: Vasile Mihai Ghete   - HEPHY Vienna
+ *
  *
  */
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -27,6 +27,7 @@
 #include "L1Trigger/L1TGlobal/interface/GlobalAlgorithm.h"
 
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
@@ -42,6 +43,7 @@
 
 // Conditions for uGt
 #include "L1Trigger/L1TGlobal/interface/MuCondition.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CaloCondition.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumCondition.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalCondition.h"
@@ -60,6 +62,7 @@
 // constructor
 l1t::GlobalBoard::GlobalBoard()
     : m_candL1Mu(new BXVector<const l1t::Muon*>),
+      m_candL1MuShower(new BXVector<const l1t::MuonShower*>),
       m_candL1EG(new BXVector<const l1t::L1Candidate*>),
       m_candL1Tau(new BXVector<const l1t::L1Candidate*>),
       m_candL1Jet(new BXVector<const l1t::L1Candidate*>),
@@ -91,6 +94,7 @@ l1t::GlobalBoard::GlobalBoard()
 l1t::GlobalBoard::~GlobalBoard() {
   //reset();  //why would we need a reset?
   delete m_candL1Mu;
+  delete m_candL1MuShower;
   delete m_candL1EG;
   delete m_candL1Tau;
   delete m_candL1Jet;
@@ -107,6 +111,7 @@ void l1t::GlobalBoard::setBxLast(int bx) { m_bxLast_ = bx; }
 
 void l1t::GlobalBoard::init(const int numberPhysTriggers,
                             const int nrL1Mu,
+                            const int nrL1MuShower,
                             const int nrL1EG,
                             const int nrL1Tau,
                             const int nrL1Jet,
@@ -116,6 +121,7 @@ void l1t::GlobalBoard::init(const int numberPhysTriggers,
   setBxLast(bxLast);
 
   m_candL1Mu->setBXRange(m_bxFirst_, m_bxLast_);
+  m_candL1MuShower->setBXRange(m_bxFirst_, m_bxLast_);
   m_candL1EG->setBXRange(m_bxFirst_, m_bxLast_);
   m_candL1Tau->setBXRange(m_bxFirst_, m_bxLast_);
   m_candL1Jet->setBXRange(m_bxFirst_, m_bxLast_);
@@ -293,19 +299,19 @@ void l1t::GlobalBoard::receiveCaloObjectData(edm::Event& iEvent,
 			 //(*m_candETM).push_back(i,&(*etsum));
 			 LogDebug("L1TGlobal") << "ETM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
 		       }
-		       break; 
+		       break;
 		     case l1t::EtSum::EtSumType::kMissingHt:
 		       {
 			 //(*m_candHTM).push_back(i,&(*etsum));
 			 LogDebug("L1TGlobal") << "HTM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
 		       }
-		       break; 		     
+		       break;
 		     case l1t::EtSum::EtSumType::kTotalEt:
 		       {
 			 //(*m_candETT).push_back(i,&(*etsum));
 			 LogDebug("L1TGlobal") << "ETT:  Pt " << etsum->hwPt() << std::endl;
 		       }
-		       break; 		     
+		       break;
 		     case l1t::EtSum::EtSumType::kTotalHt:
 		       {
 			 //(*m_candHTT).push_back(i,&(*etsum));
@@ -384,6 +390,54 @@ void l1t::GlobalBoard::receiveMuonObjectData(edm::Event& iEvent,
   }  //end if ReveiveMuon data
 }
 
+// receive muon shower data from Global Muon Trigger
+void l1t::GlobalBoard::receiveMuonShowerObjectData(edm::Event& iEvent,
+                                                   const edm::EDGetTokenT<BXVector<l1t::MuonShower>>& muShowerInputToken,
+                                                   const bool receiveMuShower,
+                                                   const int nrL1MuShower) {
+  // get data from Global Muon Trigger
+  if (receiveMuShower) {
+    edm::Handle<BXVector<l1t::MuonShower>> muonData;
+    iEvent.getByToken(muShowerInputToken, muonData);
+
+    if (!muonData.isValid()) {
+      if (m_verbosity) {
+        edm::LogWarning("L1TGlobal") << "\nWarning: BXVector<l1t::MuonShower> with input tag "
+                                     << "\nrequested in configuration, but not found in the event.\n"
+                                     << std::endl;
+      }
+    } else {
+      //Loop over Muon Showers in this bx
+      int nObj = 0;
+      for (auto mu = muonData->begin(0); mu != muonData->end(0); ++mu) {
+        if (nObj < nrL1MuShower) {
+          /* Important here to split up the single object into 4 separate MuonShower
+             bits for the global board. This is because the UTM library considers those bits separate as well
+           */
+          l1t::MuonShower mus0;
+          l1t::MuonShower mus1;
+          l1t::MuonShower musOutOfTime0;
+          l1t::MuonShower musOutOfTime1;
+
+          mus0.setMus0(mu->mus0());
+          mus1.setMus1(mu->mus1());
+          musOutOfTime0.setMusOutOfTime0(mu->musOutOfTime0());
+          musOutOfTime1.setMusOutOfTime1(mu->musOutOfTime1());
+
+          (*m_candL1MuShower).push_back(0, &mus0);
+          (*m_candL1MuShower).push_back(0, &mus1);
+          (*m_candL1MuShower).push_back(0, &musOutOfTime0);
+          (*m_candL1MuShower).push_back(0, &musOutOfTime1);
+        } else {
+          edm::LogWarning("L1TGlobal") << " Too many Muon Showers (" << nObj
+                                       << ") for uGT Configuration maxMuShower =" << nrL1MuShower << std::endl;
+        }
+        nObj++;
+      }  //end loop over muon showers in bx
+    }    //end if over valid muon shower data
+  }      //end if ReveiveMuonShower data
+}
+
 // receive data from Global External Conditions
 void l1t::GlobalBoard::receiveExternalData(edm::Event& iEvent,
                                            const edm::EDGetTokenT<BXVector<GlobalExtBlk>>& extInputToken,
@@ -435,6 +489,7 @@ void l1t::GlobalBoard::runGTL(edm::Event& iEvent,
                               std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,
                               const unsigned int numberPhysTriggers,
                               const int nrL1Mu,
+                              const int nrL1MuShower,
                               const int nrL1EG,
                               const int nrL1Tau,
                               const int nrL1Jet) {
@@ -504,6 +559,24 @@ void l1t::GlobalBoard::runGTL(edm::Event& iEvent,
             LogTrace("L1TGlobal") << myCout.str() << std::endl;
           }
           //delete muCondition;
+
+        } break;
+        case CondMuonShower: {
+          MuonShowerCondition* muShowerCondition = new MuonShowerCondition(itCond->second, this, nrL1MuShower);
+
+          muShowerCondition->setVerbosity(m_verbosity);
+
+          muShowerCondition->evaluateConditionStoreResult(iBxInEvent);
+
+          cMapResults[itCond->first] = muShowerCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            muShowerCondition->print(myCout);
+
+            edm::LogWarning("L1TGlobal") << "MuonShowerCondition " << myCout.str() << std::endl;
+          }
+          //delete muShowerCondition;
 
         } break;
         case CondCalo: {
@@ -1039,6 +1112,7 @@ void l1t::GlobalBoard::fillAlgRecord(int iBxInEvent,
 // clear GTL
 void l1t::GlobalBoard::reset() {
   resetMu();
+  resetMuonShower();
   resetCalo();
   resetExternal();
 
@@ -1052,6 +1126,12 @@ void l1t::GlobalBoard::reset() {
 void l1t::GlobalBoard::resetMu() {
   m_candL1Mu->clear();
   m_candL1Mu->setBXRange(m_bxFirst_, m_bxLast_);
+}
+
+// clear muon shower
+void l1t::GlobalBoard::resetMuonShower() {
+  m_candL1MuShower->clear();
+  m_candL1MuShower->setBXRange(m_bxFirst_, m_bxLast_);
 }
 
 // clear calo

--- a/L1Trigger/L1TGlobal/src/GlobalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalCondition.cc
@@ -180,6 +180,12 @@ void GlobalCondition::print(std::ostream& myCout) const {
     }
 
     break;
+    case l1t::CondMuonShower: {
+      myCout << "  Condition category: "
+             << "l1t::CondMuonShower" << std::endl;
+    }
+
+    break;
     case l1t::CondCalo: {
       myCout << "  Condition category: "
              << "l1t::CondCalo" << std::endl;
@@ -429,6 +435,11 @@ void GlobalCondition::print(std::ostream& myCout) const {
     switch (m_objectType[i]) {
       case l1t::gtMu: {
         myCout << " Mu ";
+      }
+
+      break;
+      case l1t::gtMuShower: {
+        myCout << " MuShower ";
       }
 
       break;

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -1,0 +1,188 @@
+// this class header
+#include "L1Trigger/L1TGlobal/interface/MuonShowerCondition.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+#include "L1Trigger/L1TGlobal/interface/GlobalBoard.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+// constructors
+//     default
+l1t::MuonShowerCondition::MuonShowerCondition() : ConditionEvaluation() {
+  // empty
+}
+
+//     from base template condition (from event setup usually)
+l1t::MuonShowerCondition::MuonShowerCondition(const GlobalCondition* muonShowerTemplate,
+                                              const GlobalBoard* ptrGTL,
+                                              const int nrL1MuShower)
+    : ConditionEvaluation(),
+      m_gtMuonShowerTemplate(static_cast<const MuonShowerTemplate*>(muonShowerTemplate)),
+      m_gtGTL(ptrGTL) {
+  m_condMaxNumberObjects = nrL1MuShower;
+}
+
+// copy constructor
+void l1t::MuonShowerCondition::copy(const l1t::MuonShowerCondition& cp) {
+  m_gtMuonShowerTemplate = cp.gtMuonShowerTemplate();
+  m_gtGTL = cp.gtGTL();
+
+  m_condMaxNumberObjects = cp.condMaxNumberObjects();
+  m_condLastResult = cp.condLastResult();
+  m_combinationsInCond = cp.getCombinationsInCond();
+
+  m_verbosity = cp.m_verbosity;
+}
+
+l1t::MuonShowerCondition::MuonShowerCondition(const l1t::MuonShowerCondition& cp) : ConditionEvaluation() { copy(cp); }
+
+// destructor
+l1t::MuonShowerCondition::~MuonShowerCondition() {
+  // empty
+}
+
+// equal operator
+l1t::MuonShowerCondition& l1t::MuonShowerCondition::operator=(const l1t::MuonShowerCondition& cp) {
+  copy(cp);
+  return *this;
+}
+
+// methods
+void l1t::MuonShowerCondition::setGtMuonShowerTemplate(const MuonShowerTemplate* muonTempl) {
+  m_gtMuonShowerTemplate = muonTempl;
+}
+
+///   set the pointer to GTL
+void l1t::MuonShowerCondition::setGtGTL(const GlobalBoard* ptrGTL) { m_gtGTL = ptrGTL; }
+
+// try all object permutations and check spatial correlations, if required
+const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
+  // number of trigger objects in the condition
+  int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
+
+  // the candidates
+  const BXVector<const l1t::MuonShower*>* candVec = m_gtGTL->getCandL1MuShower();
+
+  // Look at objects in bx = bx + relativeBx
+  int useBx = bxEval + m_gtMuonShowerTemplate->condRelativeBx();
+
+  // Fail condition if attempting to get Bx outside of range
+  if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
+    return false;
+  }
+
+  // store the indices of the shower objects
+  // from the combination evaluated in the condition
+  SingleCombInCond objectsInComb;
+  objectsInComb.reserve(nObjInCond);
+
+  // clear the m_combinationsInCond vector
+  (combinationsInCond()).clear();
+
+  // clear the indices in the combination
+  objectsInComb.clear();
+
+  // If no candidates, no use looking any further.
+  int numberObjects = candVec->size(useBx);
+  if (numberObjects < 1) {
+    return false;
+  }
+
+  std::vector<int> index(numberObjects);
+
+  for (int i = 0; i < numberObjects; ++i) {
+    index[i] = i;
+  }
+
+  bool condResult = false;
+
+  // index is always zero, as they are global quantities (there is only one object)
+  int indexObj = 0;
+
+  objectsInComb.push_back(indexObj);
+  (combinationsInCond()).push_back(objectsInComb);
+
+  // if we get here all checks were successfull for this combination
+  // set the general result for evaluateCondition to "true"
+
+  condResult = true;
+  return condResult;
+}
+
+// load muon candidates
+const l1t::MuonShower* l1t::MuonShowerCondition::getCandidate(const int bx, const int indexCand) const {
+  return (m_gtGTL->getCandL1MuShower())->at(bx, indexCand);  //BLW Change for BXVector
+}
+
+/**
+ * checkObjectParameter - Compare a single particle with a numbered condition.
+ *
+ * @param iCondition The number of the condition.
+ * @param cand The candidate to compare.
+ *
+ * @return The result of the comparison (false if a condition does not exist).
+ */
+
+const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
+                                                          const l1t::MuonShower& cand,
+                                                          const unsigned int index) const {
+  // number of objects in condition
+  int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
+
+  if (iCondition >= nObjInCond || iCondition < 0) {
+    return false;
+  }
+
+  const MuonShowerTemplate::ObjectParameter objPar = (*(m_gtMuonShowerTemplate->objectParameter()))[iCondition];
+
+  LogDebug("L1TGlobal") << "\n MuonShowerTemplate::ObjectParameter : " << std::hex << "\n\t MuonShower0 = 0x "
+                        << objPar.MuonShower0 << "\n\t MuonShower1 = 0x " << objPar.MuonShower1
+                        << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
+                        << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 << std::endl;
+
+  LogDebug("L1TGlobal") << "\n l1t::MuonShower : "
+                        << "\n\t MuonShower0 = 0x " << cand.mus0() << "\n\t MuonShower1 = 0x " << cand.mus1()
+                        << "\n\t MuonShowerOutOfTime0 = 0x " << cand.musOutOfTime0()
+                        << "\n\t MuonShowerOutOfTime1 = 0x " << cand.musOutOfTime1() << std::dec << std::endl;
+
+  // check oneNominalInTime
+  if (cand.mus0() != objPar.MuonShower0) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower0 requirement" << std::endl;
+    return false;
+  }
+  if (cand.mus1() != objPar.MuonShower1) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower1 requirement" << std::endl;
+    return false;
+  }
+  if (cand.musOutOfTime0() != objPar.MuonShowerOutOfTime0) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShowerOutOfTime0 requirement" << std::endl;
+    return false;
+  }
+  if (cand.musOutOfTime1() != objPar.MuonShowerOutOfTime1) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShowerOutOfTime1 requirement" << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+void l1t::MuonShowerCondition::print(std::ostream& myCout) const {
+  m_gtMuonShowerTemplate->print(myCout);
+
+  ConditionEvaluation::print(myCout);
+}

--- a/L1Trigger/L1TGlobal/src/MuonShowerTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerTemplate.cc
@@ -1,0 +1,81 @@
+// this class header
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+
+MuonShowerTemplate::MuonShowerTemplate() : GlobalCondition() { m_condCategory = l1t::CondMuonShower; }
+
+MuonShowerTemplate::MuonShowerTemplate(const std::string& cName) : GlobalCondition(cName) {
+  m_condCategory = l1t::CondMuonShower;
+}
+
+MuonShowerTemplate::MuonShowerTemplate(const std::string& cName, const l1t::GtConditionType& cType)
+    : GlobalCondition(cName, l1t::CondMuonShower, cType) {
+  int nObjects = nrObjects();
+
+  if (nObjects > 0) {
+    m_objectParameter.reserve(nObjects);
+
+    m_objectType.reserve(nObjects);
+    m_objectType.assign(nObjects, l1t::gtMuShower);
+  }
+}
+
+// copy constructor
+MuonShowerTemplate::MuonShowerTemplate(const MuonShowerTemplate& cp) : GlobalCondition(cp.m_condName) { copy(cp); }
+
+// destructor
+MuonShowerTemplate::~MuonShowerTemplate() {
+  // empty now
+}
+
+// assign operator
+MuonShowerTemplate& MuonShowerTemplate::operator=(const MuonShowerTemplate& cp) {
+  copy(cp);
+  return *this;
+}
+
+// setConditionParameter - set the parameters of the condition
+void MuonShowerTemplate::setConditionParameter(const std::vector<ObjectParameter>& objParameter) {
+  m_objectParameter = objParameter;
+}
+
+void MuonShowerTemplate::print(std::ostream& myCout) const {
+  myCout << "\n  MuonShowerTemplate print..." << std::endl;
+
+  GlobalCondition::print(myCout);
+
+  int nObjects = nrObjects();
+
+  for (int i = 0; i < nObjects; i++) {
+    myCout << std::endl;
+    myCout << "  Template for object " << i << " [ hex ]" << std::endl;
+    myCout << "    MuonShower0   = " << std::hex << m_objectParameter[i].MuonShower0 << std::endl;
+    myCout << "    MuonShower1   = " << std::hex << m_objectParameter[i].MuonShower1 << std::endl;
+    myCout << "    MuonShowerOutOfTime0   = " << std::hex << m_objectParameter[i].MuonShowerOutOfTime0 << std::endl;
+    myCout << "    MuonShowerOutOfTime1   = " << std::hex << m_objectParameter[i].MuonShowerOutOfTime1 << std::endl;
+  }
+
+  // reset to decimal output
+  myCout << std::dec << std::endl;
+}
+
+void MuonShowerTemplate::copy(const MuonShowerTemplate& cp) {
+  m_condName = cp.condName();
+  m_condCategory = cp.condCategory();
+  m_condType = cp.condType();
+  m_objectType = cp.objectType();
+  m_condGEq = cp.condGEq();
+  m_condChipNr = cp.condChipNr();
+  m_condRelativeBx = cp.condRelativeBx();
+
+  m_objectParameter = *(cp.objectParameter());
+}
+
+// output stream operator
+std::ostream& operator<<(std::ostream& os, const MuonShowerTemplate& result) {
+  result.print(os);
+  return os;
+}

--- a/L1Trigger/L1TGlobal/src/TriggerMenu.cc
+++ b/L1Trigger/L1TGlobal/src/TriggerMenu.cc
@@ -41,6 +41,7 @@ TriggerMenu::TriggerMenu(
     const std::string& triggerMenuNameVal,
     const unsigned int numberConditionChips,
     const std::vector<std::vector<MuonTemplate> >& vecMuonTemplateVal,
+    const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTemplateVal,
     const std::vector<std::vector<CaloTemplate> >& vecCaloTemplateVal,
     const std::vector<std::vector<EnergySumTemplate> >& vecEnergySumTemplateVal,
     const std::vector<std::vector<ExternalTemplate> >& vecExternalTemplateVal,
@@ -57,6 +58,7 @@ TriggerMenu::TriggerMenu(
       m_triggerMenuImplementation(0x0),
       m_scaleDbKey("NULL"),
       m_vecMuonTemplate(vecMuonTemplateVal),
+      m_vecMuonShowerTemplate(vecMuonShowerTemplateVal),
       m_vecCaloTemplate(vecCaloTemplateVal),
       m_vecEnergySumTemplate(vecEnergySumTemplateVal),
       m_vecExternalTemplate(vecExternalTemplateVal),
@@ -81,6 +83,7 @@ TriggerMenu::TriggerMenu(const TriggerMenu& rhs) {
 
   // copy physics conditions
   m_vecMuonTemplate = rhs.m_vecMuonTemplate;
+  m_vecMuonShowerTemplate = rhs.m_vecMuonShowerTemplate;
   m_vecCaloTemplate = rhs.m_vecCaloTemplate;
   m_vecEnergySumTemplate = rhs.m_vecEnergySumTemplate;
   m_vecExternalTemplate = rhs.m_vecExternalTemplate;
@@ -128,6 +131,7 @@ TriggerMenu& TriggerMenu::operator=(const TriggerMenu& rhs) {
     m_triggerMenuUUID = rhs.m_triggerMenuUUID;
 
     m_vecMuonTemplate = rhs.m_vecMuonTemplate;
+    m_vecMuonShowerTemplate = rhs.m_vecMuonShowerTemplate;
     m_vecCaloTemplate = rhs.m_vecCaloTemplate;
     m_vecEnergySumTemplate = rhs.m_vecEnergySumTemplate;
     m_vecExternalTemplate = rhs.m_vecExternalTemplate;
@@ -185,6 +189,26 @@ void TriggerMenu::buildGtConditionMap() {
     chipNr++;
 
     for (std::vector<MuonTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
+      (m_conditionMap.at(chipNr))[itCond->condName()] = &(*itCond);
+    }
+  }
+
+  //
+  size_t vecMuonShowerSize = m_vecMuonShowerTemplate.size();
+  if (condMapSize < vecMuonShowerSize) {
+    m_conditionMap.resize(vecMuonShowerSize);
+    condMapSize = m_conditionMap.size();
+  }
+
+  chipNr = -1;
+
+  for (std::vector<std::vector<MuonShowerTemplate> >::iterator itCondOnChip = m_vecMuonShowerTemplate.begin();
+       itCondOnChip != m_vecMuonShowerTemplate.end();
+       itCondOnChip++) {
+    chipNr++;
+
+    for (std::vector<MuonShowerTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end();
+         itCond++) {
       (m_conditionMap.at(chipNr))[itCond->condName()] = &(*itCond);
     }
   }

--- a/L1Trigger/L1TGlobal/src/classes.h
+++ b/L1Trigger/L1TGlobal/src/classes.h
@@ -8,5 +8,6 @@ namespace L1Trigger_L1TGlobal {
     std::vector<CorrelationTemplate> dummy3;
     std::vector<CorrelationThreeBodyTemplate> dummy4;
     std::vector<CorrelationWithOverlapRemovalTemplate> dummy5;
+    std::vector<MuonShowerTemplate> dummy6;
   };
 }  // namespace L1Trigger_L1TGlobal

--- a/L1Trigger/L1TGlobal/src/classes_def.xml
+++ b/L1Trigger/L1TGlobal/src/classes_def.xml
@@ -31,17 +31,25 @@
     <field name="m_vecHfRingEtSumsTemplate" mapping="blob" />
     <field name="m_vecJetCountsTemplate" mapping="blob" />
     <field name="m_vecMuonTemplate" mapping="blob" />
+    <field name="m_vecMuonShowerTemplate" mapping="blob" />
   </class>
   <class name="MuonTemplate"/>
   <class name="MuonTemplate::ObjectParameter"/>
   <class name="std::vector<MuonTemplate::ObjectParameter>"/>
-  <class name="MuonTemplate::CorrelationParameter"/>
   <class name="std::vector<MuonTemplate>"/>
   <class name="std::vector<std::vector<MuonTemplate> >"/>
+  <class name="MuonTemplate::CorrelationParameter"/>
+
   <class name="CaloTemplate"/>
   <class name="CaloTemplate::ObjectParameter"/>
   <class name="std::vector<CaloTemplate::ObjectParameter>"/>
-  <class name="CaloTemplate::CorrelationParameter"/>
   <class name="std::vector<CaloTemplate>"/>
   <class name="std::vector<std::vector<CaloTemplate> >"/>
+  <class name="CaloTemplate::CorrelationParameter"/>
+
+  <class name="MuonShowerTemplate"/>
+  <class name="MuonShowerTemplate::ObjectParameter"/>
+  <class name="std::vector<MuonShowerTemplate::ObjectParameter>"/>
+  <class name="std::vector<MuonShowerTemplate>"/>
+  <class name="std::vector<std::vector<MuonShowerTemplate> >"/>
 </lcgdict>

--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -87,11 +87,15 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   }
 
   // Check for at least one nominal shower
-  const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or
-                             isTwoLooseInTime or isTwoLooseOutOfTime  or
+  const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or isTwoLooseInTime or isTwoLooseOutOfTime or
                              isOneNominalInTime or isOneNominalOutOfTime);
   if (acceptCondition) {
-    MuonShower outShower(isOneNominalInTime, isOneNominalOutOfTime, isTwoLooseInTime, isTwoLooseOutOfTime, isOneTightInTime, isOneTightOutOfTime);
+    MuonShower outShower(isOneNominalInTime,
+                         isOneNominalOutOfTime,
+                         isTwoLooseInTime,
+                         isTwoLooseOutOfTime,
+                         isOneTightInTime,
+                         isOneTightOutOfTime);
     outShowers->push_back(0, outShower);
   }
   iEvent.put(std::move(outShowers));

--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -56,46 +56,34 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   /*
     Check each sector for a valid EMTF shower. A valid EMTF shower
-    can either be in-time or out-of-time. The minimal implementation
-    only considers the "at least 1-nominal shower" case.
+    for startup Run-3 can either be "one nominal shower" or "one tight shower".
+    The case  "two loose showers" is under consideration but needs more study.
+    Showers that arrive out-of-time are also under consideration, but are not
+    going be to enabled at startup Run-3. So all showers should be in-time.
    */
   bool isOneNominalInTime = false;
-  bool isOneNominalOutOfTime = false;
   bool isTwoLooseInTime = false;
-  bool isTwoLooseOutOfTime = false;
   bool isOneTightInTime = false;
-  bool isOneTightOutOfTime = false;
   for (size_t i = 0; i < emtfShowers->size(0); ++i) {
     auto shower = emtfShowers->at(0, i);
     if (shower.isValid()) {
       // nominal
       if (shower.isOneNominalInTime())
         isOneNominalInTime = true;
-      if (shower.isOneNominalOutOfTime())
-        isOneNominalOutOfTime = true;
       // two loose
       if (shower.isTwoLooseInTime())
         isTwoLooseInTime = true;
-      if (shower.isTwoLooseOutOfTime())
-        isTwoLooseOutOfTime = true;
       // tight
       if (shower.isOneTightInTime())
         isOneTightInTime = true;
-      if (shower.isOneTightOutOfTime())
-        isOneTightOutOfTime = true;
     }
   }
 
   // Check for at least one nominal shower
-  const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or isTwoLooseInTime or isTwoLooseOutOfTime or
-                             isOneNominalInTime or isOneNominalOutOfTime);
+  const bool acceptCondition(isOneNominalInTime or isTwoLooseInTime or isOneTightInTime);
+
   if (acceptCondition) {
-    MuonShower outShower(isOneNominalInTime,
-                         isOneNominalOutOfTime,
-                         isTwoLooseInTime,
-                         isTwoLooseOutOfTime,
-                         isOneTightInTime,
-                         isOneTightOutOfTime);
+    MuonShower outShower(isOneNominalInTime, false, isTwoLooseInTime, false, isOneTightInTime, false);
     outShowers->push_back(0, outShower);
   }
   iEvent.put(std::move(outShowers));
@@ -107,9 +95,6 @@ void L1TMuonShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("showerInput", edm::InputTag("simEmtfShowers", "EMTF"));
   desc.add<int32_t>("bxMin", 0);
   desc.add<int32_t>("bxMax", 0);
-  desc.add<uint32_t>("minNominalShowers", 1);
-  desc.add<uint32_t>("minTightShowers", 1);
-  desc.add<uint32_t>("minTwoLooseShowers", 0);
   descriptions.add("simGmtShowerDigisDef", desc);
 }
 

--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -63,6 +63,8 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   bool isOneNominalOutOfTime = false;
   bool isTwoLooseInTime = false;
   bool isTwoLooseOutOfTime = false;
+  bool isOneTightInTime = false;
+  bool isOneTightOutOfTime = false;
   for (size_t i = 0; i < emtfShowers->size(0); ++i) {
     auto shower = emtfShowers->at(0, i);
     if (shower.isValid()) {
@@ -76,13 +78,20 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
         isTwoLooseInTime = true;
       if (shower.isTwoLooseOutOfTime())
         isTwoLooseOutOfTime = true;
+      // tight
+      if (shower.isOneTightInTime())
+        isOneTightInTime = true;
+      if (shower.isOneTightOutOfTime())
+        isOneTightOutOfTime = true;
     }
   }
 
   // Check for at least one nominal shower
-  const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or isTwoLooseInTime or isTwoLooseOutOfTime);
+  const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or
+                             isTwoLooseInTime or isTwoLooseOutOfTime  or
+                             isOneNominalInTime or isOneNominalOutOfTime);
   if (acceptCondition) {
-    MuonShower outShower(isOneNominalInTime, isOneNominalOutOfTime, isTwoLooseInTime, isTwoLooseOutOfTime);
+    MuonShower outShower(isOneNominalInTime, isOneNominalOutOfTime, isTwoLooseInTime, isTwoLooseOutOfTime, isOneTightInTime, isOneTightOutOfTime);
     outShowers->push_back(0, outShower);
   }
   iEvent.put(std::move(outShowers));
@@ -94,6 +103,7 @@ void L1TMuonShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("showerInput", edm::InputTag("simEmtfShowers", "EMTF"));
   desc.add<int32_t>("bxMin", 0);
   desc.add<int32_t>("bxMax", 0);
+  desc.add<uint32_t>("minTightShowers", 1);
   desc.add<uint32_t>("minNominalShowers", 1);
   desc.add<uint32_t>("minTwoLooseShowers", 0);
   descriptions.add("simGmtShowerDigisDef", desc);

--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -107,8 +107,8 @@ void L1TMuonShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("showerInput", edm::InputTag("simEmtfShowers", "EMTF"));
   desc.add<int32_t>("bxMin", 0);
   desc.add<int32_t>("bxMax", 0);
-  desc.add<uint32_t>("minTightShowers", 1);
   desc.add<uint32_t>("minNominalShowers", 1);
+  desc.add<uint32_t>("minTightShowers", 1);
   desc.add<uint32_t>("minTwoLooseShowers", 0);
   descriptions.add("simGmtShowerDigisDef", desc);
 }

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -32,14 +32,14 @@ private:
   bool is_in_sector_csc(int tp_endcap, int tp_sector) const;
 
   int verbose_, endcap_, sector_;
-  // backup trigger
-  bool enableOneTightShower_;
   // nominal trigger for physics
   bool enableOneNominalShower_;
+  // backup trigger
+  bool enableOneTightShower_;
   // trigger to extend the physics reach
   bool enableTwoLooseShowers_;
-  unsigned nTightShowers_;
   unsigned nNominalShowers_;
+  unsigned nTightShowers_;
   unsigned nLooseShowers_;
 };
 

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -32,8 +32,13 @@ private:
   bool is_in_sector_csc(int tp_endcap, int tp_sector) const;
 
   int verbose_, endcap_, sector_;
+  // backup trigger
+  bool enableOneTightShower_;
+  // nominal trigger for physics
   bool enableOneNominalShower_;
+  // trigger to extend the physics reach
   bool enableTwoLooseShowers_;
+  unsigned nTightShowers_;
   unsigned nNominalShowers_;
   unsigned nLooseShowers_;
 };

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -41,8 +41,8 @@ void L1TMuonEndCapShowerProducer::produce(edm::Event& iEvent, const edm::EventSe
 void L1TMuonEndCapShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // these are different shower selections that can be enabled
-  desc.add<bool>("enableOneTightShowers", true);
   desc.add<bool>("enableOneNominalShowers", true);
+  desc.add<bool>("enableOneTightShowers", true);
   desc.add<bool>("enableTwoLooseShowers", false);
   desc.add<unsigned>("nLooseShowers", 2);
   desc.add<unsigned>("nNominalShowers", 1);

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -41,10 +41,12 @@ void L1TMuonEndCapShowerProducer::produce(edm::Event& iEvent, const edm::EventSe
 void L1TMuonEndCapShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // these are different shower selections that can be enabled
+  desc.add<bool>("enableOneTightShowers", true);
   desc.add<bool>("enableOneNominalShowers", true);
   desc.add<bool>("enableTwoLooseShowers", false);
   desc.add<unsigned>("nLooseShowers", 2);
   desc.add<unsigned>("nNominalShowers", 1);
+  desc.add<unsigned>("nTightShowers", 1);
   desc.add<edm::InputTag>("CSCShowerInput", edm::InputTag("simCscTriggerPrimitiveDigis"));
   descriptions.add("simEmtfShowersDef", desc);
   descriptions.setComment("This is the generic cfi file for the EMTF shower producer");

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -10,10 +10,10 @@ void SectorProcessorShower::configure(const edm::ParameterSet& pset, int endcap,
 
   enableTwoLooseShowers_ = pset.getParameter<bool>("enableTwoLooseShowers");
   enableOneNominalShower_ = pset.getParameter<bool>("enableOneNominalShowers");
-  enableOneNominalShower_ = pset.getParameter<bool>("enableOneNominalShowers");
+  enableOneTightShower_ = pset.getParameter<bool>("enableOneTightShowers");
   nLooseShowers_ = pset.getParameter<unsigned>("nLooseShowers");
   nNominalShowers_ = pset.getParameter<unsigned>("nNominalShowers");
-  nNominalShowers_ = pset.getParameter<unsigned>("nNominalShowers");
+  nTightShowers_ = pset.getParameter<unsigned>("nTightShowers");
 }
 
 void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
@@ -51,36 +51,21 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
       selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalInTime(); }));
   const unsigned nTightInTime(std::count_if(
       selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isTightInTime(); }));
-  const unsigned nLooseOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseOutOfTime(); }));
-  const unsigned nNominalOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalOutOfTime(); }));
-  const unsigned nTightOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isTightOutOfTime(); }));
 
   const bool hasTwoLooseInTime(nLooseInTime >= nLooseShowers_);
   const bool hasOneNominalInTime(nNominalInTime >= nNominalShowers_);
   const bool hasOneTightInTime(nTightInTime >= nTightShowers_);
 
-  const bool hasTwoLooseOutOfTime(nLooseOutOfTime >= nLooseShowers_);
-  const bool hasOneNominalOutOfTime(nNominalOutOfTime >= nNominalShowers_);
-  const bool hasOneTightOutOfTime(nTightOutOfTime >= nTightShowers_);
-
-  const bool acceptLoose(enableTwoLooseShowers_ and (hasTwoLooseInTime or hasTwoLooseOutOfTime));
-  const bool acceptNominal(enableOneNominalShower_ and (hasOneNominalInTime or hasOneNominalOutOfTime));
-  const bool acceptTight(enableOneTightShower_ and (hasOneTightInTime or hasOneTightOutOfTime));
+  const bool acceptLoose(enableTwoLooseShowers_ and hasTwoLooseInTime);
+  const bool acceptNominal(enableOneNominalShower_ and hasOneNominalInTime);
+  const bool acceptTight(enableOneTightShower_ and hasOneTightInTime);
 
   // trigger condition
   const bool accept(acceptLoose or acceptNominal or acceptTight);
 
   if (accept) {
     // shower output
-    l1t::RegionalMuonShower out_shower(hasOneNominalInTime,
-                                       hasOneNominalOutOfTime,
-                                       hasTwoLooseInTime,
-                                       hasTwoLooseOutOfTime,
-                                       hasOneTightInTime,
-                                       hasOneTightOutOfTime);
+    l1t::RegionalMuonShower out_shower(hasOneNominalInTime, false, hasTwoLooseInTime, false, hasOneTightInTime, false);
     // convert [1,2] to [1, -1]
     const int endcap(endcap_ == 1 ? 1 : -1);
     out_shower.setEndcap(endcap);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -61,6 +61,7 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
   const bool hasTwoLooseInTime(nLooseInTime >= nLooseShowers_);
   const bool hasOneNominalInTime(nNominalInTime >= nNominalShowers_);
   const bool hasOneTightInTime(nTightInTime >= nTightShowers_);
+
   const bool hasTwoLooseOutOfTime(nLooseOutOfTime >= nLooseShowers_);
   const bool hasOneNominalOutOfTime(nNominalOutOfTime >= nNominalShowers_);
   const bool hasOneTightOutOfTime(nTightOutOfTime >= nTightShowers_);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -74,9 +74,12 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
 
   if (accept) {
     // shower output
-    l1t::RegionalMuonShower out_shower(hasOneNominalInTime, hasOneNominalOutOfTime,
-                                       hasTwoLooseInTime, hasTwoLooseOutOfTime,
-                                       hasOneTightInTime, hasOneTightOutOfTime);
+    l1t::RegionalMuonShower out_shower(hasOneNominalInTime,
+                                       hasOneNominalOutOfTime,
+                                       hasTwoLooseInTime,
+                                       hasTwoLooseOutOfTime,
+                                       hasOneTightInTime,
+                                       hasOneTightOutOfTime);
     out_shower.setEndcap(endcap_);
     out_shower.setSector(sector_);
     out_showers.push_back(0, out_shower);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -81,7 +81,9 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
                                        hasTwoLooseOutOfTime,
                                        hasOneTightInTime,
                                        hasOneTightOutOfTime);
-    out_shower.setEndcap(endcap_);
+    // convert [1,2] to [1, -1]
+    const int endcap(endcap_ == 1 ? 1 : -1);
+    out_shower.setEndcap(endcap);
     out_shower.setSector(sector_);
     out_showers.push_back(0, out_shower);
   }

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1Upgrade.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1Upgrade.h
@@ -12,6 +12,7 @@
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
 
 #include "L1AnalysisL1UpgradeDataFormat.h"
@@ -30,6 +31,7 @@ namespace L1Analysis {
     void SetJet(const edm::Handle<l1t::JetBxCollection> jet, unsigned maxL1Upgrade);
     void SetSum(const edm::Handle<l1t::EtSumBxCollection> sums, unsigned maxL1Upgrade);
     void SetMuon(const edm::Handle<l1t::MuonBxCollection> muon, unsigned maxL1Upgrade);
+    void SetMuonShower(const edm::Handle<l1t::MuonShowerBxCollection> muonShower, unsigned maxL1Upgrade);
     L1AnalysisL1UpgradeDataFormat* getData() { return &l1upgrade_; }
 
   private:

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -125,6 +125,11 @@ namespace L1Analysis {
       muonTfMuonIdx.clear();
       muonBx.clear();
 
+      nMuonShowers = 0;
+      muonShowerOneNominal.clear();
+      muonShowerOneTight.clear();
+      muonShowerTwoLoose.clear();
+
       nSums = 0;
       sumType.clear();
       sumEt.clear();
@@ -210,6 +215,11 @@ namespace L1Analysis {
     std::vector<unsigned short int> muonDxy;
     std::vector<unsigned short int> muonTfMuonIdx;
     std::vector<short int> muonBx;
+
+    unsigned short int nMuonShowers;
+    std::vector<short int> muonShowerOneNominal;
+    std::vector<short int> muonShowerOneTight;
+    std::vector<short int> muonShowerTwoLoose;
 
     unsigned short int nSums;
     std::vector<short int> sumType;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -126,6 +126,7 @@ namespace L1Analysis {
       muonBx.clear();
 
       nMuonShowers = 0;
+      muonShowerBx.clear();
       muonShowerOneNominal.clear();
       muonShowerOneTight.clear();
       muonShowerTwoLoose.clear();
@@ -217,6 +218,7 @@ namespace L1Analysis {
     std::vector<short int> muonBx;
 
     unsigned short int nMuonShowers;
+    std::vector<short int> muonShowerBx;
     std::vector<short int> muonShowerOneNominal;
     std::vector<short int> muonShowerOneTight;
     std::vector<short int> muonShowerTwoLoose;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -43,6 +43,13 @@ namespace L1Analysis {
     kAsymHtHF
   };
 
+  enum MuonShowerType {
+    kInvalid,
+    kOneNominal,
+    kOneTight,
+    kTwoLoose
+  };
+
   struct L1AnalysisL1UpgradeDataFormat {
     L1AnalysisL1UpgradeDataFormat() { Reset(); };
     ~L1AnalysisL1UpgradeDataFormat(){};
@@ -127,9 +134,7 @@ namespace L1Analysis {
 
       nMuonShowers = 0;
       muonShowerBx.clear();
-      muonShowerOneNominal.clear();
-      muonShowerOneTight.clear();
-      muonShowerTwoLoose.clear();
+      muonShowerType.clear();
 
       nSums = 0;
       sumType.clear();
@@ -219,9 +224,7 @@ namespace L1Analysis {
 
     unsigned short int nMuonShowers;
     std::vector<short int> muonShowerBx;
-    std::vector<short int> muonShowerOneNominal;
-    std::vector<short int> muonShowerOneTight;
-    std::vector<short int> muonShowerTwoLoose;
+    std::vector<short int> muonShowerType;
 
     unsigned short int nSums;
     std::vector<short int> sumType;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -43,13 +43,6 @@ namespace L1Analysis {
     kAsymHtHF
   };
 
-  enum MuonShowerType {
-    kInvalid = 0,
-    kOneNominal,
-    kOneTight,
-    kTwoLoose
-  };
-
   struct L1AnalysisL1UpgradeDataFormat {
     L1AnalysisL1UpgradeDataFormat() { Reset(); };
     ~L1AnalysisL1UpgradeDataFormat(){};
@@ -134,7 +127,9 @@ namespace L1Analysis {
 
       nMuonShowers = 0;
       muonShowerBx.clear();
-      muonShowerType.clear();
+      muonShowerOneNominal.clear();
+      muonShowerOneTight.clear();
+      muonShowerTwoLoose.clear();
 
       nSums = 0;
       sumType.clear();
@@ -224,7 +219,9 @@ namespace L1Analysis {
 
     unsigned short int nMuonShowers;
     std::vector<short int> muonShowerBx;
-    std::vector<short int> muonShowerType;
+    std::vector<short int> muonShowerOneNominal;
+    std::vector<short int> muonShowerOneTight;
+    std::vector<short int> muonShowerTwoLoose;
 
     unsigned short int nSums;
     std::vector<short int> sumType;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -44,7 +44,7 @@ namespace L1Analysis {
   };
 
   enum MuonShowerType {
-    kInvalid,
+    kInvalid = 0,
     kOneNominal,
     kOneTight,
     kTwoLoose

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShower.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShower.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 
-#include "L1AnalysisL1UpgradeTfMuonShowerDataFormat.h"
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h"
 namespace L1Analysis {
   class L1AnalysisL1UpgradeTfMuonShower {
   public:

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShower.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShower.h
@@ -1,0 +1,23 @@
+#ifndef __L1Analysis_L1AnalysisL1UpgradeTfMuonShower_H__
+#define __L1Analysis_L1AnalysisL1UpgradeTfMuonShower_H__
+
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+
+#include "L1AnalysisL1UpgradeTfMuonShowerDataFormat.h"
+namespace L1Analysis {
+  class L1AnalysisL1UpgradeTfMuonShower {
+  public:
+    enum { TEST = 0 };
+    L1AnalysisL1UpgradeTfMuonShower();
+    ~L1AnalysisL1UpgradeTfMuonShower();
+    void Reset() {
+      l1upgradetfmuonshower_.Reset();
+    }
+    void SetTfMuonShower(const l1t::RegionalMuonShowerBxCollection& muon, unsigned maxL1UpgradeTfMuonShower);
+    L1AnalysisL1UpgradeTfMuonShowerDataFormat* getData() { return &l1upgradetfmuonshower_; }
+
+  private:
+    L1AnalysisL1UpgradeTfMuonShowerDataFormat l1upgradetfmuonshower_;
+  };
+}  // namespace L1Analysis
+#endif

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
@@ -5,23 +5,28 @@
 #include <map>
 
 namespace L1Analysis {
+
   struct L1AnalysisL1UpgradeTfMuonShowerDataFormat {
+
+    enum TfMuonShowerType {
+      kInvalid,
+      kOneNominal,
+      kOneTight,
+      kTwoLoose
+    };
+
     L1AnalysisL1UpgradeTfMuonShowerDataFormat() { Reset(); };
     ~L1AnalysisL1UpgradeTfMuonShowerDataFormat(){};
 
     void Reset() {
       nTfMuonShowers = 0;
       tfMuonShowerBx.clear();
-      tfMuonShowerOneNominal.clear();
-      tfMuonShowerOneTight.clear();
-      tfMuonShowerTwoLoose.clear();
+      tfMuonShowerType.clear();
     }
 
     unsigned short int nTfMuonShowers;
     std::vector<short int> tfMuonShowerBx;
-    std::vector<short int> tfMuonShowerOneNominal;
-    std::vector<short int> tfMuonShowerOneTight;
-    std::vector<short int> tfMuonShowerTwoLoose;
+    std::vector<short int> tfMuonShowerType;
   };
 }  // namespace L1Analysis
 #endif

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
@@ -1,0 +1,25 @@
+#ifndef __L1Analysis_L1AnalysisL1UpgradeTfMuonShowerDataFormat_H__
+#define __L1Analysis_L1AnalysisL1UpgradeTfMuonShowerDataFormat_H__
+
+#include <vector>
+#include <map>
+
+namespace L1Analysis {
+  struct L1AnalysisL1UpgradeTfMuonShowerDataFormat {
+    L1AnalysisL1UpgradeTfMuonShowerDataFormat() { Reset(); };
+    ~L1AnalysisL1UpgradeTfMuonShowerDataFormat(){};
+
+    void Reset() {
+      nTfMuonShowers = 0;
+      tfMuonShowerOneNominal.clear();
+      tfMuonShowerOneTight.clear();
+      tfMuonShowerTwoLoose.clear();
+    }
+
+    unsigned short int nTfMuonShowers;
+    std::vector<short int> tfMuonShowerOneNominal;
+    std::vector<short int> tfMuonShowerOneTight;
+    std::vector<short int> tfMuonShowerTwoLoose;
+  };
+}  // namespace L1Analysis
+#endif

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
@@ -9,7 +9,7 @@ namespace L1Analysis {
   struct L1AnalysisL1UpgradeTfMuonShowerDataFormat {
 
     enum TfMuonShowerType {
-      kInvalid,
+      kInvalid = 0,
       kOneNominal,
       kOneTight,
       kTwoLoose

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
@@ -11,12 +11,14 @@ namespace L1Analysis {
 
     void Reset() {
       nTfMuonShowers = 0;
+      tfMuonShowerBx.clear();
       tfMuonShowerOneNominal.clear();
       tfMuonShowerOneTight.clear();
       tfMuonShowerTwoLoose.clear();
     }
 
     unsigned short int nTfMuonShowers;
+    std::vector<short int> tfMuonShowerBx;
     std::vector<short int> tfMuonShowerOneNominal;
     std::vector<short int> tfMuonShowerOneTight;
     std::vector<short int> tfMuonShowerTwoLoose;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
@@ -8,25 +8,26 @@ namespace L1Analysis {
 
   struct L1AnalysisL1UpgradeTfMuonShowerDataFormat {
 
-    enum TfMuonShowerType {
-      kInvalid = 0,
-      kOneNominal,
-      kOneTight,
-      kTwoLoose
-    };
-
     L1AnalysisL1UpgradeTfMuonShowerDataFormat() { Reset(); };
     ~L1AnalysisL1UpgradeTfMuonShowerDataFormat(){};
 
     void Reset() {
       nTfMuonShowers = 0;
       tfMuonShowerBx.clear();
-      tfMuonShowerType.clear();
+      tfMuonShowerOneNominal.clear();
+      tfMuonShowerOneTight.clear();
+      tfMuonShowerTwoLoose.clear();
+      tfMuonShowerEndcap.clear();
+      tfMuonShowerSector.clear();
     }
 
     unsigned short int nTfMuonShowers;
     std::vector<short int> tfMuonShowerBx;
-    std::vector<short int> tfMuonShowerType;
+    std::vector<short int> tfMuonShowerOneNominal;
+    std::vector<short int> tfMuonShowerOneTight;
+    std::vector<short int> tfMuonShowerTwoLoose;
+    std::vector<short int> tfMuonShowerEndcap;
+    std::vector<short int> tfMuonShowerSector;
   };
 }  // namespace L1Analysis
 #endif

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonShowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonShowerTreeProducer.cc
@@ -1,0 +1,96 @@
+// system include files
+#include <memory>
+
+// framework
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// data formats
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+
+// ROOT output stuff
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TTree.h"
+
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShower.h"
+
+//
+// class declaration
+//
+
+class L1UpgradeTfMuonShowerTreeProducer : public edm::EDAnalyzer {
+public:
+  explicit L1UpgradeTfMuonShowerTreeProducer(const edm::ParameterSet&);
+  ~L1UpgradeTfMuonShowerTreeProducer() override;
+
+private:
+  void beginJob(void) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+public:
+  L1Analysis::L1AnalysisL1UpgradeTfMuonShower l1UpgradeEmtf;
+  L1Analysis::L1AnalysisL1UpgradeTfMuonShowerDataFormat* l1UpgradeEmtfData;
+
+private:
+  unsigned maxL1UpgradeTfMuonShower_;
+
+  // output file
+  edm::Service<TFileService> fs_;
+
+  // tree
+  TTree* tree_;
+
+  // EDM input tags
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> emtfMuonShowerToken_;
+};
+
+L1UpgradeTfMuonShowerTreeProducer::L1UpgradeTfMuonShowerTreeProducer(const edm::ParameterSet& iConfig) {
+  emtfMuonShowerToken_ =
+      consumes<l1t::RegionalMuonShowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("emtfMuonShowerToken"));
+
+  maxL1UpgradeTfMuonShower_ = iConfig.getParameter<unsigned int>("maxL1UpgradeTfMuonShower");
+
+  l1UpgradeEmtfData = l1UpgradeEmtf.getData();
+
+  // set up output
+  tree_ = fs_->make<TTree>("L1UpgradeTfMuonShowerTree", "L1UpgradeTfMuonShowerTree");
+  tree_->Branch("L1UpgradeEmtfMuonShower", "L1Analysis::L1AnalysisL1UpgradeTfMuonShowerDataFormat", &l1UpgradeEmtfData, 32000, 3);
+}
+
+L1UpgradeTfMuonShowerTreeProducer::~L1UpgradeTfMuonShowerTreeProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to for each event  ------------
+void L1UpgradeTfMuonShowerTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  l1UpgradeEmtf.Reset();
+
+  edm::Handle<l1t::RegionalMuonShowerBxCollection> emtfMuonShower;
+
+  iEvent.getByToken(emtfMuonShowerToken_, emtfMuonShower);
+
+  if (emtfMuonShower.isValid()) {
+    l1UpgradeEmtf.SetTfMuonShower(*emtfMuonShower, maxL1UpgradeTfMuonShower_);
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade EMTF muons not found. Branch will not be filled" << std::endl;
+  }
+
+  tree_->Fill();
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void L1UpgradeTfMuonShowerTreeProducer::beginJob(void) {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void L1UpgradeTfMuonShowerTreeProducer::endJob() {}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1UpgradeTfMuonShowerTreeProducer);

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTreeProducer.cc
@@ -8,7 +8,7 @@
 Description: Produce L1 Extra tree
 
 Implementation:
-     
+
 */
 //
 // Original Author:
@@ -33,6 +33,7 @@ Implementation:
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
 
 // ROOT output stuff
@@ -75,6 +76,7 @@ private:
   edm::EDGetTokenT<l1t::JetBxCollection> jetToken_;
   edm::EDGetTokenT<l1t::EtSumBxCollection> sumToken_;
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken_;
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> muonShowerToken_;
 };
 
 L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig) {
@@ -83,6 +85,7 @@ L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig) {
   jetToken_ = consumes<l1t::JetBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetToken"));
   sumToken_ = consumes<l1t::EtSumBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("sumToken"));
   muonToken_ = consumes<l1t::MuonBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonToken"));
+  muonShowerToken_ = consumes<l1t::MuonShowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonShowerToken"));
 
   const auto& taus = iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("tauTokens");
   for (const auto& tau : taus) {
@@ -116,11 +119,13 @@ void L1UpgradeTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSe
   edm::Handle<l1t::JetBxCollection> jet;
   edm::Handle<l1t::EtSumBxCollection> sums;
   edm::Handle<l1t::MuonBxCollection> muon;
+  edm::Handle<l1t::MuonShowerBxCollection> muonShower;
 
   iEvent.getByToken(egToken_, eg);
   iEvent.getByToken(jetToken_, jet);
   iEvent.getByToken(sumToken_, sums);
   iEvent.getByToken(muonToken_, muon);
+  iEvent.getByToken(muonShowerToken_, muonShower);
 
   if (eg.isValid()) {
     l1Upgrade->SetEm(eg, maxL1Upgrade_);
@@ -143,6 +148,12 @@ void L1UpgradeTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSe
     l1Upgrade->SetMuon(muon, maxL1Upgrade_);
   } else {
     edm::LogWarning("MissingProduct") << "L1Upgrade Muons not found. Branch will not be filled" << std::endl;
+  }
+
+  if (muonShower.isValid()) {
+    l1Upgrade->SetMuonShower(muonShower, maxL1Upgrade_);
+  } else {
+    edm::LogWarning("MissingProduct") << "L1Upgrade Muon Showers not found. Branch will not be filled" << std::endl;
   }
 
   for (auto& tautoken : tauTokens_) {

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
@@ -3,6 +3,7 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *
+from L1Trigger.L1TNtuples.l1UpgradeTfMuonShowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
 from L1Trigger.L1TNtuples.l1EventTree_cfi import *
 from L1Trigger.L1TNtuples.l1uGTTree_cfi import *

--- a/L1Trigger/L1TNtuples/python/L1NtupleRAW_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleRAW_cff.py
@@ -4,26 +4,28 @@ from L1Trigger.L1TNtuples.l1EventTree_cfi import *
 from L1Trigger.L1TNtuples.l1ExtraTree_cfi import *
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *
+from L1Trigger.L1TNtuples.l1UpgradeTfMuonShowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
 from L1Trigger.L1TNtuples.l1uGTTree_cfi import *
 from L1Trigger.L1TNtuples.l1HOTree_cfi import *
 
 # we don't have omtfDigis yet, use unpacked input payloads of GMT
-l1UpgradeTfMuonTree.omtfMuonToken = cms.untracked.InputTag("gmtStage2Digis","OMTF") 
+l1UpgradeTfMuonTree.omtfMuonToken = cms.untracked.InputTag("gmtStage2Digis","OMTF")
 # we don't have emtfDigis yet, use unpacked input payloads of GMT
-l1UpgradeTfMuonTree.emtfMuonToken = cms.untracked.InputTag("gmtStage2Digis","EMTF") 
+l1UpgradeTfMuonTree.emtfMuonToken = cms.untracked.InputTag("gmtStage2Digis","EMTF")
 
 L1NtupleRAW = cms.Sequence(
   l1EventTree
   #+l1ExtraTree
   +l1CaloTowerTree
   +l1UpgradeTfMuonTree
+  +l1UpgradeTfMuonShowerTree
   +l1UpgradeTree
   +l1uGTTree
   +l1HOTree
 )
 
-#  do not have l1t::CaloTowerBxCollection in Stage1 
+#  do not have l1t::CaloTowerBxCollection in Stage1
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 _stage1_L1NTupleRAW = L1NtupleRAW.copyAndExclude([l1CaloTowerTree,l1UpgradeTfMuonTree])
 stage1L1Trigger.toReplaceWith(L1NtupleRAW,_stage1_L1NTupleRAW)

--- a/L1Trigger/L1TNtuples/python/l1UpgradeTfMuonShowerTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1UpgradeTfMuonShowerTree_cfi.py
@@ -7,6 +7,6 @@ l1UpgradeTfMuonShowerTree = cms.EDAnalyzer(
 )
 
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
-stage1L1Trigger.toModify( l1UpgradeTfMuonTree,
+stage1L1Trigger.toModify( l1UpgradeTfMuonShowerTree,
     emtfMuonShowerToken = "none",
 )

--- a/L1Trigger/L1TNtuples/python/l1UpgradeTfMuonShowerTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1UpgradeTfMuonShowerTree_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+l1UpgradeTfMuonShowerTree = cms.EDAnalyzer(
+    "L1UpgradeTfMuonTreeProducer",
+    emtfMuonShowerToken = cms.untracked.InputTag("simEmtfShowers","EMTF"),
+    maxL1UpgradeTfMuonShower = cms.uint32(12),
+)
+
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+stage1L1Trigger.toModify( l1UpgradeTfMuonTree,
+    emtfMuonShowerToken = "none",
+)

--- a/L1Trigger/L1TNtuples/python/l1UpgradeTfMuonShowerTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1UpgradeTfMuonShowerTree_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 l1UpgradeTfMuonShowerTree = cms.EDAnalyzer(
-    "L1UpgradeTfMuonTreeProducer",
+    "L1UpgradeTfMuonShowerTreeProducer",
     emtfMuonShowerToken = cms.untracked.InputTag("simEmtfShowers","EMTF"),
     maxL1UpgradeTfMuonShower = cms.uint32(12),
 )

--- a/L1Trigger/L1TNtuples/python/l1UpgradeTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1UpgradeTree_cfi.py
@@ -6,6 +6,7 @@ l1UpgradeTree = cms.EDAnalyzer(
     tauTokens = cms.untracked.VInputTag(cms.InputTag("caloStage2Digis","Tau")),
     jetToken = cms.untracked.InputTag("caloStage2Digis","Jet"),
     muonToken = cms.untracked.InputTag("gmtStage2Digis","Muon"),
+    muonShowerToken = cms.untracked.InputTag("simGmtShowerDigis"),
     muonLegacyToken = cms.untracked.InputTag("muonLegacyInStage2FormatDigis","legacyMuon"),
     sumToken = cms.untracked.InputTag("caloStage2Digis","EtSum"),
     maxL1Upgrade = cms.uint32(60)
@@ -17,6 +18,6 @@ stage1L1Trigger.toModify( l1UpgradeTree,
     tauTokens = cms.untracked.VInputTag("caloStage1FinalDigis:rlxTaus"),
     jetToken = "caloStage1FinalDigis",
     muonToken = "muonLegacyInStage2FormatDigis",
+                          muonShowerToken = "",
     sumToken = "caloStage1FinalDigis",
 )
-

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -127,6 +127,7 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const edm::Handle<l1t::MuonS
          it != muonShower->end(ibx) && l1upgrade_.nMuonShowers < maxL1Upgrade;
          it++) {
       if (it->isValid()) {
+        l1upgrade_.muonShowerBx.push_back(ibx);
         l1upgrade_.muonShowerOneNominal.push_back(it->isOneNominalInTime());
         l1upgrade_.muonShowerOneTight.push_back(it->isOneTightInTime());
         l1upgrade_.muonShowerTwoLoose.push_back(it->isTwoLooseInTime());

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -121,6 +121,21 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuon(const edm::Handle<l1t::MuonBxColle
   }
 }
 
+void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const edm::Handle<l1t::MuonShowerBxCollection> muonShower, unsigned maxL1Upgrade) {
+  for (int ibx = muonShower->getFirstBX(); ibx <= muonShower->getLastBX(); ++ibx) {
+    for (l1t::MuonShowerBxCollection::const_iterator it = muonShower->begin(ibx);
+         it != muonShower->end(ibx) && l1upgrade_.nMuonShowers < maxL1Upgrade;
+         it++) {
+      if (it->isValid()) {
+        l1upgrade_.muonShowerOneNominal.push_back(it->isOneNominalInTime());
+        l1upgrade_.muonShowerOneTight.push_back(it->isOneTightInTime());
+        l1upgrade_.muonShowerTwoLoose.push_back(it->isTwoLooseInTime());
+        l1upgrade_.nMuonShowers++;
+      }
+    }
+  }
+}
+
 void L1Analysis::L1AnalysisL1Upgrade::SetSum(const edm::Handle<l1t::EtSumBxCollection> sums, unsigned maxL1Upgrade) {
   for (int ibx = sums->getFirstBX(); ibx <= sums->getLastBX(); ++ibx) {
     for (l1t::EtSumBxCollection::const_iterator it = sums->begin(ibx);

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -128,9 +128,16 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const edm::Handle<l1t::MuonS
          it++) {
       if (it->isValid()) {
         l1upgrade_.muonShowerBx.push_back(ibx);
-        l1upgrade_.muonShowerOneNominal.push_back(it->isOneNominalInTime());
-        l1upgrade_.muonShowerOneTight.push_back(it->isOneTightInTime());
-        l1upgrade_.muonShowerTwoLoose.push_back(it->isTwoLooseInTime());
+        int type;
+        if (it->isOneNominalInTime())
+          type = kOneNominal;
+        else if (it->isOneTightInTime())
+          type = kOneTight;
+        else if (it->isTwoLooseInTime())
+          type = kTwoLoose;
+        else
+          type = kInvalid;
+        l1upgrade_.muonShowerType.push_back(type);
         l1upgrade_.nMuonShowers++;
       }
     }

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -128,16 +128,9 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const edm::Handle<l1t::MuonS
          it++) {
       if (it->isValid()) {
         l1upgrade_.muonShowerBx.push_back(ibx);
-        int type;
-        if (it->isOneNominalInTime())
-          type = kOneNominal;
-        else if (it->isOneTightInTime())
-          type = kOneTight;
-        else if (it->isTwoLooseInTime())
-          type = kTwoLoose;
-        else
-          type = kInvalid;
-        l1upgrade_.muonShowerType.push_back(type);
+        l1upgrade_.muonShowerOneNominal.push_back(it->isOneNominalInTime());
+        l1upgrade_.muonShowerOneTight.push_back(it->isOneTightInTime());
+        l1upgrade_.muonShowerTwoLoose.push_back(it->isTwoLooseInTime());
         l1upgrade_.nMuonShowers++;
       }
     }

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
@@ -12,16 +12,11 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuonShower::SetTfMuonShower(const l1t::Reg
          ++it) {
       if (it->isValid()) {
         l1upgradetfmuonshower_.tfMuonShowerBx.push_back(ibx);
-        int type;
-        if (it->isOneNominalInTime())
-          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kOneNominal;
-        else if (it->isOneTightInTime())
-          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kOneTight;
-        else if (it->isTwoLooseInTime())
-          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kTwoLoose;
-        else
-          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kInvalid;
-        l1upgradetfmuonshower_.tfMuonShowerType.push_back(type);
+        l1upgradetfmuonshower_.tfMuonShowerEndcap.push_back(it->endcap());
+        l1upgradetfmuonshower_.tfMuonShowerSector.push_back(it->sector());
+        l1upgradetfmuonshower_.tfMuonShowerOneNominal.push_back(it->isOneNominalInTime());
+        l1upgradetfmuonshower_.tfMuonShowerOneTight.push_back(it->isOneTightInTime());
+        l1upgradetfmuonshower_.tfMuonShowerTwoLoose.push_back(it->isTwoLooseInTime());
         l1upgradetfmuonshower_.nTfMuonShowers++;
       }
     }

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
@@ -1,0 +1,21 @@
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShower.h"
+#include <cmath>
+L1Analysis::L1AnalysisL1UpgradeTfMuonShower::L1AnalysisL1UpgradeTfMuonShower() {}
+
+L1Analysis::L1AnalysisL1UpgradeTfMuonShower::~L1AnalysisL1UpgradeTfMuonShower() {}
+
+void L1Analysis::L1AnalysisL1UpgradeTfMuonShower::SetTfMuonShower(const l1t::RegionalMuonShowerBxCollection& muonShower,
+                                                      unsigned maxL1UpgradeTfMuonShower) {
+  for (int ibx = muonShower.getFirstBX(); ibx <= muonShower.getLastBX(); ++ibx) {
+    for (auto it = muonShower.begin(ibx);
+         it != muonShower.end(ibx) && l1upgradetfmuonshower_.nTfMuonShowers < maxL1UpgradeTfMuonShower;
+         ++it) {
+      if (it->isValid()) {
+        l1upgradetfmuonshower_.tfMuonShowerOneNominal.push_back(it->isOneNominalInTime());
+        l1upgradetfmuonshower_.tfMuonShowerOneTight.push_back(it->isOneTightInTime());
+        l1upgradetfmuonshower_.tfMuonShowerTwoLoose.push_back(it->isTwoLooseInTime());
+        l1upgradetfmuonshower_.nTfMuonShowers++;
+      }
+    }
+  }
+}

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
@@ -11,9 +11,17 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuonShower::SetTfMuonShower(const l1t::Reg
          it != muonShower.end(ibx) && l1upgradetfmuonshower_.nTfMuonShowers < maxL1UpgradeTfMuonShower;
          ++it) {
       if (it->isValid()) {
-        l1upgradetfmuonshower_.tfMuonShowerOneNominal.push_back(it->isOneNominalInTime());
-        l1upgradetfmuonshower_.tfMuonShowerOneTight.push_back(it->isOneTightInTime());
-        l1upgradetfmuonshower_.tfMuonShowerTwoLoose.push_back(it->isTwoLooseInTime());
+        l1upgradetfmuonshower_.tfMuonShowerBx.push_back(ibx);
+        int type;
+        if (it->isOneNominalInTime())
+          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kOneNominal;
+        else if (it->isOneTightInTime())
+          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kOneTight;
+        else if (it->isTwoLooseInTime())
+          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kTwoLoose;
+        else
+          type = L1AnalysisL1UpgradeTfMuonShowerDataFormat::kInvalid;
+        l1upgradetfmuonshower_.tfMuonShowerType.push_back(type);
         l1upgradetfmuonshower_.nTfMuonShowers++;
       }
     }

--- a/L1Trigger/L1TNtuples/src/classes.h
+++ b/L1Trigger/L1TNtuples/src/classes.h
@@ -20,6 +20,7 @@
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisL1MenuDataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonDataFormat.h"
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisL1CaloTowerDataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisL1CaloClusterDataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisBMTFInputsDataFormat.h"

--- a/L1Trigger/L1TNtuples/src/classes_def.xml
+++ b/L1Trigger/L1TNtuples/src/classes_def.xml
@@ -21,6 +21,7 @@
 <class name="L1Analysis::L1AnalysisL1MenuDataFormat"/>
 <class name="L1Analysis::L1AnalysisL1UpgradeDataFormat"/>
 <class name="L1Analysis::L1AnalysisL1UpgradeTfMuonDataFormat"/>
+<class name="L1Analysis::L1AnalysisL1UpgradeTfMuonShowerDataFormat"/>
 <class name="L1Analysis::L1AnalysisL1CaloTowerDataFormat"/>
 <class name="L1Analysis::L1AnalysisBMTFInputsDataFormat"/>
 <class name="L1Analysis::L1AnalysisL1HODataFormat"/>


### PR DESCRIPTION
#### PR description:

This PR is a first attempt to include the core code for the uGT emulator for hadronic shower triggers for Run-3. In previous PRs I introduced data formats for the CSC, EMTF and uGMT shower objects, and emulators for the CSC trigger, EMTF and uGMT. A new object MuonShower object is introduced in the L1TGlobal emulator and data format packages. This object is treated separately from the regular Muon object. The core code is currently switched off, i.e. the parameter that enables reading muon shower trigger bits from the L1T menu XML file is set to False. As such, there should be no differences in any workflow. The code is based on UTM lib 0.9.X (https://gitlab.cern.ch/cms-l1t-utm/utm), which was recently integrated into CMSSW_12_0_X (cms-sw/cmsdist#7337) and CMSSW_12_1_X (cms-sw/cmsdist#7281).

A few relevant presentations can be found here:

- https://indico.cern.ch/event/1032087/contributions/4334392/attachments/2239866/3798910/HadronicShowerTrigger_EXO_LL_L1DPG_6May2021.pdf
- https://indico.cern.ch/event/1032087/contributions/4334095/attachments/2241349/3800447/HLT_muon_shower_martin.pdf
- https://indico.cern.ch/event/1080450/contributions/4548741/attachments/2320995/3952292/MuonShower_Oct1_Martin.pdf

#### PR validation:

I tested the code on a private XML L1T menu, stripped from the regular trigger algorithms. 

Additional validation with scram b runtests and with WF 11634.0.
```
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Fri Oct  1 15:25:09 2021-date Fri Oct  1 14:50:10 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
