### PR TITLE
Updates to MET Emulation & Simulation

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/Cordic.h
+++ b/L1Trigger/L1TTrackMatch/interface/Cordic.h
@@ -17,7 +17,7 @@ using namespace l1tmetemu;
 class Cordic {
 public:
   Cordic();
-  Cordic(int aPhiScale, int aMagnitudeBits, const int aSteps, bool debug, bool writeLUTs);
+  Cordic(int aPhiScale, int aMagnitudeBits, const int aSteps, bool debug);
 
   EtMiss toPolar(Et_t x, Et_t y) const;
 

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuTrackTransform.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuTrackTransform.h
@@ -57,23 +57,19 @@ public:
   // Function to count stubs in hitpattern
   nstub_t countNStub(TTTrack_TrackWord::hit_t Hitpattern);
 
-  // Function to take float phi to local integer phi
-  TTTrack_TrackWord::phi_t floatGlobalPhiToSectorPhi(float phi, unsigned int sector);
-
   std::vector<global_phi_t> generatePhiSliceLUT(unsigned int N);
 
   std::vector<global_phi_t> getPhiQuad() const { return phiQuadrants; }
   std::vector<global_phi_t> getPhiShift() const { return phiShift; }
 
   void setGTTinput(bool input) { GTTinput_ = input; }
-  void setVtxEmulator(bool vtx) { VtxEmulator_ = vtx; }
 
 private:
   std::vector<global_phi_t> phiQuadrants;
   std::vector<global_phi_t> phiShift;
 
   bool GTTinput_ = false;
-  bool VtxEmulator_ = false;
+
 };
 
 // Template to allow vertex word or vertex from vertex finder depending on simulation vs emulation
@@ -111,29 +107,24 @@ InternalEtWord L1TkEtMissEmuTrackTransform::transformTrack(track& track_ref, ver
     Outword.eta = digitizeSignedValue<TTTrack_TrackWord::tanl_t>(
         abs(track_ref.momentum().eta()), kInternalEtaWidth, l1tmetemu::kStepEta);
   }
-
-  unsigned int temp_pv = digitizeSignedValue<TTTrack_TrackWord::z0_t>(
-      PV.z0(),
-      TTTrack_TrackWord::TrackBitWidths::kZ0Size,
-      TTTrack_TrackWord::stepZ0);  // Convert vertex to integer representation
+    
   Outword.chi2rphidof = track_ref.getChi2RPhiWord();
   Outword.chi2rzdof = track_ref.getChi2RZWord();
   Outword.bendChi2 = track_ref.getBendChi2Word();
   Outword.nstubs = countNStub(track_ref.getHitPatternWord());
   Outword.Hitpattern = track_ref.getHitPatternWord();
-
-  unsigned int Sector = track_ref.phiSector();
-  Outword.Sector = Sector;
+  Outword.Sector =  track_ref.phiSector();
   Outword.EtaSector = (track_ref.getTanlWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize - 1)));
-  // convert to local phi
   Outword.phi = track_ref.phi();
-  TTTrack_TrackWord::phi_t localPhi = floatGlobalPhiToSectorPhi(track_ref.phi(), Sector);
-  // Convert to global phi
-  Outword.globalPhi = localToGlobalPhi(localPhi, phiShift[Sector]);
+  Outword.globalPhi = localToGlobalPhi(track_ref.getPhiWord(), phiShift[track_ref.phiSector()]);
 
+  unsigned int temp_pv = digitizeSignedValue<TTTrack_TrackWord::z0_t>(
+      PV.z0(),
+      TTTrack_TrackWord::TrackBitWidths::kZ0Size,
+      TTTrack_TrackWord::stepZ0);  // Convert vertex to integer representation
   //Rescale to internal representations
   Outword.z0 = transformSignedValue(track_ref.getZ0Word(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, kInternalVTXWidth);
-  Outword.pV = transformSignedValue(temp_pv, TTTrack_TrackWord::TrackBitWidths::kZ0Size, kInternalVTXWidth);
+  Outword.pV = transformSignedValue( temp_pv, TTTrack_TrackWord::TrackBitWidths::kZ0Size, kInternalVTXWidth);
 
   return Outword;
 }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -73,17 +73,16 @@ private:
   l1tmetemu::pt_t minPt_;
   l1tmetemu::nstub_t nStubsmin_;
 
