### PR TITLE
Update BoardDataReader and associated codecs

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -3,6 +3,7 @@
 #define L1Trigger_DemonstratorTools_codecs_tracks_h
 
 #include <array>
+#include <sstream>
 #include <vector>
 
 #include "ap_int.h"

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -57,7 +57,8 @@ private:
   // ----------constants, enums and typedefs ---------
   // NOTE: At least some of the info from these constants will eventually come from config files
   static constexpr size_t kFramesPerTMUXPeriod = 9;
-  static constexpr size_t kGapLength = 6;
+  static constexpr size_t kGapLengthInput = 6;
+  static constexpr size_t kGapLengthOutput = 44;
   static constexpr size_t kTrackTMUX = 18;
   static constexpr size_t kGTTBoardTMUX = 6;
   static constexpr size_t kMaxLinesPerFile = 1024;
@@ -85,12 +86,12 @@ private:
 
   const std::map<std::string, l1t::demo::ChannelSpec> kChannelSpecsInput = {
       /* interface name -> {link TMUX, inter-packet gap} */
-      {"tracks", {kTrackTMUX, kGapLength}}};
+      {"tracks", {kTrackTMUX, kGapLengthInput}}};
 
   const std::map<l1t::demo::LinkId, std::pair<l1t::demo::ChannelSpec, std::vector<size_t>>>
       kChannelSpecsOutputToCorrelator = {
           /* logical channel within time slice -> {{link TMUX, inter-packet gap}, vector of channel indices} */
-          {{"vertices", 0}, {{kGTTBoardTMUX, kGapLength}, {0}}}};
+          {{"vertices", 0}, {{kGTTBoardTMUX, kGapLengthOutput}, {0}}}};
 
   typedef TTTrack<Ref_Phase2TrackerDigi_> Track_t;
 

--- a/L1Trigger/DemonstratorTools/src/BoardDataReader.cc
+++ b/L1Trigger/DemonstratorTools/src/BoardDataReader.cc
@@ -70,6 +70,8 @@ namespace l1t::demo {
           }
 
           for (size_t j = framesBeforeFirstPacket; j < chanData.size(); j++) {
+            if ((j + (framesPerBX_ * spec.tmux)) >= chanData.size()) continue;
+
             bool expectValid(((j - framesBeforeFirstPacket) % eventLength) < packetLength);
 
             if (expectValid) {

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -30,4 +30,58 @@ namespace l1t::demo::codecs {
     return linkData;
   }
 
+  std::vector<TTTrack_TrackWord> decodeTracks(const std::vector<ap_uint<64>>& frames) {
+    std::vector<TTTrack_TrackWord> tracks;
+
+    if ( (frames.size() % 3) != 0 ) {
+       std::stringstream message;
+       message << "The number of track frames (" << frames.size() << ") is not evenly divisible by 3";
+       throw std::runtime_error(message.str());
+    }
+
+    for (size_t i = 0; i < frames.size(); i += 3) {
+      TTTrack_TrackWord::tkword_t combination1 = (ap_uint<32>(frames.at(i + 1)(31, 0)), frames.at(i)(63,0));
+      TTTrack_TrackWord::tkword_t combination2 = (frames.at(i + 2)(63,0), ap_uint<32>(frames.at(i + 1)(63,32)));
+      TTTrack_TrackWord track1, track2;
+      track1.setTrackWord(TTTrack_TrackWord::valid_t(combination1(TTTrack_TrackWord::kValidMSB, TTTrack_TrackWord::kValidLSB)),
+                          TTTrack_TrackWord::rinv_t(combination1(TTTrack_TrackWord::kRinvMSB, TTTrack_TrackWord::kRinvLSB)),
+                          TTTrack_TrackWord::phi_t(combination1(TTTrack_TrackWord::kPhiMSB, TTTrack_TrackWord::kPhiLSB)),
+                          TTTrack_TrackWord::tanl_t(combination1(TTTrack_TrackWord::kTanlMSB, TTTrack_TrackWord::kTanlLSB)),
+                          TTTrack_TrackWord::z0_t(combination1(TTTrack_TrackWord::kZ0MSB, TTTrack_TrackWord::kZ0LSB)),
+                          TTTrack_TrackWord::d0_t(combination1(TTTrack_TrackWord::kD0MSB, TTTrack_TrackWord::kD0LSB)),
+                          TTTrack_TrackWord::chi2rphi_t(combination1(TTTrack_TrackWord::kChi2RPhiMSB, TTTrack_TrackWord::kChi2RPhiLSB)),
+                          TTTrack_TrackWord::chi2rz_t(combination1(TTTrack_TrackWord::kChi2RZMSB, TTTrack_TrackWord::kChi2RZLSB)),
+                          TTTrack_TrackWord::bendChi2_t(combination1(TTTrack_TrackWord::kBendChi2MSB, TTTrack_TrackWord::kBendChi2LSB)),
+                          TTTrack_TrackWord::hit_t(combination1(TTTrack_TrackWord::kHitPatternMSB, TTTrack_TrackWord::kHitPatternLSB)),
+                          TTTrack_TrackWord::qualityMVA_t(combination1(TTTrack_TrackWord::kMVAQualityMSB, TTTrack_TrackWord::kMVAQualityLSB)),
+                          TTTrack_TrackWord::otherMVA_t(combination1(TTTrack_TrackWord::kMVAOtherMSB, TTTrack_TrackWord::kMVAOtherLSB)));
+      track2.setTrackWord(TTTrack_TrackWord::valid_t(combination2(TTTrack_TrackWord::kValidMSB, TTTrack_TrackWord::kValidLSB)),
+                          TTTrack_TrackWord::rinv_t(combination2(TTTrack_TrackWord::kRinvMSB, TTTrack_TrackWord::kRinvLSB)),
+                          TTTrack_TrackWord::phi_t(combination2(TTTrack_TrackWord::kPhiMSB, TTTrack_TrackWord::kPhiLSB)),
+                          TTTrack_TrackWord::tanl_t(combination2(TTTrack_TrackWord::kTanlMSB, TTTrack_TrackWord::kTanlLSB)),
+                          TTTrack_TrackWord::z0_t(combination2(TTTrack_TrackWord::kZ0MSB, TTTrack_TrackWord::kZ0LSB)),
+                          TTTrack_TrackWord::d0_t(combination2(TTTrack_TrackWord::kD0MSB, TTTrack_TrackWord::kD0LSB)),
+                          TTTrack_TrackWord::chi2rphi_t(combination2(TTTrack_TrackWord::kChi2RPhiMSB, TTTrack_TrackWord::kChi2RPhiLSB)),
+                          TTTrack_TrackWord::chi2rz_t(combination2(TTTrack_TrackWord::kChi2RZMSB, TTTrack_TrackWord::kChi2RZLSB)),
+                          TTTrack_TrackWord::bendChi2_t(combination2(TTTrack_TrackWord::kBendChi2MSB, TTTrack_TrackWord::kBendChi2LSB)),
+                          TTTrack_TrackWord::hit_t(combination2(TTTrack_TrackWord::kHitPatternMSB, TTTrack_TrackWord::kHitPatternLSB)),
+                          TTTrack_TrackWord::qualityMVA_t(combination2(TTTrack_TrackWord::kMVAQualityMSB, TTTrack_TrackWord::kMVAQualityLSB)),
+                          TTTrack_TrackWord::otherMVA_t(combination2(TTTrack_TrackWord::kMVAOtherMSB, TTTrack_TrackWord::kMVAOtherLSB)));
+      tracks.push_back(track1);
+      tracks.push_back(track2);
+    }
+
+    return tracks;
+  }
+
+  std::array<std::vector<TTTrack_TrackWord>, 18> decodeTracks(const std::array<std::vector<ap_uint<64>>, 18>& frames) {
+    std::array<std::vector<TTTrack_TrackWord>, 18> tracks;
+
+    for ( size_t i = 0; i < tracks.size(); i++) {
+       tracks.at(i) = decodeTracks(frames.at(i));
+    }
+
+    return tracks;
+  }
+
 }  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
@@ -11,13 +11,14 @@ namespace l1t::demo::codecs {
 
     for (const auto& vertex : vertices)
       vertexWords.push_back(encodeVertex(vertex));
-    // Pad vertex vectors -> full packet length (10 frames = 10 vertices)
-    vertexWords.resize(10, 0);
 
     std::array<std::vector<ap_uint<64>>, 1> linkData;
 
-    for (size_t i = 0; i < linkData.size(); i++)
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad vertex vectors -> full packet length (48 frames = 48 vertices)
+      vertexWords.resize(48, 0);
       linkData.at(i) = vertexWords;
+    }
 
     return linkData;
   }

