### PR TITLE
New producer to simulate and emulate the TrackSelection module

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -223,6 +223,7 @@ public:
   double getChi2RZ() const { return chi2RZBins[getChi2RZBits()]; }
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
   unsigned int getHitPattern() const { return getHitPatternBits(); }
+  unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
   unsigned int getMVAQuality() const { return getMVAQualityBits(); }
   unsigned int getMVAOther() const { return getMVAOtherBits(); }
 
@@ -277,6 +278,16 @@ protected:
 
 private:
   // ----------private member functions --------------
+  unsigned int countSetBits(unsigned int n) const {
+    // Adapted from: https://www.geeksforgeeks.org/count-set-bits-in-an-integer/
+    unsigned int count = 0;
+    while (n) {
+      n &= (n - 1);
+      count++;
+    }
+    return count;
+  }
+
   unsigned int digitizeSignedValue(double value, unsigned int nBits, double lsb) const {
     // Digitize the incoming value
     int digitizedValue = std::floor(value / lsb);

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -20,6 +20,8 @@
   <class name="vector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
+  <class name="vector<edm::Ref<vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > >" />
+  <class name="edm::Wrapper<vector<edm::Ref<vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > > >" />
   <class name="TTTrack_TrackWord" ClassVersion="4">
    <version ClassVersion="4" checksum="133238749"/>
    <version ClassVersion="3" checksum="4186150061"/>

--- a/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 
 <library   file="*.cc" name="L1TrackTriggerPlugins">
 <use   name="CommonTools/BaseParticlePropagator"/>
+<use   name="CommonTools/Utils"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1TrackTrigger"/>

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -1,0 +1,421 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1TrackSelectionProducer
+//
+/**\class L1TrackSelectionProducer L1TrackSelectionProducer.cc L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+
+ Description: Selects a set of L1Tracks based on a set of predefined criteria.
+
+ Implementation:
+     Inputs:
+         std::vector<TTTrack> - Each floating point TTTrack inside this collection inherits from
+                                a bit-accurate TTTrack_TrackWord, used for emulation purposes.
+     Outputs:
+         std::vector<TTTrack> - A collection of TTTracks selected from cuts on the TTTrack properties
+         std::vector<TTTrack> - A collection of TTTracks selected from cuts on the TTTrack_TrackWord properties
+*/
+//
+// Original Author:  Alexx Perloff
+//         Created:  Thu, 16 Dec 2021 19:02:50 GMT
+//
+//
+
+// system include files
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Xilinx HLS includes
+#include <ap_fixed.h>
+#include <ap_int.h>
+
+// user include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1Trigger/interface/Vertex.h"
+#include "DataFormats/L1Trigger/interface/VertexWord.h"
+#include "CommonTools/Utils/interface/AndSelector.h"
+#include "CommonTools/Utils/interface/EtaRangeSelector.h"
+#include "CommonTools/Utils/interface/MinSelector.h"
+#include "CommonTools/Utils/interface/MinFunctionSelector.h"
+#include "CommonTools/Utils/interface/MinNumberSelector.h"
+#include "CommonTools/Utils/interface/PtMinSelector.h"
+#include "CommonTools/Utils/interface/Selection.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+//
+// class declaration
+//
+
+class L1TrackSelectionProducer : public edm::global::EDProducer<> {
+public:
+  explicit L1TrackSelectionProducer(const edm::ParameterSet&);
+  ~L1TrackSelectionProducer();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+	// ----------constants, enums and typedefs ---------
+  // Relevant constants for the converted track word
+  enum TrackBitWidths {
+      kPtSize = TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1, // Width of pt
+      kPtMagSize = 9,                                             // Width of pt magnitude (unsigned)
+      kEtaSize = TTTrack_TrackWord::TrackBitWidths::kTanlSize,    // Width of eta
+      kEtaMagSize = 3,                                            // Width of eta magnitude (signed)
+    };
+
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1Track;
+  typedef std::vector<L1Track> TTTrackCollection;
+  typedef edm::View<L1Track> TTTrackCollectionView;
+
+  // ----------member functions ----------------------
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------selectors -----------------------------
+  // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
+  struct TTTrackPtMinSelector {
+    TTTrackPtMinSelector( double ptMin ) : ptMin_( ptMin ) { }
+    TTTrackPtMinSelector( const edm::ParameterSet & cfg ) :
+      ptMin_( cfg.template getParameter<double>( "ptMin" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.momentum().perp() >= ptMin_; }
+  private:
+    double ptMin_;
+  };
+  struct TTTrackWordPtMinSelector {
+    TTTrackWordPtMinSelector( double ptMin ) : ptMin_( ptMin ) { }
+    TTTrackWordPtMinSelector( const edm::ParameterSet & cfg ) :
+      ptMin_( cfg.template getParameter<double>( "ptMin" ) ) { }
+    bool operator()( const L1Track & t ) const {
+      ap_uint<TrackBitWidths::kPtSize> ptEmulationBits = t.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
+      ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize> ptEmulation;
+      ptEmulation.V = ptEmulationBits.range();
+      //edm::LogInfo("L1TrackSelectionProducer") << "produce::Emulation track properties::ap_uint(bits) = " << ptEmulationBits.to_string(2)
+      //                                         << " ap_ufixed(bits) = " << ptEmulation.to_string(2) << " ap_ufixed(float) = " << ptEmulation.to_double();
+      return ptEmulation.to_double() >= ptMin_;
+    }
+  private:
+    double ptMin_;
+  };
+  struct TTTrackAbsEtaMaxSelector {
+    TTTrackAbsEtaMaxSelector( double absEtaMax ) : absEtaMax_( absEtaMax ) { }
+    TTTrackAbsEtaMaxSelector( const edm::ParameterSet & cfg ) :
+      absEtaMax_( cfg.template getParameter<double>( "absEtaMax" ) ) { }
+    bool operator()( const L1Track & t ) const { return std::abs(t.eta()) <= absEtaMax_; }
+  private:
+    double absEtaMax_;
+  };
+  struct TTTrackWordAbsEtaMaxSelector {
+    TTTrackWordAbsEtaMaxSelector( double absEtaMax ) : absEtaMax_( absEtaMax ) { }
+    TTTrackWordAbsEtaMaxSelector( const edm::ParameterSet & cfg ) :
+      absEtaMax_( cfg.template getParameter<double>( "absEtaMax" ) ) { }
+    bool operator()( const L1Track & t ) const {
+      TTTrack_TrackWord::tanl_t etaEmulationBits = t.getTanlWord();
+      ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize> etaEmulation;
+      etaEmulation.V = etaEmulationBits.range();
+      return std::abs(etaEmulation.to_double()) <= absEtaMax_;
+    }
+  private:
+    double absEtaMax_;
+  };
+  struct TTTrackAbsZ0MaxSelector {
+    TTTrackAbsZ0MaxSelector( double absZ0Max ) : absZ0Max_( absZ0Max ) { }
+    TTTrackAbsZ0MaxSelector( const edm::ParameterSet & cfg ) :
+      absZ0Max_( cfg.template getParameter<double>( "absZ0Max" ) ) { }
+    bool operator()( const L1Track & t ) const { return std::abs(t.z0()) <= absZ0Max_; }
+  private:
+    double absZ0Max_;
+  };
+  struct TTTrackWordAbsZ0MaxSelector {
+    TTTrackWordAbsZ0MaxSelector( double absZ0Max ) : absZ0Max_( absZ0Max ) { }
+    TTTrackWordAbsZ0MaxSelector( const edm::ParameterSet & cfg ) :
+      absZ0Max_( cfg.template getParameter<double>( "absZ0Max" ) ) { }
+    bool operator()( const L1Track & t ) const { return std::abs(t.getZ0()) <= absZ0Max_; }
+  private:
+    double absZ0Max_;
+  };
+  struct TTTrackNStubsMinSelector {
+    TTTrackNStubsMinSelector( double nStubsMin ) : nStubsMin_( nStubsMin ) { }
+    TTTrackNStubsMinSelector( const edm::ParameterSet & cfg ) :
+      nStubsMin_( cfg.template getParameter<double>( "nStubsMin" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.getStubRefs().size() >= nStubsMin_; }
+  private:
+    double nStubsMin_;
+  };
+  struct TTTrackWordNStubsMinSelector {
+    TTTrackWordNStubsMinSelector( double nStubsMin ) : nStubsMin_( nStubsMin ) { }
+    TTTrackWordNStubsMinSelector( const edm::ParameterSet & cfg ) :
+      nStubsMin_( cfg.template getParameter<double>( "nStubsMin" ) ) { }
+    bool operator()( const L1Track & t ) const { return countSetBits(t.getHitPatternBits()) >= nStubsMin_; }
+    // Adapted from: https://www.geeksforgeeks.org/count-set-bits-in-an-integer/
+    unsigned int countSetBits(unsigned int n) const {
+      unsigned int count = 0;
+      while (n) {
+          n &= (n - 1);
+          count++;
+      }
+      return count;
+    }
+  private:
+    double nStubsMin_;
+  };
+  struct TTTrackBendChi2MaxSelector {
+    TTTrackBendChi2MaxSelector( double bendChi2Max ) : bendChi2Max_( bendChi2Max ) { }
+    TTTrackBendChi2MaxSelector( const edm::ParameterSet & cfg ) :
+      bendChi2Max_( cfg.template getParameter<double>( "reducedBendChi2Max" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.stubPtConsistency() <= bendChi2Max_; }
+  private:
+    double bendChi2Max_;
+  };
+  struct TTTrackWordBendChi2MaxSelector {
+    TTTrackWordBendChi2MaxSelector( double bendChi2Max ) : bendChi2Max_( bendChi2Max ) { }
+    TTTrackWordBendChi2MaxSelector( const edm::ParameterSet & cfg ) :
+      bendChi2Max_( cfg.template getParameter<double>( "reducedBendChi2Max" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.getBendChi2() <= bendChi2Max_; }
+  private:
+    double bendChi2Max_;
+  };
+  struct TTTrackChi2RZMaxSelector {
+    TTTrackChi2RZMaxSelector( double reducedChi2RZMax ) : reducedChi2RZMax_( reducedChi2RZMax ) { }
+    TTTrackChi2RZMaxSelector( const edm::ParameterSet & cfg ) :
+      reducedChi2RZMax_( cfg.template getParameter<double>( "reducedChi2RZMax" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.chi2ZRed() <= reducedChi2RZMax_; }
+  private:
+    double reducedChi2RZMax_;
+  };
+  struct TTTrackWordChi2RZMaxSelector {
+    TTTrackWordChi2RZMaxSelector( double reducedChi2RZMax ) : reducedChi2RZMax_( reducedChi2RZMax ) { }
+    TTTrackWordChi2RZMaxSelector( const edm::ParameterSet & cfg ) :
+      reducedChi2RZMax_( cfg.template getParameter<double>( "reducedChi2RZMax" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.getChi2RZ() <= reducedChi2RZMax_; }
+  private:
+    double reducedChi2RZMax_;
+  };
+  struct TTTrackChi2RPhiMaxSelector {
+    TTTrackChi2RPhiMaxSelector( double reducedChi2RPhiMax ) : reducedChi2RPhiMax_( reducedChi2RPhiMax ) { }
+    TTTrackChi2RPhiMaxSelector( const edm::ParameterSet & cfg ) :
+      reducedChi2RPhiMax_( cfg.template getParameter<double>( "reducedChi2RPhiMax" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.chi2XYRed() <= reducedChi2RPhiMax_; }
+  private:
+    double reducedChi2RPhiMax_;
+  };
+  struct TTTrackWordChi2RPhiMaxSelector {
+    TTTrackWordChi2RPhiMaxSelector( double reducedChi2RPhiMax ) : reducedChi2RPhiMax_( reducedChi2RPhiMax ) { }
+    TTTrackWordChi2RPhiMaxSelector( const edm::ParameterSet & cfg ) :
+      reducedChi2RPhiMax_( cfg.template getParameter<double>( "reducedChi2RPhiMax" ) ) { }
+    bool operator()( const L1Track & t ) const { return t.getChi2RPhi() <= reducedChi2RPhiMax_; }
+  private:
+    double reducedChi2RPhiMax_;
+  };
+  struct TTTrackDeltaZMaxSelector {
+    TTTrackDeltaZMaxSelector( const std::vector<double> & deltaZMaxEtaBounds, const std::vector<double> & deltaZMax ) :
+      deltaZMaxEtaBounds_( deltaZMaxEtaBounds ), deltaZMax_( deltaZMax ) { }
+    TTTrackDeltaZMaxSelector( const edm::ParameterSet & cfg ) :
+      deltaZMaxEtaBounds_( cfg.template getParameter<double>( "deltaZMaxEtaBounds" ) ),
+      deltaZMax_( cfg.template getParameter<double>( "deltaZMax" ) ) { }
+    bool operator()( const L1Track & t, const l1t::Vertex & v ) const {
+      size_t etaIndex = std::lower_bound (deltaZMaxEtaBounds_.begin(), deltaZMaxEtaBounds_.end(), std::abs(t.eta())) - deltaZMaxEtaBounds_.begin();
+      if (etaIndex > deltaZMax_.size() - 1) etaIndex = deltaZMax_.size() - 1;
+      return std::abs(v.z0() - t.z0()) <= deltaZMax_[etaIndex];
+    }
+  private:
+    std::vector<double> deltaZMaxEtaBounds_;
+    std::vector<double> deltaZMax_;
+  };
+  struct TTTrackWordDeltaZMaxSelector {
+    TTTrackWordDeltaZMaxSelector( const std::vector<double> & deltaZMaxEtaBounds, const std::vector<double> & deltaZMax ) :
+      deltaZMaxEtaBounds_( deltaZMaxEtaBounds ), deltaZMax_( deltaZMax ) { }
+    TTTrackWordDeltaZMaxSelector( const edm::ParameterSet & cfg ) :
+      deltaZMaxEtaBounds_( cfg.template getParameter<double>( "deltaZMaxEtaBounds" ) ),
+      deltaZMax_( cfg.template getParameter<double>( "deltaZMax" ) ) { }
+    bool operator()( const L1Track & t, const l1t::VertexWord & v ) const {
+      size_t etaIndex = std::lower_bound (deltaZMaxEtaBounds_.begin(), deltaZMaxEtaBounds_.end(), std::abs(t.eta())) - deltaZMaxEtaBounds_.begin();
+      if (etaIndex > deltaZMax_.size() - 1) etaIndex = deltaZMax_.size() - 1;
+      return std::abs(v.z0() - t.getZ0()) <= deltaZMax_[etaIndex];
+    }
+  private:
+    std::vector<double> deltaZMaxEtaBounds_;
+    std::vector<double> deltaZMax_;
+  };
+
+  typedef AndSelector<
+          TTTrackPtMinSelector,
+          TTTrackAbsEtaMaxSelector,
+          TTTrackAbsZ0MaxSelector,
+          TTTrackNStubsMinSelector
+          > TTTrackPtMinEtaMaxZ0MaxNStubsMinSelector;
+  typedef AndSelector<
+          TTTrackWordPtMinSelector,
+          TTTrackWordAbsEtaMaxSelector,
+          TTTrackWordAbsZ0MaxSelector,
+          TTTrackWordNStubsMinSelector
+          > TTTrackWordPtMinEtaMaxZ0MaxNStubsMinSelector;
+  typedef AndSelector<
+          TTTrackBendChi2MaxSelector,
+          TTTrackChi2RZMaxSelector,
+          TTTrackChi2RPhiMaxSelector
+          > TTTrackBendChi2Chi2RZChi2RPhiMaxSelector;
+  typedef AndSelector<
+          TTTrackWordBendChi2MaxSelector,
+          TTTrackWordChi2RZMaxSelector,
+          TTTrackWordChi2RPhiMaxSelector
+          > TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector;
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TTTrackCollectionView> l1TracksToken_;
+  const edm::EDGetTokenT<l1t::VertexCollection> l1VerticesToken_;
+  const edm::EDGetTokenT<l1t::VertexWordCollection> l1VerticesEmulationToken_;
+  const std::string outputCollectionName_;
+  const edm::ParameterSet cutSet_;
+  const double ptMin_, absEtaMax_, absZ0Max_, bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
+  const int nStubsMin_;
+  const std::vector<double> deltaZMaxEtaBounds_, deltaZMax_;
+  int debug_;
+};
+
+//
+// constructors and destructor
+//
+L1TrackSelectionProducer::L1TrackSelectionProducer(const edm::ParameterSet& iConfig)
+    : l1TracksToken_(consumes<TTTrackCollectionView>(iConfig.getParameter<edm::InputTag>("l1TracksInputTag"))),
+      l1VerticesToken_(consumes<l1t::VertexCollection>(iConfig.getParameter<edm::InputTag>("l1VerticesInputTag"))),
+      l1VerticesEmulationToken_(consumes<l1t::VertexWordCollection>(iConfig.getParameter<edm::InputTag>("l1VerticesEmulationInputTag"))),
+      outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+
+      ptMin_(cutSet_.getParameter<double>("ptMin")),
+      absEtaMax_(cutSet_.getParameter<double>("absEtaMax")),
+      absZ0Max_(cutSet_.getParameter<double>("absZ0Max")),
+      bendChi2Max_(cutSet_.getParameter<double>("reducedBendChi2Max")),
+      reducedChi2RZMax_(cutSet_.getParameter<double>("reducedChi2RZMax")),
+      reducedChi2RPhiMax_(cutSet_.getParameter<double>("reducedChi2RPhiMax")),
+      nStubsMin_(cutSet_.getParameter<int>("nStubsMin")),
+      deltaZMaxEtaBounds_(cutSet_.getParameter<std::vector<double>>("deltaZMaxEtaBounds")),
+      deltaZMax_(cutSet_.getParameter<std::vector<double>>("deltaZMax")),
+
+      debug_(iConfig.getParameter<int>("debug")) {
+
+  // Confirm the the configuration makes sense
+  if (deltaZMax_.size() != deltaZMaxEtaBounds_.size() - 1) {
+    throw cms::Exception("The number of deltaZ cuts does not match the number of eta bins!");
+  }
+
+  // Define EDM output to be written to file (if required)
+  produces<TTTrackCollection>(outputCollectionName_);
+  produces<TTTrackCollection>(outputCollectionName_+"Emulation");
+}
+
+L1TrackSelectionProducer::~L1TrackSelectionProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void L1TrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto vTTTrackOutput = std::make_unique<TTTrackCollection>();
+  auto vTTTrackEmulationOutput = std::make_unique<TTTrackCollection>();
+  
+  edm::Handle<TTTrackCollectionView> l1TracksHandle;
+  iEvent.getByToken(l1TracksToken_, l1TracksHandle);
+
+  edm::Handle<l1t::VertexCollection> l1VerticesHandle;
+  iEvent.getByToken(l1VerticesToken_, l1VerticesHandle);
+  l1t::Vertex leadingVertex = l1VerticesHandle->at(0);
+
+  edm::Handle<l1t::VertexWordCollection> l1VerticesEmulationHandle;
+  iEvent.getByToken(l1VerticesEmulationToken_, l1VerticesEmulationHandle);
+  l1t::VertexWord leadingEmulationVertex = l1VerticesEmulationHandle->at(0);
+  
+  unsigned int nOutputApproximate = l1TracksHandle->size();
+  vTTTrackOutput->reserve(nOutputApproximate);
+  vTTTrackEmulationOutput->reserve(nOutputApproximate);
+
+  TTTrackPtMinEtaMaxZ0MaxNStubsMinSelector kinSel(ptMin_, absEtaMax_, absZ0Max_, nStubsMin_);
+  TTTrackWordPtMinEtaMaxZ0MaxNStubsMinSelector kinSelEmu(ptMin_, absEtaMax_, absZ0Max_, nStubsMin_);
+  TTTrackBendChi2Chi2RZChi2RPhiMaxSelector chi2Sel(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_);
+  TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector chi2SelEmu(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_);
+  TTTrackDeltaZMaxSelector deltaZSel(deltaZMaxEtaBounds_, deltaZMax_);
+  TTTrackWordDeltaZMaxSelector deltaZSelEmu(deltaZMaxEtaBounds_, deltaZMax_);
+
+  for (const auto& track : *l1TracksHandle) {
+
+    // Select tracks based on the floating point TTTrack
+    if (kinSel(track) && chi2Sel(track) && deltaZSel(track, leadingVertex)) {
+      vTTTrackOutput->push_back(track);
+    }
+
+    // Select tracks based on the bitwise accurate TTTrack_TrackWord
+    if (kinSelEmu(track) && chi2SelEmu(track) && deltaZSelEmu(track, leadingEmulationVertex)) {
+      vTTTrackEmulationOutput->push_back(track);
+    }
+
+  }
+
+  if (debug_ >= 2) {
+    edm::LogInfo log("L1TrackSelectionProducer");
+    log << "The original track collection (pt, eta, phi, nstub, bendchi2, chi2rz, chi2rphi, deltaz) values are ... \n";
+    for (const auto& track : *l1TracksHandle) {
+      log << "\t(" << track.momentum().perp() << ", " << track.eta() << ", " << track.phi() << ", " << track.getStubRefs().size() << ", "
+          << track.stubPtConsistency() << ", " << track.chi2ZRed() << ", " << track.chi2XYRed() << ", " << std::abs(leadingVertex.z0() - track.z0()) << ")\n";
+    }
+    log << "---\n" << "Total number of tracks = " << l1TracksHandle->size() << "\n\n"
+        << "The selected track collection (pt, eta, phi, nstub, bendchi2, chi2rz, chi2rphi, deltaz) values are ... \n";
+    for (const auto& track : *vTTTrackOutput) {
+      log << "\t(" << track.momentum().perp() << ", " << track.eta() << ", " << track.phi() << ", " << track.getStubRefs().size() << ", "
+          << track.stubPtConsistency() << ", " << track.chi2ZRed() << ", " << track.chi2XYRed() << ", " << std::abs(leadingVertex.z0() - track.z0()) << ")\n";
+    }
+    log << "---\n" << "Total number of tracks selected = " << vTTTrackOutput->size() << "\n\n"
+        << "\nThe emulation selected track collection (pt, eta, phi, nstub, bendchi2, chi2rz, chi2rphi, deltaz) values are ... \n";
+    for (const auto& track : *vTTTrackEmulationOutput) {
+      log << "\t(" << track.momentum().perp() << ", " << track.eta() << ", " << track.phi() << ", " << track.getStubRefs().size() << ", "
+          << track.stubPtConsistency() << ", " << track.chi2ZRed() << ", " << track.chi2XYRed() << ", " << std::abs(leadingVertex.z0() - track.z0()) << ")\n";
+    }
+    log << "---\n" << "Total number of tracks selected = " << vTTTrackEmulationOutput->size() << "\n";
+  }
+
+  // Put the outputs into the event
+  iEvent.put(std::move(vTTTrackOutput), outputCollectionName_);
+  iEvent.put(std::move(vTTTrackEmulationOutput), outputCollectionName_+"Emulation");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TrackSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //L1TrackSelectionProducer
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1TracksInputTag", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
+  desc.add<edm::InputTag>("l1VerticesInputTag", edm::InputTag("L1VertexFinder", "l1vertices"));
+  desc.add<edm::InputTag>("l1VerticesEmulationInputTag", edm::InputTag("L1VertexFinderEmulator", "l1verticesEmulation"));
+  desc.add<std::string>("outputCollectionName", "Level1TTTracksSelected");
+  {
+    edm::ParameterSetDescription descCutSet;
+    descCutSet.add<double>("ptMin", 2.0)->setComment("pt must be greater than this value, [GeV]");
+    descCutSet.add<double>("absEtaMax", 2.4)->setComment("absolute value of eta must be less than this value");
+    descCutSet.add<double>("absZ0Max", 15.0)->setComment("z0 must be less than this value, [cm]");
+    descCutSet.add<int>("nStubsMin", 4)->setComment("number of stubs must be greater than or equal to this value");
+
+    descCutSet.add<double>("reducedBendChi2Max", 2.25)->setComment("bend chi2 must be less than this value");
+    descCutSet.add<double>("reducedChi2RZMax", 5.0)->setComment("chi2rz/dof must be less than this value");
+    descCutSet.add<double>("reducedChi2RPhiMax", 20.0)->setComment("chi2rphi/dof must be less than this value");
+
+    descCutSet.add<std::vector<double>>("deltaZMaxEtaBounds", {0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4})->setComment("these values define the bin boundaries in |eta|");
+    descCutSet.add<std::vector<double>>("deltaZMax", {0.37, 0.50, 0.60, 0.75, 1.00, 1.60})->setComment("delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]");
+    desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);
+  }
+  desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TrackSelectionProducer);

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -11,6 +11,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     absEtaMax = cms.double(2.4), # absolute value of eta must be less than this value
                     absZ0Max = cms.double(15.0), # z0 must be less than this value, [cm]
                     nStubsMin = cms.int32(4), # number of stubs must be greater than or equal to this value
+                    nPSStubsMin = cms.int32(0), # the number of stubs in the PS Modules must be greater than or equal to this value
 
                     reducedBendChi2Max = cms.double(2.25), # bend chi2 must be less than this value
                     reducedChi2RZMax = cms.double(5.0), # chi2rz/dof must be less than this value
@@ -21,6 +22,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # these values define the bin boundaries in |eta|
                     deltaZMax = cms.vdouble(0.37, 0.50, 0.60, 0.75, 1.00, 1.60), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     ),
+  useDisplacedTracksDeltaZOverride = cms.bool(-1.0), # Use promt/displaced tracks
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
   debug = cms.int32(0) # Verbosity levels: 0, 1, 2, 3, 4
@@ -29,5 +31,8 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
 L1TrackSelectionProducerExtended = L1TrackSelectionProducer.clone(
   l1TracksInputTag = cms.InputTag("L1GTTInputProducerExtended","Level1TTTracksExtendedConverted"),
   outputCollectionName = cms.string("Level1TTTracksExtendedSelected"),
+  useDisplacedTracksDeltaZOverride = cms.bool(3.0), # Use promt/displaced tracks
+  deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # Eta bins for choosing deltaZ threshold.
+  deltaZMax = cms.vdouble(3.0, 3.0, 3.0, 3.0, 3.0, 3.0), # Threshold for track to vertex association.
 )
 

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -31,7 +31,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
 L1TrackSelectionProducerExtended = L1TrackSelectionProducer.clone(
   l1TracksInputTag = cms.InputTag("L1GTTInputProducerExtended","Level1TTTracksExtendedConverted"),
   outputCollectionName = cms.string("Level1TTTracksExtendedSelected"),
-  useDisplacedTracksDeltaZOverride = cms.bool(3.0), # Use promt/displaced tracks
+  useDisplacedTracksDeltaZOverride = cms.double(3.0), # Use promt/displaced tracks
   deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # Eta bins for choosing deltaZ threshold.
   deltaZMax = cms.vdouble(3.0, 3.0, 3.0, 3.0, 3.0, 3.0), # Threshold for track to vertex association.
 )

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
+  l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),
+  l1VerticesInputTag = cms.InputTag("L1VertexFinder", "l1vertices"),
+  l1VerticesEmulationInputTag = cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
+  outputCollectionName = cms.string("Level1TTTracksSelected"),
+  cutSet = cms.PSet(
+                    ptMin = cms.double(2.0), # pt must be greater than this value, [GeV]
+                    absEtaMax = cms.double(2.4), # absolute value of eta must be less than this value
+                    absZ0Max = cms.double(15.0), # z0 must be less than this value, [cm]
+                    nStubsMin = cms.int32(4), # number of stubs must be greater than or equal to this value
+
+                    reducedBendChi2Max = cms.double(2.25), # bend chi2 must be less than this value
+                    reducedChi2RZMax = cms.double(5.0), # chi2rz/dof must be less than this value
+                    reducedChi2RPhiMax = cms.double(20.0), # chi2rphi/dof must be less than this value
+
+                    #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
+                    #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
+                    deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # these values define the bin boundaries in |eta|
+                    deltaZMax = cms.vdouble(0.37, 0.50, 0.60, 0.75, 1.00, 1.60), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
+                    ),
+  debug = cms.int32(2) # Verbosity levels: 0, 1, 2, 3
+)
+
+L1TrackSelectionProducerExtended = cms.EDProducer('L1TrackSelectionProducer',
+  l1TracksInputTag = cms.InputTag("L1GTTInputProducerExtended","Level1TTTracksExtendedConverted"),
+  l1VerticesInputTag = cms.InputTag("L1VertexFinder", "l1vertices"),
+  l1VerticesEmulationInputTag = cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
+  outputCollectionName = cms.string("Level1TTTracksExtendedSelected"),
+  cutSet = L1TrackSelectionProducer.cutSet,
+  debug = cms.int32(2) # Verbosity levels: 0, 1, 2, 3
+)

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -4,6 +4,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
   l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),
   l1VerticesInputTag = cms.InputTag("L1VertexFinder", "l1vertices"),
   l1VerticesEmulationInputTag = cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
+  # If no vertex collection is provided, then the DeltaZ cuts will not be run
   outputCollectionName = cms.string("Level1TTTracksSelected"),
   cutSet = cms.PSet(
                     ptMin = cms.double(2.0), # pt must be greater than this value, [GeV]
@@ -20,14 +21,13 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # these values define the bin boundaries in |eta|
                     deltaZMax = cms.vdouble(0.37, 0.50, 0.60, 0.75, 1.00, 1.60), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     ),
+  processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
+  processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
   debug = cms.int32(2) # Verbosity levels: 0, 1, 2, 3
 )
 
-L1TrackSelectionProducerExtended = cms.EDProducer('L1TrackSelectionProducer',
+L1TrackSelectionProducerExtended = L1TrackSelectionProducer.clone(
   l1TracksInputTag = cms.InputTag("L1GTTInputProducerExtended","Level1TTTracksExtendedConverted"),
-  l1VerticesInputTag = cms.InputTag("L1VertexFinder", "l1vertices"),
-  l1VerticesEmulationInputTag = cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
   outputCollectionName = cms.string("Level1TTTracksExtendedSelected"),
-  cutSet = L1TrackSelectionProducer.cutSet,
-  debug = cms.int32(2) # Verbosity levels: 0, 1, 2, 3
 )
+

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -22,7 +22,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # these values define the bin boundaries in |eta|
                     deltaZMax = cms.vdouble(0.37, 0.50, 0.60, 0.75, 1.00, 1.60), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     ),
-  useDisplacedTracksDeltaZOverride = cms.bool(-1.0), # Use promt/displaced tracks
+  useDisplacedTracksDeltaZOverride = cms.double(-1.0), # override the deltaZ cut value for displaced tracks
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
   debug = cms.int32(0) # Verbosity levels: 0, 1, 2, 3, 4

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -23,7 +23,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     ),
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
-  debug = cms.int32(3) # Verbosity levels: 0, 1, 2, 3, 4
+  debug = cms.int32(0) # Verbosity levels: 0, 1, 2, 3, 4
 )
 
 L1TrackSelectionProducerExtended = L1TrackSelectionProducer.clone(

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -32,7 +32,5 @@ L1TrackSelectionProducerExtended = L1TrackSelectionProducer.clone(
   l1TracksInputTag = cms.InputTag("L1GTTInputProducerExtended","Level1TTTracksExtendedConverted"),
   outputCollectionName = cms.string("Level1TTTracksExtendedSelected"),
   useDisplacedTracksDeltaZOverride = cms.double(3.0), # Use promt/displaced tracks
-  deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # Eta bins for choosing deltaZ threshold.
-  deltaZMax = cms.vdouble(3.0, 3.0, 3.0, 3.0, 3.0, 3.0), # Threshold for track to vertex association.
 )
 

--- a/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackSelectionProducer_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
   l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),
