### PR TITLE
New Delta Z Cut for Track Jet Emulation & Updated Track Jet Word

### DIFF
--- a/DataFormats/L1Trigger/interface/TkJetWord.h
+++ b/DataFormats/L1Trigger/interface/TkJetWord.h
@@ -5,7 +5,7 @@
 #include <ap_int.h>
 #include <cassert>
 #include <cmath>
-#include <bitset>
+#include <bitset> 
 #include <string>
 
 namespace l1t {
@@ -15,15 +15,15 @@ namespace l1t {
     // ----------constants, enums and typedefs ---------
     int INTPHI_PI = 720;
     int INTPHI_TWOPI = 2 * INTPHI_PI;
-    float INTPT_LSB = 0.25;
-    float ETAPHI_LSB = M_PI / INTPHI_PI;
+    float INTPT_LSB = 1>>5;
+    float ETAPHI_LSB = M_PI / (1<<12);
     float Z0_LSB = 0.05;
 
     enum TkJetBitWidths {
-      kPtSize = 14,
-      kPtMagSize = 12,
-      kGlbEtaSize = 12,
-      kGlbPhiSize = 11,
+      kPtSize = 16,
+      kPtMagSize = 11,
+      kGlbEtaSize = 14,
+      kGlbPhiSize = 13,
       kZ0Size = 10,
       kNtSize = 5,
       kXtSize = 4,
@@ -51,35 +51,53 @@ namespace l1t {
     typedef ap_ufixed<kPtSize, kPtMagSize, AP_TRN, AP_SAT> pt_t;
     typedef ap_int<kGlbEtaSize> glbeta_t;
     typedef ap_int<kGlbPhiSize> glbphi_t;
-    typedef ap_int<kZ0Size> z0_t;                                        // 40cm / 0.1
-    typedef ap_uint<kNtSize> nt_t;                                       //number of tracks
-    typedef ap_uint<kXtSize> nx_t;                                       //number of tracks with xbit = 1
+    typedef ap_int<kZ0Size> z0_t;         // 40cm / 0.1
+    typedef ap_uint<kNtSize> nt_t; //number of tracks
+    typedef ap_uint<kXtSize> nx_t; //number of tracks with xbit = 1
     typedef ap_uint<TkJetBitWidths::kUnassignedSize> tkjetunassigned_t;  // Unassigned bits
     typedef std::bitset<TkJetBitWidths::kTkJetWordSize> tkjetword_bs_t;
     typedef ap_uint<TkJetBitWidths::kTkJetWordSize> tkjetword_t;
-
+    
   public:
     // ----------Constructors --------------------------
     TkJetWord() {}
-    TkJetWord(pt_t pt, glbeta_t eta, glbphi_t phi, z0_t z0, nt_t nt, nx_t nx, tkjetunassigned_t unassigned) {
+    TkJetWord(pt_t pt,
+              glbeta_t eta,
+              glbphi_t phi,
+              z0_t z0,
+              nt_t nt,
+              nx_t nx,
+              tkjetunassigned_t unassigned) {
       std::string word = "";
-      word.append(TkJetBitWidths::kUnassignedSize - (unassigned.to_string().length() - 2), '0');
-      word = word + (unassigned.to_string().substr(2, unassigned.to_string().length() - 2));
-      word.append(TkJetBitWidths::kXtSize - (nx.to_string().length() - 2), '0');
-      word = word + (nx.to_string().substr(2, nx.to_string().length() - 2));
-      word.append(TkJetBitWidths::kNtSize - (nt.to_string().length() - 2), '0');
-      word = word + (nt.to_string().substr(2, nt.to_string().length() - 2));
-      word.append(TkJetBitWidths::kZ0Size - (z0.to_string().length() - 2), '0');
-      word = word + (z0.to_string().substr(2, z0.to_string().length() - 2));
-      word.append(TkJetBitWidths::kGlbPhiSize - (phi.to_string().length() - 2), '0');
-      word = word + (phi.to_string().substr(2, phi.to_string().length() - 2));
-      word.append(TkJetBitWidths::kGlbEtaSize - (eta.to_string().length() - 2), '0');
-      word = word + (eta.to_string().substr(2, eta.to_string().length() - 2));
-      ap_uint<kPtSize> pt_temp = pt << 2;
-      word.append(TkJetBitWidths::kPtSize - (pt_temp.to_string().length() - 2), '0');
-      word = word + (pt_temp.to_string().substr(2, pt_temp.to_string().length() - 2));
+      word.append(TkJetBitWidths::kUnassignedSize - (unassigned.to_string().length()-2),'0');
+      word = word + (unassigned.to_string().substr(2,unassigned.to_string().length()-2));
+      word.append(TkJetBitWidths::kXtSize - (nx.to_string().length()-2),'0');
+      word = word + (nx.to_string().substr(2,nx.to_string().length()-2));
+      word.append(TkJetBitWidths::kNtSize - (nt.to_string().length()-2),'0');
+      word = word + (nt.to_string().substr(2,nt.to_string().length()-2));
+      word.append(TkJetBitWidths::kZ0Size - (z0.to_string().length()-2),'0');
+      word = word + (z0.to_string().substr(2,z0.to_string().length()-2));
+      word.append(TkJetBitWidths::kGlbPhiSize - (phi.to_string().length()-2),'0');
+      word = word + (phi.to_string().substr(2,phi.to_string().length()-2));
+      word.append(TkJetBitWidths::kGlbEtaSize - (eta.to_string().length()-2),'0');
+      word = word + (eta.to_string().substr(2,eta.to_string().length()-2));
+      /*cout << "jet word pt: ";
+      cout << pt.to_float();
+      cout << ", not float: ";
+      cout << pt;
+      cout << ", not float str: ";
+      cout << (pt.to_string().substr(2,pt.to_string().length()-2));*/
+      ap_ufixed<kPtSize+5, kPtMagSize+5, AP_TRN, AP_SAT> pt_2 = pt;
+      ap_uint<kPtSize> pt_temp = pt_2 << 5;
+      /*cout << ", pt_temp: ";
+      cout << pt_temp;
+      cout << ", pt_tmp_str: ";
+      cout << (pt_temp.to_string().substr(2,pt_temp.to_string().length()-2));
+      cout << endl;*/
+      word.append(TkJetBitWidths::kPtSize - (pt_temp.to_string().length()-2),'0');
+      word = word + (pt_temp.to_string().substr(2,pt_temp.to_string().length()-2));
 
-      tkjetword_bs_t tmp(word);
+      tkjetword_bs_t tmp (word);
       tkJetWord_ = tmp;
     }
 
@@ -147,12 +165,18 @@ namespace l1t {
     float glbeta() const { return glbEtaWord().to_float() * ETAPHI_LSB; }
     float glbphi() const { return glbPhiWord().to_float() * ETAPHI_LSB; }
     float z0() const { return z0Word().to_float() * Z0_LSB; }
-    int nt() const { return (ap_ufixed<kNtSize + 2, kNtSize>(ntWord())).to_int(); }
-    int xt() const { return (ap_ufixed<kXtSize + 2, kXtSize>(xtWord())).to_int(); }
+    int nt() const { return (ap_ufixed<kNtSize+2, kNtSize>(ntWord())).to_int(); }
+    int xt() const { return (ap_ufixed<kXtSize+2, kXtSize>(xtWord())).to_int(); }
     unsigned int unassigned() const { return unassignedWord().to_uint(); }
 
     // ----------member functions (setters) ------------
-    void setTkJetWord(pt_t pt, glbeta_t eta, glbphi_t phi, z0_t z0, nt_t nt, nx_t nx, tkjetunassigned_t unassigned);
+    void setTkJetWord(pt_t pt,
+                      glbeta_t eta,
+              	      glbphi_t phi,
+               	      z0_t z0,
+                      nt_t nt,
+                      nx_t nx,
+                      tkjetunassigned_t unassigned);
 
   private:
     // ----------private member functions --------------
@@ -169,9 +193,10 @@ namespace l1t {
     // ----------member data ---------------------------
     tkjetword_bs_t tkJetWord_;
   };
+ 
 
   typedef std::vector<l1t::TkJetWord> TkJetWordCollection;
-
+  
 }  // namespace l1t
 
 #endif

--- a/DataFormats/L1Trigger/interface/TkJetWord.h
+++ b/DataFormats/L1Trigger/interface/TkJetWord.h
@@ -81,19 +81,8 @@ namespace l1t {
       word = word + (phi.to_string().substr(2,phi.to_string().length()-2));
       word.append(TkJetBitWidths::kGlbEtaSize - (eta.to_string().length()-2),'0');
       word = word + (eta.to_string().substr(2,eta.to_string().length()-2));
-      /*cout << "jet word pt: ";
-      cout << pt.to_float();
-      cout << ", not float: ";
-      cout << pt;
-      cout << ", not float str: ";
-      cout << (pt.to_string().substr(2,pt.to_string().length()-2));*/
       ap_ufixed<kPtSize+5, kPtMagSize+5, AP_TRN, AP_SAT> pt_2 = pt;
       ap_uint<kPtSize> pt_temp = pt_2 << 5;
-      /*cout << ", pt_temp: ";
-      cout << pt_temp;
-      cout << ", pt_tmp_str: ";
-      cout << (pt_temp.to_string().substr(2,pt_temp.to_string().length()-2));
-      cout << endl;*/
       word.append(TkJetBitWidths::kPtSize - (pt_temp.to_string().length()-2),'0');
       word = word + (pt_temp.to_string().substr(2,pt_temp.to_string().length()-2));
 

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -278,8 +278,8 @@
   <class name="l1t::VertexWord::VertexRef"/>
   <class name="edm::Wrapper<l1t::VertexWord::VertexRef>"/>
 
-  <class name="l1t::TkJetWord" ClassVersion="11">
-    <version ClassVersion="11" checksum="3521396535"/>
+  <class name="l1t::TkJetWord" ClassVersion="12">
+    <version ClassVersion="12" checksum="3521396532"/>
   </class>
   <class name="std::vector<l1t::TkJetWord>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkJetWord> >"/>

--- a/L1Trigger/L1TTrackMatch/interface/L1TrackJetEmulationProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TrackJetEmulationProducer.h
@@ -15,29 +15,29 @@ const int ETA_EXTRABITS = 0;
 const int PHI_EXTRABITS = 0;
 const int Z0_EXTRABITS = 0;
 
-typedef ap_ufixed<14 + PT_EXTRABITS, 12, AP_TRN, AP_SAT> pt_intern;
-typedef ap_int<12 + ETA_EXTRABITS> glbeta_intern;
-typedef ap_int<11 + PHI_EXTRABITS> glbphi_intern;
-typedef ap_int<10 + Z0_EXTRABITS> z0_intern;  // 40cm / 0.1
+typedef ap_ufixed<16 + PT_EXTRABITS, 11, AP_TRN, AP_SAT> pt_intern;
+typedef ap_int<14+ETA_EXTRABITS> glbeta_intern;
+typedef ap_int<14+PHI_EXTRABITS> glbphi_intern;
+typedef ap_int<10+Z0_EXTRABITS> z0_intern;  // 40cm / 0.1
 
 namespace convert {
   const int INTPHI_PI = 720;
   const int INTPHI_TWOPI = 2 * INTPHI_PI;
-  constexpr float INTPT_LSB_POW = pow(2.0, -2 - PT_EXTRABITS);
+  constexpr float INTPT_LSB_POW = pow(2.0,-5 - PT_EXTRABITS);
   constexpr float INTPT_LSB = INTPT_LSB_POW;
-  constexpr float ETA_LSB_POW = pow(2.0, -1 * ETA_EXTRABITS);
-  constexpr float ETA_LSB = M_PI / INTPHI_PI * ETA_LSB_POW;
-  constexpr float PHI_LSB_POW = pow(2.0, -1 * PHI_EXTRABITS);
-  constexpr float PHI_LSB = M_PI / INTPHI_PI * PHI_LSB_POW;
-  constexpr float Z0_LSB_POW = pow(2.0, -1 * Z0_EXTRABITS);
+  constexpr float ETA_LSB_POW = pow(2.0,-1 * ETA_EXTRABITS);
+  constexpr float ETA_LSB = M_PI / pow(2.0,12) * ETA_LSB_POW;
+  constexpr float PHI_LSB_POW = pow(2.0,-1 * PHI_EXTRABITS);
+  constexpr float PHI_LSB = M_PI / pow(2.0,12) * PHI_LSB_POW;
+  constexpr float Z0_LSB_POW = pow(2.0,-1 * Z0_EXTRABITS);
   constexpr float Z0_LSB = 0.05 * Z0_LSB_POW;
   inline float floatPt(pt_intern pt) { return pt.to_float(); }
-  inline int intPt(pt_intern pt) { return (ap_ufixed<16 + PT_EXTRABITS, 14>(pt)).to_int(); }
+  inline int intPt(pt_intern pt) { return (ap_ufixed<18+PT_EXTRABITS, 13+PT_EXTRABITS>(pt)).to_int(); }
   inline float floatEta(glbeta_intern eta) { return eta.to_float() * ETA_LSB; }
   inline float floatPhi(glbphi_intern phi) { return phi.to_float() * PHI_LSB; }
   inline float floatZ0(z0_intern z0) { return z0.to_float() * Z0_LSB; }
 
-  inline pt_intern makePt(int pt) { return ap_ufixed<16 + PT_EXTRABITS, 14>(pt); }
+  inline pt_intern makePt(int pt) { return ap_ufixed<18+PT_EXTRABITS, 13+PT_EXTRABITS>(pt); }
   inline pt_intern makePtFromFloat(float pt) { return pt_intern(INTPT_LSB_POW * round(pt / INTPT_LSB_POW)); }
   inline z0_intern makeZ0(float z0) { return z0_intern(round(z0 / Z0_LSB)); }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -146,7 +146,7 @@ L1TrackJetEmulationProducer::L1TrackJetEmulationProducer(const ParameterSet &iCo
   nStubs4DisplacedBendTight_ = (float)iConfig.getParameter<double>("nStubs4Displacedbend_Tight");
   nStubs5DisplacedBendTight_ = (float)iConfig.getParameter<double>("nStubs5Displacedbend_Tight");
 
-  zStep_ = convert::makeZ0(2.0 * trkZMax_ / zBins_);
+  zStep_ = convert::makeZ0(2.0 * trkZMax_ / (zBins_+1));
   etaStep_ = convert::makeGlbEta(2.0 * trkEtaMax_ / etaBins_);  //etaStep is the width of an etabin
   phiStep_ = convert::makeGlbPhi(2.0 * M_PI / phiBins_);        ////phiStep is the width of a phibin
 
@@ -282,7 +282,7 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
     kPhiMagSize = 1,
   };
 
-  const int nz = zBins_;
+  const int nz = zBins_+1;
   MaxZBin all_zBins[nz];
   MaxZBin mzbtemp;
   for (int z = 0; z < nz; ++z)

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -367,8 +367,6 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
           TTTrack_TrackWord::stepZ0 / convert::Z0_LSB;  //conversion factor from input z format to internal format
       z0_intern trkZ = z0_conv * inputTrkZ0;
 
-      //ap_ufixed<32 + PHI_EXTRABITS, 1 + PHI_EXTRABITS> phi_conv = TTTrack_TrackWord::stepPhi0 / convert::PHI_LSB;
-
       for (int i = 0; i < phiBins_; ++i) {
         for (int j = 0; j < etaBins_; ++j) {
           L2cluster[k] = epbins[i][j];

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -279,7 +279,7 @@ void L1TrackJetProducer::L2_cluster(vector<Ptr<L1TTTrackType> > L1TrkPtrs_, vect
   EtaPhiBin *L1clusters[phiBins_];
   EtaPhiBin L2cluster[ntracks];
 
-  for (int zbin = 0; zbin < zBins_ - 1; ++zbin) {
+  for (int zbin = 0; zbin < zBins_; ++zbin) {
     for (int i = 0; i < phiBins_; ++i) {  //First initialize pT, numtracks, used to 0 (or false)
       for (int j = 0; j < etaBins_; ++j) {
         epbins[i][j].pTtot = 0;
@@ -526,7 +526,7 @@ void L1TrackJetProducer::L2_cluster(vector<Ptr<L1TTTrackType> > L1TrkPtrs_, vect
     zmin = zmin + zStep_;
     zmax = zmax + zStep_;
   }  // for each zbin
-  for (int zbin = 0; zbin < zBins_ - 1; ++zbin) {
+  for (int zbin = 0; zbin < zBins_; ++zbin) {
     if (zbin == mzb.znum)
       continue;
     delete[] all_zBins[zbin].clusters;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -124,7 +124,7 @@ L1TrackJetProducer::L1TrackJetProducer(const ParameterSet &iConfig)
   nDisplacedTracks_ = (int)iConfig.getParameter<int>("nDisplacedTracks");
   dzPVTrk_ = (float)iConfig.getParameter<double>("MaxDzTrackPV");
 
-  zStep_ = 2.0 * trkZMax_ / zBins_;
+  zStep_ = 2.0 * trkZMax_ / (zBins_+1);
   etaStep_ = 2.0 * trkEtaMax_ / etaBins_;  //etaStep is the width of an etabin
   phiStep_ = 2 * M_PI / phiBins_;          ////phiStep is the width of a phibin
 
@@ -247,7 +247,7 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
 }
 
 void L1TrackJetProducer::L2_cluster(vector<Ptr<L1TTTrackType> > L1TrkPtrs_, vector<int> tdtrk_, MaxZBin &mzb) {
-  const int nz = zBins_;
+  const int nz = zBins_+1;
   MaxZBin all_zBins[nz];
   MaxZBin mzbtemp;
   for (int z = 0; z < nz; ++z)

--- a/L1Trigger/L1TTrackMatch/python/L1TrackJetEmulationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackJetEmulationProducer_cfi.py
@@ -4,7 +4,7 @@ from L1Trigger.VertexFinder.VertexProducer_cff import VertexProducer
 L1TrackJetsEmulation = cms.EDProducer('L1TrackJetEmulationProducer',
 	L1TrackInputTag= cms.InputTag("L1GTTInputProducer", "Level1TTTracksConverted"),
         VertexInputTag=cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
-	MaxDzTrackPV = cms.double(4.0),
+	MaxDzTrackPV = cms.double(0.5),
         trk_zMax = cms.double (15.) ,    # maximum track z
 	trk_ptMax = cms.double(200.),    # maximumum track pT before saturation [GeV]
 	trk_ptMin = cms.double(2.0),     # minimum track pt [GeV]
@@ -15,7 +15,7 @@ L1TrackJetsEmulation = cms.EDProducer('L1TrackJetEmulationProducer',
 	minTrkJetpT=cms.double(5.),      # minimum track pt to be considered for track jet
 	etaBins=cms.int32(24),
 	phiBins=cms.int32(27),
-	zBins=cms.int32(60),
+	zBins=cms.int32(1),
 	d0_cutNStubs4=cms.double(0.15),
 	d0_cutNStubs5=cms.double(0.5),
 	lowpTJetMinTrackMultiplicity=cms.int32(2),

--- a/L1Trigger/L1TTrackMatch/python/L1TrackJetEmulationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackJetEmulationProducer_cfi.py
@@ -1,8 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.VertexFinder.VertexProducer_cff import VertexProducer
 
 L1TrackJetsEmulation = cms.EDProducer('L1TrackJetEmulationProducer',
 	L1TrackInputTag= cms.InputTag("L1GTTInputProducer", "Level1TTTracksConverted"),
-	trk_zMax = cms.double (15.) ,    # maximum track z
+        VertexInputTag=cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
+	MaxDzTrackPV = cms.double(4.0),
+        trk_zMax = cms.double (15.) ,    # maximum track z
 	trk_ptMax = cms.double(200.),    # maximumum track pT before saturation [GeV]
 	trk_ptMin = cms.double(2.0),     # minimum track pt [GeV]
    	trk_etaMax = cms.double(2.4),    # maximum track eta
@@ -32,7 +35,9 @@ L1TrackJetsEmulation = cms.EDProducer('L1TrackJetEmulationProducer',
 
 L1TrackJetsExtendedEmulation = cms.EDProducer('L1TrackJetEmulationProducer',
 	L1TrackInputTag= cms.InputTag("L1GTTInputProducerExtended", "Level1TTTracksExtendedConverted"),
-	trk_zMax = cms.double (15.) ,    # maximum track z
+        VertexInputTag=cms.InputTag("L1VertexFinderEmulator", "l1verticesEmulation"),
+	MaxDzTrackPV = cms.double(4.0),
+        trk_zMax = cms.double (15.) ,    # maximum track z
 	trk_ptMax = cms.double(200.),    # maximumum track pT before saturation [GeV]
 	trk_ptMin = cms.double(3.0),     # minimum track pt [GeV]
    	trk_etaMax = cms.double(2.4),    # maximum track eta

--- a/L1Trigger/L1TTrackMatch/python/L1TrackJetProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackJetProducer_cfi.py
@@ -5,7 +5,7 @@ from L1Trigger.VertexFinder.VertexProducer_cff import VertexProducer
 L1TrackJets = cms.EDProducer('L1TrackJetProducer',
 	L1TrackInputTag= cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
         L1PVertexCollection = cms.InputTag("VertexProducer", VertexProducer.l1VertexCollectionName.value()),
-        MaxDzTrackPV = cms.double( 4.0 ),
+        MaxDzTrackPV = cms.double( 0.5 ),
 	trk_zMax = cms.double (15.) ,    # maximum track z
 	trk_ptMax = cms.double(200.),    # maximumum track pT before saturation [GeV]
 	trk_ptMin = cms.double(2.0),     # minimum track pt [GeV]
@@ -16,7 +16,7 @@ L1TrackJets = cms.EDProducer('L1TrackJetProducer',
 	minTrkJetpT=cms.double(5.),      # minimum track pt to be considered for track jet
 	etaBins=cms.int32(24),
 	phiBins=cms.int32(27),
-	zBins=cms.int32(60),
+	zBins=cms.int32(1),
 	d0_cutNStubs4=cms.double(0.15),
 	d0_cutNStubs5=cms.double(0.5),
 	lowpTJetMinTrackMultiplicity=cms.int32(2),

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -37,7 +37,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # input and output
 ############################################################
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 readFiles = cms.untracked.vstring(
     # 'file:F7BF4AED-51F1-9D47-B86D-6C3DDA134AB9.root'

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -37,7 +37,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # input and output
 ############################################################
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
 readFiles = cms.untracked.vstring(
     # 'file:F7BF4AED-51F1-9D47-B86D-6C3DDA134AB9.root'


### PR DESCRIPTION
**PR description:**

This PR does the following:

1.    Adds the z-position of the primary vertex, as found by the L1VertexFinderEmulator, as an input to the track jet emulation.
2.    Implements a maximum allowed distance between the z-coordinate of clustered tracks and the z-position of the primary vertex.
3.    Updates the track jet word to a new format with more bits for pT, eta, and phi.
4.    Changes the track jet emulator such that it now calculates the global phi of each track by summing the phi sector and the local phi value provided by the TTTrack_TrackWord. This is how global phi is computed in the firmware.
4.    Fixes minor bugs in the track jet emulation and the track jet simulation.

**Future updates not included in this PR:**

1. In the future we will want the ability to write out text files which contain the emulation inputs and outputs, for comparison to the HLS/firmware code. However, this feature is not yet implemented.
2. We would like the track quality cuts and the delta Z cuts to be performed in the L1TrackSelectionProducer instead of in the track jet emulator and simulator, to better reflect what occurs in the firmware.

**PR validation:**

This PR has been validated in the following ways:

1.    We created some validation plots to see that the code was behaving as expected.