--- a/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
@@ -15,8 +15,8 @@ namespace l1t::demo::codecs {
     std::array<std::vector<ap_uint<64>>, 1> linkData;
 
     for (size_t i = 0; i < linkData.size(); i++) {
-      // Pad vertex vectors -> full packet length (48 frames = 48 vertices)
-      vertexWords.resize(48, 0);
+      // Pad vertex vectors -> full packet length (48 frames, but only 10 vertices max)
+      vertexWords.resize(10, 0);
       linkData.at(i) = vertexWords;
     }
 

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -11,6 +11,16 @@ options.register ('format',
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "File format (APx, EMP or X20)")
+options.register('threads',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Number of threads to run")
+options.register('streams',
+                 0, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Number of streams to run")
 options.parseArguments()
 
 inputFiles = []
@@ -18,6 +28,8 @@ for filePath in options.inputFiles:
     if filePath.endswith(".root"):
         inputFiles.append(filePath)
     elif filePath.endswith("_cff.py"):
+        filePath = filePath.replace("/python/","/")
+        filePath = filePath.replace("/", ".")
         inputFilesImport = getattr(__import__(filePath.strip(".py"),fromlist=["readFiles"]),"readFiles")
         inputFiles.extend( inputFilesImport )
     else:
@@ -37,6 +49,10 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(inputFiles) )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(options.threads),
+    numberOfStreams = cms.untracked.uint32(options.streams if options.streams>0 else 0)
+)
 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
 process.load('L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi')


### PR DESCRIPTION
#### PR description:

This PR does a couple of things, but it's main importance come from making some modifications to the DemonstratorTools.
1. It adds a new check to the `BoardDataReader` to allow it to read files that aren't completely filled due to a constraint in the tmux/framesPerBx. Most files won't use 100% of the frames because you can't write a complete event. This check will allow those files to be read.
2. Add a `decodeTracks` function to the codecs.
3. Change the gap length for the vertices to be more in line with what will actually be used in the system.
4. Add some multithreading options to the python configuration, though I doubt these will be used very often.

#### PR validation:

I created a set of files to make sure they conformed to the expected output description. The track files shouldn't have changed, but the files with vertices will have fewer valid frames.

@tswilliams