+  # If no vertex collection is provided, then the DeltaZ cuts will not be run
   l1VerticesInputTag = cms.InputTag("L1VertexFinder", "l1vertices"),
   l1VerticesEmulationInputTag = cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
-  # If no vertex collection is provided, then the DeltaZ cuts will not be run
   outputCollectionName = cms.string("Level1TTTracksSelected"),
   cutSet = cms.PSet(
                     ptMin = cms.double(2.0), # pt must be greater than this value, [GeV]
@@ -23,7 +23,7 @@ L1TrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     ),
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
-  debug = cms.int32(2) # Verbosity levels: 0, 1, 2, 3
+  debug = cms.int32(3) # Verbosity levels: 0, 1, 2, 3, 4
 )
 
 L1TrackSelectionProducerExtended = L1TrackSelectionProducer.clone(

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -121,7 +121,8 @@ public:
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   // Other member functions
-  int getSelectedTrackIndex(const L1TrackRef & trackRef, const edm::Handle<L1TrackRefCollection> & selectedTrackRefs) const;
+  int getSelectedTrackIndex(const L1TrackRef& trackRef,
+                            const edm::Handle<L1TrackRefCollection>& selectedTrackRefs) const;
 
 private:
   //-----------------------------------------------------------------------------------------------
@@ -142,16 +143,16 @@ private:
   bool SaveTrackJets;
   bool SaveTrackSums;
 
-  edm::InputTag L1TrackInputTag;                          // L1 track collection
-  edm::InputTag MCTruthTrackInputTag;                     // MC truth collection
-  edm::InputTag L1TrackGTTInputTag;                       // L1 track collection
-  edm::InputTag L1TrackSelectedInputTag;                  // L1 track collection
-  edm::InputTag L1TrackSelectedEmulationInputTag;         // L1 track collection
-  edm::InputTag L1TrackExtendedInputTag;                  // L1 track collection
-  edm::InputTag MCTruthTrackExtendedInputTag;             // MC truth collection
-  edm::InputTag L1TrackExtendedGTTInputTag;               // L1 track collection
-  edm::InputTag L1TrackExtendedSelectedInputTag;          // L1 track collection
-  edm::InputTag L1TrackExtendedSelectedEmulationInputTag; // L1 track collection
+  edm::InputTag L1TrackInputTag;                           // L1 track collection
+  edm::InputTag MCTruthTrackInputTag;                      // MC truth collection
+  edm::InputTag L1TrackGTTInputTag;                        // L1 track collection
+  edm::InputTag L1TrackSelectedInputTag;                   // L1 track collection
+  edm::InputTag L1TrackSelectedEmulationInputTag;          // L1 track collection
+  edm::InputTag L1TrackExtendedInputTag;                   // L1 track collection
+  edm::InputTag MCTruthTrackExtendedInputTag;              // MC truth collection
+  edm::InputTag L1TrackExtendedGTTInputTag;                // L1 track collection
+  edm::InputTag L1TrackExtendedSelectedInputTag;           // L1 track collection
+  edm::InputTag L1TrackExtendedSelectedEmulationInputTag;  // L1 track collection
   edm::InputTag MCTruthClusterInputTag;
   edm::InputTag L1StubInputTag;
   edm::InputTag MCTruthStubInputTag;
@@ -519,7 +520,8 @@ L1TrackObjectNtupleMaker::L1TrackObjectNtupleMaker(edm::ParameterSet const& iCon
     MCTruthTrackExtendedInputTag = iConfig.getParameter<edm::InputTag>("MCTruthTrackExtendedInputTag");
     L1TrackExtendedGTTInputTag = iConfig.getParameter<edm::InputTag>("L1TrackExtendedGTTInputTag");
     L1TrackExtendedSelectedInputTag = iConfig.getParameter<edm::InputTag>("L1TrackExtendedSelectedInputTag");
-    L1TrackExtendedSelectedEmulationInputTag = iConfig.getParameter<edm::InputTag>("L1TrackExtendedSelectedEmulationInputTag");
+    L1TrackExtendedSelectedEmulationInputTag =
+        iConfig.getParameter<edm::InputTag>("L1TrackExtendedSelectedEmulationInputTag");
     TrackFastJetsExtendedInputTag = iConfig.getParameter<InputTag>("TrackFastJetsExtendedInputTag");
     TrackJetsExtendedInputTag = iConfig.getParameter<InputTag>("TrackJetsExtendedInputTag");
     TrackJetsExtendedEmuInputTag = iConfig.getParameter<InputTag>("TrackJetsExtendedEmuInputTag");
@@ -1854,7 +1856,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trkExt_gtt_eta->push_back(l1track_ref->momentum().eta());
       m_trkExt_gtt_phi->push_back(l1track_ref->momentum().phi());
       m_trkExt_selected_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedHandle));
