### PR TITLE
Minor changes to GMTMuons Dataformat to include physical variables

### DIFF
--- a/DataFormats/L1TMuonPhase2/interface/SAMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/SAMuon.h
@@ -33,12 +33,12 @@ namespace l1t {
     void setBeta(uint beta) { hwBeta_ = beta; }
 
     // For HLT
-    const double phZ0() const { return Phase2L1GMT::LSBSAz0*hwZ0_;}
-    const double phD0() const { return Phase2L1GMT::LSBSAd0*hwD0_;}
+    const double phZ0() const { return Phase2L1GMT::LSBSAz0*hwZ0();}
+    const double phD0() const { return Phase2L1GMT::LSBSAd0*hwD0();}
     const double phPt() const { return Phase2L1GMT::LSBpt*hwPt();}
     const double phEta() const { return Phase2L1GMT::LSBeta*hwEta();}
     const double phPhi() const { return Phase2L1GMT::LSBphi*hwPhi();}
-    const int    phCharge() const {return pow(-1,hwCharge_); } 
+    const int    phCharge() const {return pow(-1,hwCharge()); } 
 
     const uint64_t word() const { return word_; }
     void setWord(uint64_t word) { word_ = word; }

--- a/DataFormats/L1TMuonPhase2/interface/SAMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/SAMuon.h
@@ -38,6 +38,7 @@ namespace l1t {
     const double phPt() const { return Phase2L1GMT::LSBpt*hwPt();}
     const double phEta() const { return Phase2L1GMT::LSBeta*hwEta();}
     const double phPhi() const { return Phase2L1GMT::LSBphi*hwPhi();}
+    const int    phCharge() const {return pow(-1,hwCharge_); } 
 
     const uint64_t word() const { return word_; }
     void setWord(uint64_t word) { word_ = word; }

--- a/DataFormats/L1TMuonPhase2/interface/SAMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/SAMuon.h
@@ -8,6 +8,7 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "L1Trigger/Phase2L1GMT/interface/Constants.h"
 
 namespace l1t {
 
@@ -30,6 +31,13 @@ namespace l1t {
     const int hwD0() const { return hwD0_; }
     const uint hwBeta() const { return hwBeta_; }
     void setBeta(uint beta) { hwBeta_ = beta; }
+
+    // For HLT
+    const double phZ0() const { return Phase2L1GMT::LSBSAz0*hwZ0_;}
+    const double phD0() const { return Phase2L1GMT::LSBSAd0*hwD0_;}
+    const double phPt() const { return Phase2L1GMT::LSBpt*hwPt();}
+    const double phEta() const { return Phase2L1GMT::LSBeta*hwEta();}
+    const double phPhi() const { return Phase2L1GMT::LSBphi*hwPhi();}
 
     const uint64_t word() const { return word_; }
     void setWord(uint64_t word) { word_ = word; }

--- a/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
@@ -9,6 +9,7 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 #include "DataFormats/L1TMuonPhase2/interface/MuonStub.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "L1Trigger/Phase2L1GMT/interface/Constants.h"
 
 namespace l1t {
 
@@ -43,6 +44,13 @@ namespace l1t {
     void setMuonRef(const edm::Ref<l1t::RegionalMuonCandBxCollection>& p) { muRef_ = p; }
     void setHwIsoSum(int isoSum) { hwIsoSum_ = isoSum; }
     void setHwIsoSumAp(int isoSum) { hwIsoSumAp_ = isoSum; }
+ 
+    // For HLT
+    const double phZ0() const { return Phase2L1GMT::LSBGTz0*hwZ0_;}
+    const double phD0() const { return Phase2L1GMT::LSBGTd0*hwD0_;}
+    const double phPt() const { return Phase2L1GMT::LSBpt*hwPt();}
+    const double phEta() const { return Phase2L1GMT::LSBeta*hwEta();}
+    const double phPhi() const { return Phase2L1GMT::LSBphi*hwPhi();}
 
     const std::array<uint64_t, 2> word() const { return word_; }
     void setWord(std::array<uint64_t, 2> word) { word_ = word; }

--- a/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
@@ -51,6 +51,7 @@ namespace l1t {
     const double phPt() const { return Phase2L1GMT::LSBpt*hwPt();}
     const double phEta() const { return Phase2L1GMT::LSBeta*hwEta();}
     const double phPhi() const { return Phase2L1GMT::LSBphi*hwPhi();}
+    const int    phCharge() const {return pow(-1,hwCharge_); }
 
     const std::array<uint64_t, 2> word() const { return word_; }
     void setWord(std::array<uint64_t, 2> word) { word_ = word; }

--- a/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
@@ -46,12 +46,12 @@ namespace l1t {
     void setHwIsoSumAp(int isoSum) { hwIsoSumAp_ = isoSum; }
  
     // For HLT
-    const double phZ0() const { return Phase2L1GMT::LSBGTz0*hwZ0_;}
-    const double phD0() const { return Phase2L1GMT::LSBGTd0*hwD0_;}
+    const double phZ0() const { return Phase2L1GMT::LSBGTz0*hwZ0();}
+    const double phD0() const { return Phase2L1GMT::LSBGTd0*hwD0();}
     const double phPt() const { return Phase2L1GMT::LSBpt*hwPt();}
     const double phEta() const { return Phase2L1GMT::LSBeta*hwEta();}
     const double phPhi() const { return Phase2L1GMT::LSBphi*hwPhi();}
-    const int    phCharge() const {return pow(-1,hwCharge_); }
+    const int    phCharge() const {return pow(-1,hwCharge()); }
 
     const std::array<uint64_t, 2> word() const { return word_; }
     void setWord(std::array<uint64_t, 2> word) { word_ = word; }

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1.h
@@ -184,7 +184,8 @@ namespace L1Analysis {
     const float lsb_eta = Phase2L1GMT::LSBeta;
     const float lsb_z0 = Phase2L1GMT::LSBGTz0;
     const float lsb_d0 = Phase2L1GMT::LSBGTd0;
-
+    const float lsb_SA_z0 = Phase2L1GMT::LSBSAz0;
+    const float lsb_SA_d0 = Phase2L1GMT::LSBSAd0;
 
   };
 }  // namespace L1Analysis

--- a/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc
@@ -623,21 +623,11 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtMuon(const edm::Handle<std::vecto
   for (unsigned int i = 0; i < gmtMuon->size() && l1extra_.nGmtMuons < maxL1Extra; i++) {
     if (lsb_pt * gmtMuon->at(i).hwPt() > 0) {
 
-/*std::cout<<Phase2L1GMT::LSBpt<<"  "<<lsb_pt * gmtMuon->at(i).hwPt()<<"   "<< gmtMuon->at(i).p4().pt()<<"    "<<gmtMuon->at(i).pt()<<std::endl;
-std::cout<<Phase2L1GMT::LSBeta<<"  "<<lsb_eta * gmtMuon->at(i).hwEta()<<"   "<< gmtMuon->at(i).p4().eta()<<"    "<<gmtMuon->at(i).eta()<<std::endl;
-std::cout<<Phase2L1GMT::LSBphi<<"  "<<lsb_phi * gmtMuon->at(i).hwPhi()<<"   "<< gmtMuon->at(i).p4().phi()<<"    "<<gmtMuon->at(i).phi()<<std::endl;
-*/
-
-/*      l1extra_.gmtMuonPt.push_back(lsb_pt * gmtMuon->at(i).hwPt());  //use pT
-      l1extra_.gmtMuonEta.push_back(lsb_eta * gmtMuon->at(i).hwEta());
-      l1extra_.gmtMuonPhi.push_back(lsb_phi * gmtMuon->at(i).hwPhi());
-*/
-      l1extra_.gmtMuonPt.push_back(gmtMuon->at(i).pt());
-      l1extra_.gmtMuonEta.push_back(gmtMuon->at(i).eta());
-      l1extra_.gmtMuonPhi.push_back(gmtMuon->at(i).phi());
-
-      l1extra_.gmtMuonZ0.push_back(lsb_z0 * gmtMuon->at(i).hwZ0());
-      l1extra_.gmtMuonD0.push_back(lsb_d0 * gmtMuon->at(i).hwD0());
+      l1extra_.gmtMuonPt.push_back(gmtMuon->at(i).phPt());
+      l1extra_.gmtMuonEta.push_back(gmtMuon->at(i).phEta());
+      l1extra_.gmtMuonPhi.push_back(gmtMuon->at(i).phPhi());
+      l1extra_.gmtMuonZ0.push_back(gmtMuon->at(i).phZ0());
+      l1extra_.gmtMuonD0.push_back(gmtMuon->at(i).phD0());
 
       l1extra_.gmtMuonIPt.push_back(gmtMuon->at(i).hwPt());  //rename?
       l1extra_.gmtMuonIEta.push_back(gmtMuon->at(i).hwEta());
@@ -662,27 +652,14 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtTkMuon(const edm::Handle<std::vec
   
                                                     unsigned maxL1Extra) {
 
-/*  const float lsb_pt = Phase2L1GMT::LSBpt;
-  const float lsb_phi = Phase2L1GMT::LSBphi;
-  const float lsb_eta = Phase2L1GMT::LSBeta;
-  const float lsb_z0 = Phase2L1GMT::LSBGTz0;
-  const float lsb_d0 = Phase2L1GMT::LSBGTd0;
-*/
-
   for (unsigned int i = 0; i < gmtTkMuon->size() && l1extra_.nGmtTkMuons < maxL1Extra; i++) {
     if (lsb_pt * gmtTkMuon->at(i).hwPt() > 0) {
 
-      /*std::cout<<Phase2L1GMT::LSBpt<<"  "<<lsb_pt * gmtTkMuon->at(i).hwPt()<<"   "<< gmtTkMuon->at(i).p4().pt()<<"    "<<gmtTkMuon->at(i).pt()<<std::endl;
-      std::cout<<Phase2L1GMT::LSBeta<<"  "<<lsb_eta * gmtTkMuon->at(i).hwEta()<<"   "<< gmtTkMuon->at(i).p4().eta()<<"    "<<gmtTkMuon->at(i).eta()<<std::endl;
-      std::cout<<Phase2L1GMT::LSBphi<<"  "<<lsb_phi * gmtTkMuon->at(i).hwPhi()<<"   "<< gmtTkMuon->at(i).p4().phi()<<"    "<<gmtTkMuon->at(i).phi()<<std::endl;
-      */
-
-      l1extra_.gmtTkMuonPt.push_back(gmtTkMuon->at(i).pt());
-      l1extra_.gmtTkMuonEta.push_back(gmtTkMuon->at(i).eta());
-      l1extra_.gmtTkMuonPhi.push_back(gmtTkMuon->at(i).phi());
-
-      l1extra_.gmtTkMuonZ0.push_back(lsb_z0 * gmtTkMuon->at(i).hwZ0());
-      l1extra_.gmtTkMuonD0.push_back(lsb_d0 * gmtTkMuon->at(i).hwD0());
+      l1extra_.gmtTkMuonPt.push_back(gmtTkMuon->at(i).phPt());
+      l1extra_.gmtTkMuonEta.push_back(gmtTkMuon->at(i).phEta());
+      l1extra_.gmtTkMuonPhi.push_back(gmtTkMuon->at(i).phPhi());
+      l1extra_.gmtTkMuonZ0.push_back(gmtTkMuon->at(i).phZ0());
+      l1extra_.gmtTkMuonD0.push_back(gmtTkMuon->at(i).phD0());
 
       l1extra_.gmtTkMuonIPt.push_back(gmtTkMuon->at(i).hwPt());  //rename?
       l1extra_.gmtTkMuonIEta.push_back(gmtTkMuon->at(i).hwEta());


### PR DESCRIPTION
Following the discussion between HLT ( @trtomei ) and @jheikkil, this PR adds physical values for Pt,Eta,Phi,D0,Z0 to the GMT Muons (SA and TK) with changes to their dataformats.

In the L1TNtuples we will keep the values of hwPt and the phPt (etc). 

I have checked this runs, and that the results seems sensible over 100 events, but I have not done a through validation. I will have little time to do so until the 8th of August. @zhenbinwu has looked at the additions to the dataformats and is OK with them.

Please do not merge this until Jaana says so :). 