-  int chi2Max_;
+  vector<double> z0Thresholds_;
+  vector<double> etaRegions_;
 
   l1tmetemu::z_t deltaZ0_ = 0;
 
   int cordicSteps_;
   int debug_;
   bool cordicDebug_ = false;
-  bool writeLUTs_ = false;
 
   bool GTTinput_ = false;
-  bool VtxEmulator_ = false;
 
   L1TkEtMissEmuTrackTransform TrackTransform;
 
@@ -105,13 +104,10 @@ L1TrackerEtMissEmulatorProducer::L1TrackerEtMissEmulatorProducer(const edm::Para
   // Get Emulator config parameters
   cordicSteps_ = (int)iConfig.getParameter<int>("nCordicSteps");
   debug_ = (int)iConfig.getParameter<int>("debug");
-  writeLUTs_ = (bool)iConfig.getParameter<bool>("writeLUTs");
 
   GTTinput_ = (bool)iConfig.getParameter<bool>("useGTTinput");
-  VtxEmulator_ = (bool)iConfig.getParameter<bool>("useVertexEmulator");
 
   TrackTransform.setGTTinput(GTTinput_);
-  TrackTransform.setVtxEmulator(VtxEmulator_);
 
   // Name of output ED Product
   L1MetCollectionName_ = (std::string)iConfig.getParameter<std::string>("L1MetCollectionName");
@@ -130,12 +126,14 @@ L1TrackerEtMissEmulatorProducer::L1TrackerEtMissEmulatorProducer(const edm::Para
       l1tmetemu::getBin((double)iConfig.getParameter<double>("chi2rzdofMax"), TTTrack_TrackWord::chi2RZBins);
   bendChi2Max_ =
       l1tmetemu::getBin((double)iConfig.getParameter<double>("bendChi2Max"), TTTrack_TrackWord::bendChi2Bins);
-  chi2Max_ = (int)iConfig.getParameter<int>("chi2Max");
 
   minPt_ = l1tmetemu::digitizeSignedValue<l1tmetemu::pt_t>(
       (double)iConfig.getParameter<double>("minPt"), l1tmetemu::kInternalPtWidth, l1tmetemu::kStepPt);
 
   nStubsmin_ = (l1tmetemu::nstub_t)iConfig.getParameter<int>("nStubsmin");
+
+  z0Thresholds_ = iConfig.getParameter<std::vector<double>>("z0Thresholds");
+  etaRegions_ = iConfig.getParameter<std::vector<double>>("etaRegions");
 
   if (debug_ == 5) {
     cordicDebug_ = true;
@@ -147,26 +145,8 @@ L1TrackerEtMissEmulatorProducer::L1TrackerEtMissEmulatorProducer(const edm::Para
 
   // Compute LUTs
   cosLUT_ = l1tmetemu::generateCosLUT(cosLUTbins);
-  EtaRegionsLUT_ = l1tmetemu::generateEtaRegionLUT();
-  DeltaZLUT_ = l1tmetemu::generateDeltaZLUT();
-
-  // Write Out LUTs
-  if (writeLUTs_) {
-    l1tmetemu::writeLUTtoFile<l1tmetemu::global_phi_t>(cosLUT_, "cos", ",");
-    l1tmetemu::writeLUTtoFile<l1tmetemu::global_phi_t>(phiQuadrants_, "phiquadrants", ",");
-    l1tmetemu::writeLUTtoFile<l1tmetemu::global_phi_t>(phiShifts_, "phishift", ",");
-    l1tmetemu::writeLUTtoFile<l1tmetemu::eta_t>(EtaRegionsLUT_, "etaregions", ",");
-    l1tmetemu::writeLUTtoFile<l1tmetemu::z_t>(DeltaZLUT_, "dzbins", ",");
-    std::vector<unsigned int> cutlut = {(unsigned int)minPt_,
-                                        (unsigned int)minZ0_,
-                                        (unsigned int)maxZ0_,
-                                        (unsigned int)maxEta_,
-                                        (unsigned int)chi2rphiMax_,
-                                        (unsigned int)chi2rzMax_,
-                                        (unsigned int)bendChi2Max_,
-                                        (unsigned int)nStubsmin_};
-    l1tmetemu::writeLUTtoFile<unsigned int>(cutlut, "cuts", ",");
-  }
+  EtaRegionsLUT_ = l1tmetemu::generateEtaRegionLUT(etaRegions_);
+  DeltaZLUT_ = l1tmetemu::generateDeltaZLUT(z0Thresholds_);
 
   produces<std::vector<EtSum>>(L1MetCollectionName_);
 }
@@ -186,7 +166,7 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
   // Initialize cordic class
   Cordic cordicSqrt(
-      l1tmetemu::kMETPhiBins, l1tmetemu::kMETSize, cordicSteps_, cordicDebug_, writeLUTs_);
+      l1tmetemu::kMETPhiBins, l1tmetemu::kMETSize, cordicSteps_, cordicDebug_ );
 
   if (!L1VertexHandle.isValid()) {
     LogError("L1TrackerEtMissEmulatorProducer") << "\nWarning: VertexCollection not found in the event. Exit\n";
@@ -242,9 +222,6 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
     if (EtTrack.chi2rzdof >= chi2rzMax_)
       continue;
 
-    if (EtTrack.chi2rzdof + EtTrack.chi2rphidof >= chi2Max_)
-      continue;
-
     if (EtTrack.bendChi2 >= bendChi2Max_)
       continue;
 
@@ -269,7 +246,6 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
     if (z_diff <= deltaZ0_) {
       num_assoc_tracks++;
-
       if (debug_ == 7) {
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
             << "Track to Vertex ID: " << num_tracks << "\n"

--- a/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissEmulatorProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissEmulatorProducer_cfi.py
@@ -12,19 +12,18 @@ L1TrackerEmuEtMiss = cms.EDProducer('L1TrackerEtMissEmulatorProducer',
 
     maxZ0 = cms.double ( 15. ) ,    # in cm
     maxEta = cms.double ( 2.4 ) ,   # max eta allowed for chosen tracks
-    minPt = cms.double( 2. ),
-    chi2rzdofMax = cms.double( 10. ), # max chi2rz/dof allowed for chosen tracks
-    chi2rphidofMax = cms.double( 10. ), # max chi2rphi/dof allowed for chosen tracks
-    chi2Max        = cms.int32( 120 ), # max combined bin for chi2rphi+chi2rz (this != to a cut on floating point chi2)
-    bendChi2Max = cms.double( 2. ),# max bendchi2 allowed for chosen tracks
+    minPt = cms.double( 2.02 ),
+    chi2rzdofMax = cms.double( 5. ), # max chi2rz/dof allowed for chosen tracks
+    chi2rphidofMax = cms.double( 20. ), # max chi2rphi/dof allowed for chosen tracks
+    bendChi2Max = cms.double( 2.25 ),# max bendchi2 allowed for chosen tracks
     nStubsmin = cms.int32( 4 ),     # min number of stubs for the tracks
-  
+
+    z0Thresholds = cms.vdouble( 0.37, 0.5, 0.6, 0.75, 1.0, 1.6 ), # Threshold for track to vertex association.
+    etaRegions = cms.vdouble( 0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4 ), # Eta bins for choosing deltaZ threshold.
+    
     nCordicSteps = cms.int32( 8 ), #Number of steps for cordic sqrt and phi computation
     debug        = cms.int32( 0 ),  #0 - No Debug, 1 - LUT debug, 2 - Phi Debug, 3 - Z debug, 4 - Et Debug, 5 - Cordic Debug, 6 - Output, 7 - Every Selected Track
-    writeLUTs    = cms.bool( False ), #Write LUTs to file for use in FW
-
     useGTTinput  = cms.bool( True ),
-    useVertexEmulator = cms.bool( True )
 
 )
 

--- a/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissProducer_cfi.py
@@ -7,9 +7,9 @@ L1TrackerEtMiss = cms.EDProducer('L1TrackerEtMissProducer',
     L1MetCollectionName = cms.string("L1TrackerEtMiss"),
     maxZ0 = cms.double ( 15. ) ,    # in cm
     maxEta = cms.double ( 2.4 ) ,   # max eta allowed for chosen tracks
-    chi2dofMax = cms.double( 100. ), # max chi2/dof allowed for chosen tracks
-    splitChi2dofMax = cms.double( 10. ), # max chi2/dof allowed for chosen tracks
-    bendChi2Max = cms.double( 2. ),# max bendchi2 allowed for chosen tracks
+    chi2rzdofMax = cms.double( 5. ), # max chi2rz/dof allowed for chosen tracks
+    chi2rphidofMax = cms.double( 20. ), # max chi2rphi/dof allowed for chosen tracks
+    bendChi2Max = cms.double( 2.25 ),# max bendchi2 allowed for chosen tracks
     minPt = cms.double( 2. ),       # in GeV
     deltaZ = cms.double( 3. ),      # in cm
     nStubsmin = cms.int32( 4 ),     # min number of stubs for the tracks
@@ -21,8 +21,11 @@ L1TrackerEtMiss = cms.EDProducer('L1TrackerEtMissProducer',
                                     # when = 1 : saturation. Tracks with PT above maxPt are set to PT=maxPt.
                                     # When maxPt < 0, no special treatment is done for high PT tracks.
     displaced = cms.bool(False),     # Use promt/displaced tracks
+
+    z0Thresholds = cms.vdouble( 0.37, 0.5, 0.6, 0.75, 1.0, 1.6 ), # Threshold for track to vertex association.
+    etaRegions = cms.vdouble( 0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4 ), # Eta bins for choosing deltaZ threshold.
     
-                                 debug     = cms.bool(False)
+    debug     = cms.bool(False)
 )
 
 L1TrackerEtMissExtended = cms.EDProducer('L1TrackerEtMissProducer',

--- a/L1Trigger/L1TTrackMatch/src/Cordic.cc
+++ b/L1Trigger/L1TTrackMatch/src/Cordic.cc
@@ -5,7 +5,7 @@
 
 using namespace l1tmetemu;
 
-Cordic::Cordic(int aPhiScale, int aMagnitudeBits, const int aSteps, bool debug, bool writeLUTs)
+Cordic::Cordic(int aPhiScale, int aMagnitudeBits, const int aSteps, bool debug )
     : mPhiScale(aPhiScale),
       mMagnitudeScale(1 << aMagnitudeBits),
       mMagnitudeBits(aMagnitudeBits),
@@ -35,11 +35,6 @@ Cordic::Cordic(int aPhiScale, int aMagnitudeBits, const int aSteps, bool debug, 
     if (debug) {
       edm::LogVerbatim("L1TkEtMissEmulator") << magNormalisationLUT[j] << " | ";
     }
-  }
-
-  if (writeLUTs) {
-    writeLUTtoFile<METphi_t>(atanLUT, "cordicatan", ",");
-    writeLUTtoFile<Et_t>(magNormalisationLUT, "cordicrenorm", ",");
   }
 }
 

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -13,20 +13,22 @@ namespace l1tmetemu {
   }
 
   // Generate Eta LUT for track to vertex association
-  std::vector<eta_t> generateEtaRegionLUT() {
+  std::vector<eta_t> generateEtaRegionLUT( vector<double> EtaRegions ) {
     std::vector<eta_t> LUT;
-    for (unsigned int q = 0; q < kNEtaRegion + 1; q++) {
+    for (unsigned int q = 0; q < EtaRegions.size(); q++) {
       LUT.push_back(digitizeSignedValue<eta_t>(
-          kEtaRegionBins[q], l1tmetemu::kInternalEtaWidth, l1tmetemu::kStepEta));
+          EtaRegions[q], l1tmetemu::kInternalEtaWidth, l1tmetemu::kStepEta));
+          std::cout << LUT[q] << "|" <<  EtaRegions[q] << std::endl;
     }
     return LUT;
   }
 
-  std::vector<z_t> generateDeltaZLUT() {
+  std::vector<z_t> generateDeltaZLUT( vector<double> DeltaZBins ) {
     std::vector<z_t> LUT;
-    for (unsigned int q = 0; q < kNEtaRegion; q++) {
+    for (unsigned int q = 0; q < DeltaZBins.size(); q++) {
       LUT.push_back(
-          digitizeSignedValue<z_t>(kDeltaZBins[q], l1tmetemu::kInternalVTXWidth, TTTrack_TrackWord::stepZ0));
+          digitizeSignedValue<z_t>(DeltaZBins[q], l1tmetemu::kInternalVTXWidth, l1tmetemu::kStepZ0));
+          std::cout << LUT[q] << "|" <<  DeltaZBins[q] << std::endl;
     }
     return LUT;
   }

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuTrackTransform.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuTrackTransform.cc
@@ -39,29 +39,6 @@ nstub_t L1TkEtMissEmuTrackTransform::countNStub(TTTrack_TrackWord::hit_t Hitpatt
   return Nstub;
 }
 
-TTTrack_TrackWord::phi_t L1TkEtMissEmuTrackTransform::floatGlobalPhiToSectorPhi(float phi, unsigned int sector) {
-  float tempPhi = 0.0;
-  if (sector < 4) {
-    tempPhi = phi - (sector * (2 * M_PI) / 9);
-  } else if (sector > 5) {
-    tempPhi = phi + ((9 - sector) * (2 * M_PI) / 9);
-  } else if (sector == 4) {
-    if (phi > 0) {
-      tempPhi = phi - (sector * (2 * M_PI) / 9);
-    } else {
-      tempPhi = phi + ((9 - sector) * (2 * M_PI) / 9);
-    }
-  } else if (sector == 5) {
-    if (phi < 0) {
-      tempPhi = phi + ((9 - sector) * (2 * M_PI) / 9);
-    } else {
-      tempPhi = phi - (sector * (2 * M_PI) / 9);
-    }
-  }
-  return digitizeSignedValue<TTTrack_TrackWord::phi_t>(
-      tempPhi, TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0);
-}
-
 std::vector<global_phi_t> L1TkEtMissEmuTrackTransform::generatePhiSliceLUT(unsigned int N) {
   float sliceCentre = 0.0;
   std::vector<global_phi_t> phiLUT;


### PR DESCRIPTION
#### PR description:
This PR makes changes to the Track MET emulation to remove the writing of LUTs to file, this does not change the functioning of the code.
Other changes include updates to the Track MET simulation and emulation configs to use up to date chi2rphi/dof, chi2rz/dof and bendchi2/dof cuts and removed the single chi2. 

Also changed are the default set of z0 thresholds used, these have also been moved from hardcoded values in the producers to configurable bins in the python config.

Chi2 cuts and z0 bins specified here: https://indico.cern.ch/event/1061213/contributions/4459930/attachments/2286366/3886061/trkMETCuts_Jul23.pdf

Finally, various small updates have been made to reflect the changes to the TTTrack_word and GTT input producer

#### PR validation:

Checked floating point and emulated versions against each other to high agreement