-      m_trkExt_selected_emulation_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationHandle));
+      m_trkExt_selected_emulation_index->push_back(
+          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationHandle));
     }  //end track loop
   }    //end if SaveAllTracks (displaced)
 
@@ -2028,8 +2031,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     // ----------------------------------------------------------------------------------------------
     // look for L1 tracks (prompt) matched to the tracking particle
     if (Displaced == "Prompt" || Displaced == "Both") {
-      L1TrackPtrCollection matchedTracks =
-          MCTruthTTTrackHandle->findTTTrackPtrs(tp_ptr);
+      L1TrackPtrCollection matchedTracks = MCTruthTTTrackHandle->findTTTrackPtrs(tp_ptr);
 
       int nMatch = 0;
       int i_track = -1;
@@ -2198,8 +2200,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     // ----------------------------------------------------------------------------------------------
     // look for L1 tracks (extended) matched to the tracking particle
     if (Displaced == "Displaced" || Displaced == "Both") {
-      L1TrackPtrCollection matchedTracks =
-          MCTruthTTTrackExtendedHandle->findTTTrackPtrs(tp_ptr);
+      L1TrackPtrCollection matchedTracks = MCTruthTTTrackExtendedHandle->findTTTrackPtrs(tp_ptr);
 
       int nMatch = 0;
       int i_track = -1;
@@ -2514,12 +2515,15 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
   eventTree->Fill();
 }  // end of analyze()
 
-int L1TrackObjectNtupleMaker::getSelectedTrackIndex(const L1TrackRef & trackRef, const edm::Handle<L1TrackRefCollection> & selectedTrackRefs) const {
-  auto it = std::find_if(selectedTrackRefs->begin(), selectedTrackRefs->end(), [&trackRef](L1TrackRef const& obj){
-          return obj == trackRef;
-        } );
-  if(it!=selectedTrackRefs->end()) return std::distance(selectedTrackRefs->begin(), it);
-  else return -1;
+int L1TrackObjectNtupleMaker::getSelectedTrackIndex(const L1TrackRef& trackRef,
+                                                    const edm::Handle<L1TrackRefCollection>& selectedTrackRefs) const {
+  auto it = std::find_if(selectedTrackRefs->begin(), selectedTrackRefs->end(), [&trackRef](L1TrackRef const& obj) {
+    return obj == trackRef;
+  });
+  if (it != selectedTrackRefs->end())
+    return std::distance(selectedTrackRefs->begin(), it);
+  else
+    return -1;
 }
 
 ///////////////////////////

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -813,8 +813,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
     eventTree->Branch("trk_gtt_pt", &m_trk_gtt_pt);
     eventTree->Branch("trk_gtt_eta", &m_trk_gtt_eta);
     eventTree->Branch("trk_gtt_phi", &m_trk_gtt_phi);
-    eventTree->Branch("trk_selected_index", &m_trk_selected_index);
-    eventTree->Branch("trk_selected_emulation_index", &m_trk_selected_emulation_index);
+    eventTree->Branch("trk_gtt_selected_index", &m_trk_selected_index);
+    eventTree->Branch("trk_gtt_selected_emulation_index", &m_trk_selected_emulation_index);
   }
 
   if (SaveAllTracks && (Displaced == "Displaced" || Displaced == "Both")) {
@@ -850,8 +850,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
     eventTree->Branch("trkExt_gtt_pt", &m_trkExt_gtt_pt);
     eventTree->Branch("trkExt_gtt_eta", &m_trkExt_gtt_eta);
     eventTree->Branch("trkExt_gtt_phi", &m_trkExt_gtt_phi);
-    eventTree->Branch("trkExt_selected_index", &m_trkExt_selected_index);
-    eventTree->Branch("trkExt_selected_emulation_index", &m_trkExt_selected_emulation_index);
+    eventTree->Branch("trkExt_gtt_selected_index", &m_trkExt_selected_index);
+    eventTree->Branch("trkExt_gtt_selected_emulation_index", &m_trkExt_selected_emulation_index);
   }
   eventTree->Branch("tp_pt", &m_tp_pt);
   eventTree->Branch("tp_eta", &m_tp_eta);

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -33,6 +33,9 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000) # default: 0
+
 ############################################################
 # input and output
 ############################################################
