### PR TITLE
Bug fix for the L1GTTInputProducer emulator

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
@@ -76,7 +76,7 @@ private:
   static constexpr double kPTErrThresh = 5;                    // error threshold in percent
   static constexpr double kSynchrotron = (1.0 / (0.3 * 3.8));  // 1/(0.3*B) for 1/R to 1/pT conversion
   static constexpr unsigned int kPtLutSize = (1 << ConversionBitWidths::kPTOutputSize);
-  static constexpr unsigned int kEtaLutSize = (1 << ConversionBitWidths::kEtaOutputSize);
+  static constexpr unsigned int kEtaLutSize = (1 << ConversionBitWidths::kEtaOutputSize - 1);
 
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1Track;
   typedef std::vector<L1Track> TTTrackCollection;

--- a/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
@@ -202,7 +202,7 @@ double L1GTTInputProducer::unpackSignedValue(unsigned int bits, unsigned int nBi
   // Convert from twos compliment to C++ signed integer (normal digitized value)
   int digitizedValue = bits;
   if (bits & (1 << (nBits - 1))) {  // check if the 'bits' is negative
-     digitizedValue -= (1 << nBits);
+    digitizedValue -= (1 << nBits);
   }
 
   // Convert to floating point value
@@ -272,7 +272,8 @@ bool L1GTTInputProducer::getEtaBits(
       indexTanLambda >>
       (kEtaInputSize -
        kEtaOutputSize);  // Don't subtract 1 because we now want to take into account the sign bit of the output
-  indexTanLambda = (indexTanLambda < (1 << (kEtaOutputSize - 1))) ? indexTanLambda : in_eta_t((1 << (kEtaOutputSize - 1)) - 1);
+  indexTanLambda =
+      (indexTanLambda < (1 << (kEtaOutputSize - 1))) ? indexTanLambda : in_eta_t((1 << (kEtaOutputSize - 1)) - 1);
   etaBits = eta_lut_[indexTanLambda];
 
   // Reinacting the sign

--- a/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
@@ -272,6 +272,7 @@ bool L1GTTInputProducer::getEtaBits(
       indexTanLambda >>
       (kEtaInputSize -
        kEtaOutputSize);  // Don't subtract 1 because we now want to take into account the sign bit of the output
+  indexTanLambda = (indexTanLambda < (1 << (kEtaOutputSize - 1))) ? indexTanLambda : in_eta_t((1 << (kEtaOutputSize - 1)) - 1);
   etaBits = eta_lut_[indexTanLambda];
 
   // Reinacting the sign


### PR DESCRIPTION
#### PR description:

This PR implement a fix for when the TanL value corresponds to the minimum value of eta. Right now, when the track eta is as negative as possible (tanL=-8), there code is unable to find the index with which to look up the magnitude of eta from the LUT. As the representable values go from [-2^n,(2^n)-1], there is a missing index needed to represent the most negative value if only positive indices are allowed (i.e. there is one more value on the negative side than on the positive side). The fix is to set the index for that value equal to the most negative allowable index.

#### PR validation:
In [LogForCodeWithBug.txt](https://github.com/cms-l1t-offline/cmssw/files/7683118/LogForCodeWithBug.txt) you can see a log showing what happens when tanL=-8 (0b1000000000000000). This is from the code prior to the fix and shows that there clearly needed to be a change.

After making the change, I have run the new code over 100 ttbar events without an issue, though none of the tracks had tanL=-8. @emacdonald16, please make sure this change fixed the problem you saw.

I have also run:
```bash
scram build code-checks
scram build code-format
```