### PR TITLE
Fix for l1Event in the L1EventTreeProducer (backport from master)

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
@@ -83,7 +83,7 @@ L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig)
   bool useAvgVtx = iConfig.getUntrackedParameter<bool>("useAvgVtx", true);
   double maxAllowedWeight = iConfig.getUntrackedParameter<double>("maxAllowedWeight", -1);
 
-  std::make_unique<L1Analysis::L1AnalysisEvent>(
+  l1Event = std::make_unique<L1Analysis::L1AnalysisEvent>(
       puMCFile, puMCHist, puDataFile, puDataHist, useAvgVtx, maxAllowedWeight, consumesCollector());
   l1EventData = l1Event->getData();
 


### PR DESCRIPTION
#### PR description:
Backport of PR[36875](https://github.com/cms-sw/cmssw/pull/36875): Fix for l1Event in the L1EventTreeProducer