@@ -71,6 +74,7 @@ process.TFileService = cms.Service("TFileService", fileName = cms.string('Checki
 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
 process.load("L1Trigger.L1TTrackMatch.L1TrackJetProducer_cfi")
+process.load("L1Trigger.L1TTrackMatch.L1TrackSelectionProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1TrackJetEmulationProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1TrackFastJetProducer_cfi")
@@ -108,6 +112,7 @@ if (L1TRKALGO == 'HYBRID'):
     process.TTTracksEmuWithTruth = cms.Path(process.L1HybridTracksWithAssociators)
     process.pL1TrackJets = cms.Path(process.L1TrackJets)
     process.pL1TrackFastJets=cms.Path(process.L1TrackFastJets)
+    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducer)
     process.pL1GTTInput = cms.Path(process.L1GTTInputProducer)
     process.pL1TrackJetsEmu = cms.Path(process.L1TrackJetsEmulation)
     process.pTkMET = cms.Path(process.L1TrackerEtMiss)
@@ -122,6 +127,7 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED'):
     process.TTTracksEmuWithTruth = cms.Path(process.L1ExtendedHybridTracksWithAssociators)
     process.pL1TrackJets = cms.Path(process.L1TrackJetsExtended)
     process.pL1TrackFastJets = cms.Path(process.L1TrackFastJetsExtended)
+    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducerExtended)
     process.pL1GTTInput = cms.Path(process.L1GTTInputProducerExtended)
     process.pL1TrackJetsEmu = cms.Path(process.L1TrackJetsExtendedEmulation)
     process.pTkMET = cms.Path(process.L1TrackerEtMissExtended)
@@ -136,6 +142,7 @@ elif (L1TRKALGO == 'HYBRID_PROMPTANDDISP'):
     process.TTTracksEmuWithTruth = cms.Path(process.L1PromptExtendedHybridTracksWithAssociators)
     process.pL1TrackJets = cms.Path(process.L1TrackJets*process.L1TrackJetsExtended)
     process.pL1TrackFastJets = cms.Path(process.L1TrackFastJets*process.L1TrackFastJetsExtended)
+    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducer*process.L1TrackSelectionProducerExtended)
     process.pL1GTTInput = cms.Path(process.L1GTTInputProducer*process.L1GTTInputProducerExtended)
     process.pL1TrackJetsEmu = cms.Path(process.L1TrackJetsEmulation*process.L1TrackJetsExtendedEmulation)
     process.pTkMET = cms.Path(process.L1TrackerEtMiss*process.L1TrackerEtMissExtended)
@@ -216,5 +223,5 @@ process.pOut = cms.EndPath(process.out)
 # use this if cluster/stub associators not available
 # process.schedule = cms.Schedule(process.TTClusterStubTruth,process.TTTracksEmuWithTruth,process.ntuple)
 
-process.schedule = cms.Schedule(process.TTTracksEmuWithTruth, process.pL1GTTInput, process.pPV, process.pPVemu, process.pL1TrackJets, process.pL1TrackJetsEmu,
+process.schedule = cms.Schedule(process.TTTracksEmuWithTruth, process.pL1GTTInput, process.pPV, process.pPVemu, process.pL1TrackSelection, process.pL1TrackJets, process.pL1TrackJetsEmu,
 process.pL1TrackFastJets, process.pTkMET, process.pTkMETEmu, process.pTkMHT, process.pTkMHTEmulator, process.ntuple)

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -34,7 +34,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000) # default: 0
+process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(0) # default: 0
 
 ############################################################
 # input and output
@@ -73,8 +73,8 @@ process.TFileService = cms.Service("TFileService", fileName = cms.string('Checki
 #process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
-process.load("L1Trigger.L1TTrackMatch.L1TrackJetProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1TrackSelectionProducer_cfi")
+process.load("L1Trigger.L1TTrackMatch.L1TrackJetProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1TrackJetEmulationProducer_cfi")
 process.load("L1Trigger.L1TTrackMatch.L1TrackFastJetProducer_cfi")
@@ -110,9 +110,9 @@ process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("L1VertexFinderEmulat
 if (L1TRKALGO == 'HYBRID'):
     process.TTTracksEmu = cms.Path(process.L1HybridTracks)
     process.TTTracksEmuWithTruth = cms.Path(process.L1HybridTracksWithAssociators)
+    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducer)
     process.pL1TrackJets = cms.Path(process.L1TrackJets)
     process.pL1TrackFastJets=cms.Path(process.L1TrackFastJets)
-    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducer)
     process.pL1GTTInput = cms.Path(process.L1GTTInputProducer)
     process.pL1TrackJetsEmu = cms.Path(process.L1TrackJetsEmulation)
     process.pTkMET = cms.Path(process.L1TrackerEtMiss)
@@ -125,9 +125,9 @@ if (L1TRKALGO == 'HYBRID'):
 elif (L1TRKALGO == 'HYBRID_DISPLACED'):
     process.TTTracksEmu = cms.Path(process.L1ExtendedHybridTracks)
     process.TTTracksEmuWithTruth = cms.Path(process.L1ExtendedHybridTracksWithAssociators)
+    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducerExtended)
     process.pL1TrackJets = cms.Path(process.L1TrackJetsExtended)
     process.pL1TrackFastJets = cms.Path(process.L1TrackFastJetsExtended)
-    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducerExtended)
     process.pL1GTTInput = cms.Path(process.L1GTTInputProducerExtended)
     process.pL1TrackJetsEmu = cms.Path(process.L1TrackJetsExtendedEmulation)
     process.pTkMET = cms.Path(process.L1TrackerEtMissExtended)
@@ -140,9 +140,9 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED'):
 elif (L1TRKALGO == 'HYBRID_PROMPTANDDISP'):
     process.TTTracksEmu = cms.Path(process.L1PromptExtendedHybridTracks)
     process.TTTracksEmuWithTruth = cms.Path(process.L1PromptExtendedHybridTracksWithAssociators)
+    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducer*process.L1TrackSelectionProducerExtended)
     process.pL1TrackJets = cms.Path(process.L1TrackJets*process.L1TrackJetsExtended)
     process.pL1TrackFastJets = cms.Path(process.L1TrackFastJets*process.L1TrackFastJetsExtended)
-    process.pL1TrackSelection = cms.Path(process.L1TrackSelectionProducer*process.L1TrackSelectionProducerExtended)
     process.pL1GTTInput = cms.Path(process.L1GTTInputProducer*process.L1GTTInputProducerExtended)
     process.pL1TrackJetsEmu = cms.Path(process.L1TrackJetsEmulation*process.L1TrackJetsExtendedEmulation)
     process.pTkMET = cms.Path(process.L1TrackerEtMiss*process.L1TrackerEtMissExtended)
@@ -176,10 +176,16 @@ process.L1TrackNtuple = cms.EDAnalyzer('L1TrackObjectNtupleMaker',
         TP_minPt = cms.double(2.0),       # only save TPs with pt > X GeV
         TP_maxEta = cms.double(2.5),      # only save TPs with |eta| < X
         TP_maxZ0 = cms.double(15.0),      # only save TPs with |z0| < X cm
-        L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),                          # TTTracks, prompt
-        L1TrackExtendedInputTag = cms.InputTag("TTTracksFromExtendedTrackletEmulation", "Level1TTTracks"),          # TTTracks, extended
-        MCTruthTrackInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"),                   # MCTruth track, prompt
-        MCTruthTrackExtendedInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigisExtended", "Level1TTTracks"),   # MCTruth track, extended
+        L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),                                                      # TTTracks, prompt
+        L1TrackExtendedInputTag = cms.InputTag("TTTracksFromExtendedTrackletEmulation", "Level1TTTracks"),                                      # TTTracks, extended
+        MCTruthTrackInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"),                                               # MCTruth track, prompt
+        MCTruthTrackExtendedInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigisExtended", "Level1TTTracks"),                               # MCTruth track, extended
+        L1TrackGTTInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),                                                      # TTTracks, prompt, GTT converted
+        L1TrackExtendedGTTInputTag = cms.InputTag("L1GTTInputProducerExtended","Level1TTTracksExtendedConverted"),                              # TTTracks, extended, GTT converted
+        L1TrackSelectedInputTag = cms.InputTag("L1TrackSelectionProducer", "Level1TTTracksSelected"),                                           # TTTracks, prompt, selected
+        L1TrackSelectedEmulationInputTag = cms.InputTag("L1TrackSelectionProducer", "Level1TTTracksSelectedEmulation"),                         # TTTracks, prompt, emulation, selected
+        L1TrackExtendedSelectedInputTag = cms.InputTag("L1TrackSelectionProducerExtended", "Level1TTTracksExtendedSelected"),                   # TTTracks, extended, selected
+        L1TrackExtendedSelectedEmulationInputTag = cms.InputTag("L1TrackSelectionProducerExtended", "Level1TTTracksExtendedSelectedEmulation"), # TTTracks, extended, emulation, selected
         L1StubInputTag = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
         MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
         MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),


### PR DESCRIPTION
#### PR description:

This PR adds a new producer which is meant to simulate/emulate the TrackSelection+TrackVertexAssociation modules within the GTT. The producer takes in the TTTrack collection (i.e. `std::vector<TTTrack>`) and then outputs up to four `std::vector<edm::Ref<TTTrack>>` collections. These contain references to the original TTTrack collection for tracks which pass the selection cuts. There are two output collections possible for the simulation and two for the emulation, the latter uses the values stored in the associated TTTrack_TrackWords. If running the emulation part of this module, the input must come from the L1GTTInputProducer, as only those tracks contain the expected pt and eta format for the TTTrack_TrackWord.

In order to do the TrackVertexAssociation part of the module, the use must specify the vertex collection to use. If no vertex collection is specified in the python configuration, then the TrackVertexAssociation (a.k.a DeltaZCut) isn't run. This can be separately turned off for the cuts on the simulated or emulated tracks.

This PR adds the producer itself and stores some minimal information in the L1TrackObjectNtuple, namely the GTT input (pt, eta, phi) and the index of the track within the selected track collection for each track coming from the L1GTTInputProducer. If a track isn't selected, it is given an index of `-1`.

In a future PR we will replace the cuts built into the L1TrackerEtMissProducer and the L1TrackerEtMissEmulatorProducer. Instead, we will simply pass in the collections where these cuts have already been applied. These changes will come in a separate PR for ease of validation and review.

#### PR validation:

This code has been run using the L1TrackObjectNtupleProducer and its output has been verified by eye. To me, everything looks like its running correctly, within the bounds of the TTTrack_TrackWord parameter resolution.

I have also run the `scram b code-checks` and `scram b code-format` commands.

@emacdonald16 @Chriisbrown @tomalin