### PR TITLE
Create GTT to GT test vectors

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/etsums.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/etsums.h
@@ -1,0 +1,27 @@
+
+#ifndef L1Trigger_DemonstratorTools_codecs_EtSum_h
+#define L1Trigger_DemonstratorTools_codecs_EtSum_h
+
+#include <array>
+#include <vector>
+
+#include "ap_int.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeEtSum(const l1t::EtSum& v);
+
+  // Encodes EtSum collection onto 1 'logical' output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeEtSums(const edm::View<l1t::EtSum>&);
+
+  std::vector<l1t::EtSum> decodeEtSums(const std::vector<ap_uint<64>>&);
+
+}  // namespace l1t::demo::codecs
+
+#endif

--- a/L1Trigger/DemonstratorTools/interface/codecs/htsums.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/htsums.h
@@ -1,0 +1,27 @@
+
+#ifndef L1Trigger_DemonstratorTools_codecs_HtSum_h
+#define L1Trigger_DemonstratorTools_codecs_HtSum_h
+
+#include <array>
+#include <vector>
+
+#include "ap_int.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeHtSum(const l1t::EtSum& v);
+
+  // Encodes EtSum collection onto 1 'logical' output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>&);
+
+  std::vector<l1t::EtSum> decodeHtSums(const std::vector<ap_uint<64>>&);
+
+}  // namespace l1t::demo::codecs
+
+#endif

--- a/L1Trigger/DemonstratorTools/interface/codecs/tkjets.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tkjets.h
@@ -1,0 +1,27 @@
+
+#ifndef L1Trigger_DemonstratorTools_codecs_tkjets_h
+#define L1Trigger_DemonstratorTools_codecs_tkjets_h
+
+#include <array>
+#include <vector>
+
+#include "ap_int.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1TCorrelator/interface/TkJet.h"
+#include "DataFormats/L1TCorrelator/interface/TkJetFwd.h"
+#include "DataFormats/L1Trigger/interface/TkJetWord.h"
+#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeTkJet(const l1t::TkJetWord& t);
+
+  // Encodes TkJet collection onto 1 'logical' output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeTkJets(const edm::View<l1t::TkJetWord>&);
+
+  std::vector<l1t::TkJetWord> decodeTkJets(const std::vector<ap_uint<64>>&);
+
+}  // namespace l1t::demo::codecs
+
+#endif

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -213,8 +213,9 @@ void GTTFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
   l1t::demo::EventData eventDataGlobalTrigger;
   eventDataGlobalTrigger.add({"sums", 0}, sumsData);
-  eventDataGlobalTrigger.add({"taus", 1}, std::vector<ap_uint<64>>(18, 0)); // Placeholder until tau object is written
-  eventDataGlobalTrigger.add({"mesons", 2}, std::vector<ap_uint<64>>(39, 0)); // Placeholder until light meson objects are written
+  eventDataGlobalTrigger.add({"taus", 1}, std::vector<ap_uint<64>>(18, 0));  // Placeholder until tau object is written
+  eventDataGlobalTrigger.add({"mesons", 2},
+                             std::vector<ap_uint<64>>(39, 0));  // Placeholder until light meson objects are written
   eventDataGlobalTrigger.add({"vertices", 3}, tracksVerticesData);
 
   // 3) Pass the 'event data' object to the file writer

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -35,12 +35,16 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
 #include "DataFormats/L1Trigger/interface/VertexWord.h"
 #include "DataFormats/Common/interface/View.h"
 
 #include "L1Trigger/DemonstratorTools/interface/BoardDataWriter.h"
 #include "L1Trigger/DemonstratorTools/interface/codecs/tracks.h"
 #include "L1Trigger/DemonstratorTools/interface/codecs/vertices.h"
+#include "L1Trigger/DemonstratorTools/interface/codecs/tkjets.h"
+#include "L1Trigger/DemonstratorTools/interface/codecs/htsums.h"
+#include "L1Trigger/DemonstratorTools/interface/codecs/etsums.h"
 #include "L1Trigger/DemonstratorTools/interface/utilities.h"
 
 //
@@ -58,7 +62,11 @@ private:
   // NOTE: At least some of the info from these constants will eventually come from config files
   static constexpr size_t kFramesPerTMUXPeriod = 9;
   static constexpr size_t kGapLengthInput = 6;
-  static constexpr size_t kGapLengthOutput = 44;
+  static constexpr size_t kGapLengthOutputToCorrelator = 44;
+  static constexpr size_t kGapLengthOutputToGlobalTriggerSums = 3;
+  static constexpr size_t kGapLengthOutputToGlobalTriggerTaus = 36;
+  static constexpr size_t kGapLengthOutputToGlobalTriggerMesons = 15;
+  static constexpr size_t kGapLengthOutputToGlobalTriggerVertices = 6;
   static constexpr size_t kTrackTMUX = 18;
   static constexpr size_t kGTTBoardTMUX = 6;
   static constexpr size_t kMaxLinesPerFile = 1024;
@@ -91,7 +99,21 @@ private:
   const std::map<l1t::demo::LinkId, std::pair<l1t::demo::ChannelSpec, std::vector<size_t>>>
       kChannelSpecsOutputToCorrelator = {
           /* logical channel within time slice -> {{link TMUX, inter-packet gap}, vector of channel indices} */
-          {{"vertices", 0}, {{kGTTBoardTMUX, kGapLengthOutput}, {0}}}};
+          {{"vertices", 0}, {{kGTTBoardTMUX, kGapLengthOutputToCorrelator}, {0}}}};
+
+  const std::map<l1t::demo::LinkId, std::vector<size_t>> kChannelIdsOutputToGlobalTrigger = {
+      /* logical channel within time slice -> vector of channel indices (one entry per time slice) */
+      {{"sums", 0}, {0}},
+      {{"taus", 1}, {1}},
+      {{"mesons", 2}, {2}},
+      {{"vertices", 3}, {3}}};
+
+  const std::map<std::string, l1t::demo::ChannelSpec> kChannelSpecsOutputToGlobalTrigger = {
+      /* interface name -> {link TMUX, inter-packet gap} */
+      {"sums", {kGTTBoardTMUX, kGapLengthOutputToGlobalTriggerSums}},
+      {"taus", {kGTTBoardTMUX, kGapLengthOutputToGlobalTriggerTaus}},
+      {"mesons", {kGTTBoardTMUX, kGapLengthOutputToGlobalTriggerMesons}},
+      {"vertices", {kGTTBoardTMUX, kGapLengthOutputToGlobalTriggerVertices}}};
 
   typedef TTTrack<Ref_Phase2TrackerDigi_> Track_t;
 
@@ -103,10 +125,14 @@ private:
   edm::EDGetTokenT<edm::View<Track_t>> tracksToken_;
   edm::EDGetTokenT<edm::View<Track_t>> convertedTracksToken_;
   edm::EDGetTokenT<edm::View<l1t::VertexWord>> verticesToken_;
+  edm::EDGetTokenT<edm::View<l1t::TkJetWord>> jetsToken_;
+  edm::EDGetTokenT<edm::View<l1t::EtSum>> htMissToken_;
+  edm::EDGetTokenT<edm::View<l1t::EtSum>> etMissToken_;
 
   l1t::demo::BoardDataWriter fileWriterInputTracks_;
   l1t::demo::BoardDataWriter fileWriterConvertedTracks_;
   l1t::demo::BoardDataWriter fileWriterOutputToCorrelator_;
+  l1t::demo::BoardDataWriter fileWriterOutputToGlobalTrigger_;
 };
 
 //
@@ -118,6 +144,9 @@ GTTFileWriter::GTTFileWriter(const edm::ParameterSet& iConfig)
       convertedTracksToken_(
           consumes<edm::View<Track_t>>(iConfig.getUntrackedParameter<edm::InputTag>("convertedTracks"))),
       verticesToken_(consumes<edm::View<l1t::VertexWord>>(iConfig.getUntrackedParameter<edm::InputTag>("vertices"))),
+      jetsToken_(consumes<edm::View<l1t::TkJetWord>>(iConfig.getUntrackedParameter<edm::InputTag>("jets"))),
+      htMissToken_(consumes<edm::View<l1t::EtSum>>(iConfig.getUntrackedParameter<edm::InputTag>("htmiss"))),
+      etMissToken_(consumes<edm::View<l1t::EtSum>>(iConfig.getUntrackedParameter<edm::InputTag>("etmiss"))),
       fileWriterInputTracks_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                              iConfig.getUntrackedParameter<std::string>("inputFilename"),
                              kFramesPerTMUXPeriod,
@@ -133,22 +162,32 @@ GTTFileWriter::GTTFileWriter(const edm::ParameterSet& iConfig)
                                  kChannelIdsInput,
                                  kChannelSpecsInput),
       fileWriterOutputToCorrelator_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
-                                    iConfig.getUntrackedParameter<std::string>("outputFilename"),
+                                    iConfig.getUntrackedParameter<std::string>("outputCorrelatorFilename"),
                                     kFramesPerTMUXPeriod,
                                     kGTTBoardTMUX,
                                     kMaxLinesPerFile,
-                                    kChannelSpecsOutputToCorrelator) {}
+                                    kChannelSpecsOutputToCorrelator),
+      fileWriterOutputToGlobalTrigger_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
+                                       iConfig.getUntrackedParameter<std::string>("outputGlobalTriggerFilename"),
+                                       kFramesPerTMUXPeriod,
+                                       kGTTBoardTMUX,
+                                       kMaxLinesPerFile,
+                                       kChannelIdsOutputToGlobalTrigger,
+                                       kChannelSpecsOutputToGlobalTrigger) {}
 
 void GTTFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace l1t::demo::codecs;
 
-  // 1) Encode track information onto vectors containing link data
+  // 1) Encode 'object' information onto vectors containing link data
   const auto trackData(encodeTracks(iEvent.get(tracksToken_)));
   const auto convertedTrackData(encodeTracks(iEvent.get(convertedTracksToken_)));
-  const auto outputData(encodeVertices(iEvent.get(verticesToken_)));
+  const auto vertexData(encodeVertices(iEvent.get(verticesToken_)));
+  const auto jetsData(encodeTkJets(iEvent.get(jetsToken_)));
+  const auto htMissData(encodeHtSums(iEvent.get(htMissToken_)));
+  const auto etMissData(encodeEtSums(iEvent.get(etMissToken_)));
 
-  // 2) Pack track information into 'event data' object, and pass that to file writer
+  // 2) Pack 'object' information into 'event data' object
   l1t::demo::EventData eventDataTracks;
   l1t::demo::EventData eventDataConvertedTracks;
   for (size_t i = 0; i < 18; i++) {
@@ -157,11 +196,33 @@ void GTTFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   l1t::demo::EventData eventDataVertices;
-  eventDataVertices.add({"vertices", 0}, outputData.at(0));
+  eventDataVertices.add({"vertices", 0}, vertexData.at(0));
+
+  // 2b) For the global trigger 'event data' combine different objects into one 'logical' link
+  std::vector<ap_uint<64>> sumsData;
+  sumsData.insert(sumsData.end(), jetsData.at(0).begin(), jetsData.at(0).end());
+  sumsData.insert(sumsData.end(), 24, 0);
+  sumsData.insert(sumsData.end(), htMissData.at(0).begin(), htMissData.at(0).end());
+  sumsData.insert(sumsData.end(), 1, 0);
+  sumsData.insert(sumsData.end(), etMissData.at(0).begin(), etMissData.at(0).end());
+
+  std::vector<ap_uint<64>> tracksVerticesData;
+  tracksVerticesData.insert(tracksVerticesData.end(), 36, 0);
+  tracksVerticesData.insert(tracksVerticesData.end(), vertexData.at(0).begin(), vertexData.at(0).end());
+  tracksVerticesData.insert(tracksVerticesData.end(), 2, 0);
+
+  l1t::demo::EventData eventDataGlobalTrigger;
+  eventDataGlobalTrigger.add({"sums", 0}, sumsData);
+  eventDataGlobalTrigger.add({"taus", 1}, std::vector<ap_uint<64>>(18, 0)); // Placeholder until tau object is written
+  eventDataGlobalTrigger.add({"mesons", 2}, std::vector<ap_uint<64>>(39, 0)); // Placeholder until light meson objects are written
+  eventDataGlobalTrigger.add({"vertices", 3}, tracksVerticesData);
+
+  // 3) Pass the 'event data' object to the file writer
 
   fileWriterInputTracks_.addEvent(eventDataTracks);
   fileWriterConvertedTracks_.addEvent(eventDataConvertedTracks);
   fileWriterOutputToCorrelator_.addEvent(eventDataVertices);
+  fileWriterOutputToGlobalTrigger_.addEvent(eventDataGlobalTrigger);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
@@ -170,6 +231,7 @@ void GTTFileWriter::endJob() {
   fileWriterInputTracks_.flush();
   fileWriterConvertedTracks_.flush();
   fileWriterOutputToCorrelator_.flush();
+  fileWriterOutputToGlobalTrigger_.flush();
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -179,9 +241,13 @@ void GTTFileWriter::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
   desc.addUntracked<edm::InputTag>("convertedTracks", edm::InputTag("L1GTTInputProducer", "Level1TTTracksConverted"));
   desc.addUntracked<edm::InputTag>("vertices", edm::InputTag("VertexProducer", "l1verticesEmulation"));
+  desc.addUntracked<edm::InputTag>("jets", edm::InputTag("L1TrackJetsEmulation", "L1TrackJets"));
+  desc.addUntracked<edm::InputTag>("htmiss", edm::InputTag("L1TrackerEmuHTMiss", "L1TrackerEmuHTMiss"));
+  desc.addUntracked<edm::InputTag>("etmiss", edm::InputTag("L1TrackerEmuEtMiss", "L1TrackerEmuEtMiss"));
   desc.addUntracked<std::string>("inputFilename", "L1GTTInputFile");
   desc.addUntracked<std::string>("inputConvertedFilename", "L1GTTInputConvertedFile");
-  desc.addUntracked<std::string>("outputFilename", "L1GTTOutputToCorrelatorFile");
+  desc.addUntracked<std::string>("outputCorrelatorFilename", "L1GTTOutputToCorrelatorFile");
+  desc.addUntracked<std::string>("outputGlobalTriggerFilename", "L1GTTOutputToGlobalTriggerFile");
   desc.addUntracked<std::string>("format", "APx");
   descriptions.add("GTTFileWriter", desc);
 }

--- a/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
@@ -2,10 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 GTTFileWriter = cms.EDAnalyzer('GTTFileWriter',
   tracks = cms.untracked.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
-  convertedTracks = cms.untracked.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),
+  convertedTracks = cms.untracked.InputTag("L1GTTInputProducer", "Level1TTTracksConverted"),
   vertices = cms.untracked.InputTag("VertexProducer", "l1verticesEmulation"),
+  jets = cms.untracked.InputTag("L1TrackJetsEmulation","L1TrackJets"),
+  htmiss = cms.untracked.InputTag("L1TrackerEmuHTMiss", "L1TrackerEmuHTMiss"),
+  etmiss = cms.untracked.InputTag("L1TrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
   inputFilename = cms.untracked.string("L1GTTInputFile"),
   inputConvertedFilename = cms.untracked.string("L1GTTInputConvertedFile"),
-  outputFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
+  outputCorrelatorFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
+  outputGlobalTriggerFilename = cms.untracked.string("L1GTTOutputToGlobalTriggerFile"),
   format = cms.untracked.string("APx")
 )

--- a/L1Trigger/DemonstratorTools/src/BoardDataWriter.cc
+++ b/L1Trigger/DemonstratorTools/src/BoardDataWriter.cc
@@ -61,7 +61,7 @@ namespace l1t::demo {
     // Check that data is supplied for each channel
     for (const auto& [id, info] : channelMap_) {
       if (not eventData.has(id))
-        throw std::runtime_error("Event data for link " + id.interface + ", " + std::to_string(id.channel) +
+        throw std::runtime_error("Event data for link [" + id.interface + ", " + std::to_string(id.channel) +
                                  "] is missing.");
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -4,15 +4,13 @@
 namespace l1t::demo::codecs {
 
   ap_uint<64> encodeEtSum(const l1t::EtSum& etSum) {
-
-  	l1tmetemu::EtMiss etMiss;
-  	etMiss.Et = etSum.hwPt();
-  	etMiss.Phi = etSum.hwPhi();
-  	ap_uint<1> valid = (etSum.hwQual() > 0);
-  	ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
-  	ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
-  	return etSumWord;
-
+    l1tmetemu::EtMiss etMiss;
+    etMiss.Et = etSum.hwPt();
+    etMiss.Phi = etSum.hwPhi();
+    ap_uint<1> valid = (etSum.hwQual() > 0);
+    ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
+    ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
+    return etSumWord;
   }
 
   // Encodes etsum collection onto 1 output link
@@ -41,8 +39,12 @@ namespace l1t::demo::codecs {
         break;
 
       math::XYZTLorentzVector v(0, 0, 0, 0);
-      l1t::EtSum s(v, l1t::EtSum::EtSumType::kMissingEt, l1tmetemu::MET_t(x(1 + l1tmetemu::kMETSize, 1)).to_int(), 0,
-                   l1tmetemu::METphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(), 0);
+      l1t::EtSum s(v,
+                   l1t::EtSum::EtSumType::kMissingEt,
+                   l1tmetemu::MET_t(x(1 + l1tmetemu::kMETSize, 1)).to_int(),
+                   0,
+                   l1tmetemu::METphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(),
+                   0);
       etSums.push_back(s);
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -1,0 +1,52 @@
+
+#include "L1Trigger/DemonstratorTools/interface/codecs/etsums.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeEtSum(const l1t::EtSum& etSum) {
+
+  	l1tmetemu::EtMiss etMiss;
+  	etMiss.Et = etSum.hwPt();
+  	etMiss.Phi = etSum.hwPhi();
+  	ap_uint<1> valid = (etSum.hwQual() > 0);
+  	ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
+  	ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
+  	return etSumWord;
+
+  }
+
+  // Encodes etsum collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeEtSums(const edm::View<l1t::EtSum>& etSums) {
+    std::vector<ap_uint<64>> etSumWords;
+
+    for (const auto& etSum : etSums)
+      etSumWords.push_back(encodeEtSum(etSum));
+
+    std::array<std::vector<ap_uint<64>>, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad etsum vectors -> full packet length (48 frames, but only 1 etsum max)
+      etSumWords.resize(1, 0);
+      linkData.at(i) = etSumWords;
+    }
+
+    return linkData;
+  }
+
+  std::vector<l1t::EtSum> decodeEtSums(const std::vector<ap_uint<64>>& frames) {
+    std::vector<l1t::EtSum> etSums;
+
+    for (const auto& x : frames) {
+      if (not x.test(0))
+        break;
+
+      math::XYZTLorentzVector v(0, 0, 0, 0);
+      l1t::EtSum s(v, l1t::EtSum::EtSumType::kMissingEt, l1tmetemu::MET_t(x(1 + l1tmetemu::kMETSize, 1)).to_int(), 0,
+                   l1tmetemu::METphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(), 0);
+      etSums.push_back(s);
+    }
+
+    return etSums;
+  }
+
+}  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -3,39 +3,39 @@
 
 namespace l1t::demo::codecs {
 
-  ap_uint<64> encodeHtSum(const l1t::EtSum& etSum) {
+  ap_uint<64> encodeHtSum(const l1t::EtSum& htSum) {
 
-  	l1tmhtemu::EtMiss etMiss;
-  	etMiss.Et = etSum.p4().energy();
-  	etMiss.Phi = etSum.hwPhi();
-    l1tmhtemu::Et_t HT = etSum.hwPt();
-  	ap_uint<1> valid = (etSum.hwQual() > 0);
+  	l1tmhtemu::EtMiss htMiss;
+  	htMiss.Et = htSum.p4().energy();
+  	htMiss.Phi = htSum.hwPhi();
+    l1tmhtemu::Et_t HT = htSum.hwPt();
+  	ap_uint<1> valid = (htSum.hwQual() > 0);
   	ap_uint<64 - (l1tmhtemu::kHTSize + l1tmhtemu::kMHTSize + l1tmhtemu::kMHTPhiSize + 1)> unassigned = 0;
-  	ap_uint<64> etSumWord = (unassigned, HT, etMiss.Phi, etMiss.Et, valid);
-  	return etSumWord;
+  	ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
+  	return htSumWord;
 
   }
 
-  // Encodes etsum collection onto 1 output link
-  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>& etSums) {
-    std::vector<ap_uint<64>> etSumWords;
+  // Encodes htsum collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>& htSums) {
+    std::vector<ap_uint<64>> htSumWords;
 
-    for (const auto& etSum : etSums)
-      etSumWords.push_back(encodeHtSum(etSum));
+    for (const auto& htSum : htSums)
+      htSumWords.push_back(encodeHtSum(htSum));
 
     std::array<std::vector<ap_uint<64>>, 1> linkData;
 
     for (size_t i = 0; i < linkData.size(); i++) {
-      // Pad etsum vectors -> full packet length (48 frames, but only 1 etsum max)
-      etSumWords.resize(1, 0);
-      linkData.at(i) = etSumWords;
+      // Pad etsum vectors -> full packet length (48 frames, but only 1 htsum max)
+      htSumWords.resize(1, 0);
+      linkData.at(i) = htSumWords;
     }
 
     return linkData;
   }
 
   std::vector<l1t::EtSum> decodeHtSums(const std::vector<ap_uint<64>>& frames) {
-    std::vector<l1t::EtSum> etSums;
+    std::vector<l1t::EtSum> htSums;
 
     for (const auto& x : frames) {
       if (not x.test(0))
@@ -47,10 +47,10 @@ namespace l1t::demo::codecs {
                    l1tmhtemu::Et_t(x(l1tmhtemu::kHTSize + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1)).to_int(),
                    0,
                    l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTSize + 1)).to_int(), 0);
-      etSums.push_back(s);
+      htSums.push_back(s);
     }
 
-    return etSums;
+    return htSums;
   }
 
 }  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -1,0 +1,56 @@
+
+#include "L1Trigger/DemonstratorTools/interface/codecs/htsums.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeHtSum(const l1t::EtSum& etSum) {
+
+  	l1tmhtemu::EtMiss etMiss;
+  	etMiss.Et = etSum.p4().energy();
+  	etMiss.Phi = etSum.hwPhi();
+    l1tmhtemu::Et_t HT = etSum.hwPt();
+  	ap_uint<1> valid = (etSum.hwQual() > 0);
+  	ap_uint<64 - (l1tmhtemu::kHTSize + l1tmhtemu::kMHTSize + l1tmhtemu::kMHTPhiSize + 1)> unassigned = 0;
+  	ap_uint<64> etSumWord = (unassigned, HT, etMiss.Phi, etMiss.Et, valid);
+  	return etSumWord;
+
+  }
+
+  // Encodes etsum collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>& etSums) {
+    std::vector<ap_uint<64>> etSumWords;
+
+    for (const auto& etSum : etSums)
+      etSumWords.push_back(encodeHtSum(etSum));
+
+    std::array<std::vector<ap_uint<64>>, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad etsum vectors -> full packet length (48 frames, but only 1 etsum max)
+      etSumWords.resize(1, 0);
+      linkData.at(i) = etSumWords;
+    }
+
+    return linkData;
+  }
+
+  std::vector<l1t::EtSum> decodeHtSums(const std::vector<ap_uint<64>>& frames) {
+    std::vector<l1t::EtSum> etSums;
+
+    for (const auto& x : frames) {
+      if (not x.test(0))
+        break;
+
+      math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTSize + 1, 1)).to_int());
+      l1t::EtSum s(v,
+                   l1t::EtSum::EtSumType::kMissingHt,
+                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTSize + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1)).to_int(),
+                   0,
+                   l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTSize + 1)).to_int(), 0);
+      etSums.push_back(s);
+    }
+
+    return etSums;
+  }
+
+}  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -4,16 +4,14 @@
 namespace l1t::demo::codecs {
 
   ap_uint<64> encodeHtSum(const l1t::EtSum& htSum) {
-
-  	l1tmhtemu::EtMiss htMiss;
-  	htMiss.Et = htSum.p4().energy();
-  	htMiss.Phi = htSum.hwPhi();
+    l1tmhtemu::EtMiss htMiss;
+    htMiss.Et = htSum.p4().energy();
+    htMiss.Phi = htSum.hwPhi();
     l1tmhtemu::Et_t HT = htSum.hwPt();
-  	ap_uint<1> valid = (htSum.hwQual() > 0);
-  	ap_uint<64 - (l1tmhtemu::kHTSize + l1tmhtemu::kMHTSize + l1tmhtemu::kMHTPhiSize + 1)> unassigned = 0;
-  	ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
-  	return htSumWord;
-
+    ap_uint<l1tmhtemu::kValidSize> valid = (htSum.hwQual() > 0);
+    ap_uint<l1tmhtemu::kUnassignedSize> unassigned = 0;
+    ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
+    return htSumWord;
   }
 
   // Encodes htsum collection onto 1 output link
@@ -41,12 +39,13 @@ namespace l1t::demo::codecs {
       if (not x.test(0))
         break;
 
-      math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTSize + 1, 1)).to_int());
+      math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTMSB, l1tmhtemu::kMHTLSB)).to_int());
       l1t::EtSum s(v,
                    l1t::EtSum::EtSumType::kMissingHt,
-                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTSize + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1)).to_int(),
+                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTMSB, l1tmhtemu::kHTLSB)).to_int(),
                    0,
-                   l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTSize + 1)).to_int(), 0);
+                   l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiMSB, l1tmhtemu::kMHTPhiLSB)).to_int(),
+                   0);
       htSums.push_back(s);
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
@@ -35,12 +35,12 @@ namespace l1t::demo::codecs {
       //  break;
 
       TkJetWord j(TkJetWord::pt_t(frames[f](TkJetWord::kPtMSB, TkJetWord::kPtLSB)),
-                   TkJetWord::glbeta_t(frames[f](TkJetWord::kGlbEtaMSB, TkJetWord::kGlbEtaLSB)),
-                   TkJetWord::glbphi_t(frames[f](TkJetWord::kGlbPhiMSB, TkJetWord::kGlbPhiLSB)),
-                   TkJetWord::z0_t(frames[f](TkJetWord::kZ0MSB, TkJetWord::kZ0LSB)),
-                   TkJetWord::nt_t(frames[f](TkJetWord::kNtMSB, TkJetWord::kNtLSB)),
-                   TkJetWord::nx_t(frames[f](TkJetWord::kXtMSB, TkJetWord::kXtLSB)),
-                   TkJetWord::tkjetunassigned_t(frames[f](TkJetWord::kUnassignedMSB, TkJetWord::kUnassignedLSB)));
+                  TkJetWord::glbeta_t(frames[f](TkJetWord::kGlbEtaMSB, TkJetWord::kGlbEtaLSB)),
+                  TkJetWord::glbphi_t(frames[f](TkJetWord::kGlbPhiMSB, TkJetWord::kGlbPhiLSB)),
+                  TkJetWord::z0_t(frames[f](TkJetWord::kZ0MSB, TkJetWord::kZ0LSB)),
+                  TkJetWord::nt_t(frames[f](TkJetWord::kNtMSB, TkJetWord::kNtLSB)),
+                  TkJetWord::nx_t(frames[f](TkJetWord::kXtMSB, TkJetWord::kXtLSB)),
+                  TkJetWord::tkjetunassigned_t(frames[f](TkJetWord::kUnassignedMSB, TkJetWord::kUnassignedLSB)));
       tkJets.push_back(j);
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
@@ -1,0 +1,50 @@
+
+#include "L1Trigger/DemonstratorTools/interface/codecs/tkjets.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeTkJet(const l1t::TkJetWord& j) { return j.tkJetWord(); }
+
+  // Encodes vertex collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeTkJets(const edm::View<l1t::TkJetWord>& tkJets) {
+    std::vector<ap_uint<64>> tkJetWords;
+
+    for (const auto& tkJet : tkJets) {
+      tkJetWords.push_back(encodeTkJet(tkJet));
+      tkJetWords.push_back(ap_uint<64>(0));
+    }
+
+    std::array<std::vector<ap_uint<64>>, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad TkJet vectors -> full packet length (48 frames, but only 12 TkJets max, two words per jet)
+      tkJetWords.resize(24, 0);
+      linkData.at(i) = tkJetWords;
+    }
+
+    return linkData;
+  }
+
+  std::vector<l1t::TkJetWord> decodeTkJets(const std::vector<ap_uint<64>>& frames) {
+    std::vector<l1t::TkJetWord> tkJets;
+
+    for (size_t f = 0; f < frames.size(); f += 2) {
+      // There is no valid bit in the definition right now.
+      // Uncomment the next two lines when this is available.
+      //if (not x.test(TkJetWord::kValidLSB))
+      //  break;
+
+      TkJetWord j(TkJetWord::pt_t(frames[f](TkJetWord::kPtMSB, TkJetWord::kPtLSB)),
+                   TkJetWord::glbeta_t(frames[f](TkJetWord::kGlbEtaMSB, TkJetWord::kGlbEtaLSB)),
+                   TkJetWord::glbphi_t(frames[f](TkJetWord::kGlbPhiMSB, TkJetWord::kGlbPhiLSB)),
+                   TkJetWord::z0_t(frames[f](TkJetWord::kZ0MSB, TkJetWord::kZ0LSB)),
+                   TkJetWord::nt_t(frames[f](TkJetWord::kNtMSB, TkJetWord::kNtLSB)),
+                   TkJetWord::nx_t(frames[f](TkJetWord::kXtMSB, TkJetWord::kXtLSB)),
+                   TkJetWord::tkjetunassigned_t(frames[f](TkJetWord::kUnassignedMSB, TkJetWord::kUnassignedLSB)));
+      tkJets.push_back(j);
+    }
+
+    return tkJets;
+  }
+
+}  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -64,6 +64,10 @@ process.options = cms.untracked.PSet(
 
 process.load('L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi')
 process.load('L1Trigger.VertexFinder.VertexProducer_cff')
+process.load("L1Trigger.L1TTrackMatch.L1TrackSelectionProducer_cfi")
+process.load("L1Trigger.L1TTrackMatch.L1TrackJetEmulationProducer_cfi")
+process.load("L1Trigger.L1TTrackMatch.L1TkHTMissEmulatorProducer_cfi")
+process.load("L1Trigger.L1TTrackMatch.L1TrackerEtMissEmulatorProducer_cfi")
 process.load('L1Trigger.DemonstratorTools.GTTFileWriter_cff')
 
 process.L1GTTInputProducer.debug = cms.int32(options.debug)
@@ -71,6 +75,11 @@ process.VertexProducer.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Lev
 process.VertexProducer.VertexReconstruction.Algorithm = cms.string("fastHistoEmulation")
 process.VertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.VertexProducer.debug = options.debug
+process.L1TrackSelectionProducer.processSimulatedTracks = cms.bool(False)
+process.L1TrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+process.L1TrackJetsEmulation.VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)
 
@@ -80,4 +89,4 @@ process.GTTFileWriter.format = cms.untracked.string(options.format)
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.L1GTTInputProducer * process.VertexProducer * process.GTTFileWriter)
+process.p = cms.Path(process.L1GTTInputProducer * process.VertexProducer * process.L1TrackSelectionProducer * process.L1TrackJetsEmulation * process.L1TrackerEmuHTMiss * process.L1TrackerEmuEtMiss * process.GTTFileWriter)

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -27,10 +27,27 @@ namespace l1tmhtemu {
   // extra room for sumPx, sumPy
   const unsigned int kEtExtra{10};
 
+  const unsigned int kValidSize{1};
   const unsigned int kMHTSize{15};     // For output Magnitude default 15
   const unsigned int kMHTPhiSize{14};  // For output Phi default 14
   const unsigned int kHTSize{kInternalPtWidth + kEtExtra};
-  const float kMaxMHT{4096};           // 4 TeV
+  const unsigned int kUnassignedSize{64 - (kHTSize + kMHTSize + kMHTPhiSize + kValidSize)};
+
+  enum BitLocations {
+    // The location of the least significant bit (LSB) and most significant bit (MSB) in the sum word for different fields
+    kValidLSB = 0,
+    kValidMSB = kValidLSB + kValidSize - 1,
+    kMHTLSB = kValidMSB + 1,
+    kMHTMSB = kMHTLSB + kMHTSize - 1,
+    kMHTPhiLSB = kMHTMSB + 1,
+    kMHTPhiMSB = kMHTPhiLSB + kMHTPhiSize - 1,
+    kHTLSB = kMHTPhiMSB + 1,
+    kHTMSB = kHTLSB + kHTSize - 1,
+    kUnassignedLSB = kHTMSB + 1,
+    kUnassignedMSB = kUnassignedLSB + kUnassignedSize - 1
+  };
+
+  const float kMaxMHT{4096};  // 4 TeV
   const float kMaxMHTPhi{2 * M_PI};
 
   typedef ap_uint<5> ntracks_t;

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -29,6 +29,7 @@ namespace l1tmhtemu {
 
   const unsigned int kMHTSize{15};     // For output Magnitude default 15
   const unsigned int kMHTPhiSize{14};  // For output Phi default 14
+  const unsigned int kHTSize{kInternalPtWidth + kEtExtra};
   const float kMaxMHT{4096};           // 4 TeV
   const float kMaxMHTPhi{2 * M_PI};
 
@@ -37,7 +38,7 @@ namespace l1tmhtemu {
   typedef ap_int<kInternalEtaWidth> eta_t;
   typedef ap_int<kInternalPhiWidth> phi_t;
 
-  typedef ap_int<kInternalPtWidth + kEtExtra> Et_t;
+  typedef ap_int<kHTSize> Et_t;
   typedef ap_uint<kMHTSize> MHT_t;
   typedef ap_uint<kMHTPhiSize> MHTphi_t;
 

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2395,19 +2395,17 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
 
   if (SaveTrackSums) {
     if (Displaced == "Prompt" || Displaced == "Both") {
-      if (L1TkMETHandle.isValid()){
+      if (L1TkMETHandle.isValid()) {
         trkMET = L1TkMETHandle->begin()->etMiss();
         trkMETPhi = L1TkMETHandle->begin()->p4().phi();
-      }
-      else {
+      } else {
         edm::LogWarning("DataNotFound") << "\nWarning: tkMET handle not found" << std::endl;
       }
 
       if (L1TkMETEmuHandle.isValid()) {
         trkMETEmu = L1TkMETEmuHandle->begin()->hwPt() * l1tmetemu::kStepMET;
         trkMETEmuPhi = L1TkMETEmuHandle->begin()->hwPhi() * l1tmetemu::kStepMETPhi - M_PI;
-      }
-      else {
+      } else {
         edm::LogWarning("DataNotFound") << "\nWarning: tkMETEmu handle not found" << std::endl;
       }
 
@@ -2429,8 +2427,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       if (L1TkMETExtendedHandle.isValid()) {
         trkMETExt = L1TkMETExtendedHandle->begin()->etMiss();
         trkMETPhiExt = L1TkMETExtendedHandle->begin()->p4().phi();
-      }
-      else {
+      } else {
         edm::LogWarning("DataNotFound") << "\nWarning: tkMETExtended handle not found" << std::endl;
       }
 

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -111,6 +111,7 @@ process.pPV = cms.Path(process.L1VertexFinder)
 process.L1VertexFinderEmulator = process.VertexProducer.clone()
 process.L1VertexFinderEmulator.VertexReconstruction.Algorithm = "fastHistoEmulation"
 process.L1VertexFinderEmulator.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted")
+process.L1VertexFinderEmulator.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.pPVemu = cms.Path(process.L1VertexFinderEmulator)
 
 process.L1TrackFastJets.L1PrimaryVertexTag = cms.InputTag("L1VertexFinder", "l1vertices")


### PR DESCRIPTION
#### PR description:

This PR adds to the DemonstratorTools package the ability to write test vectors for the GTT to GT links. This is in addition to the existing files which contain the TF to GTT inputs, the converted track words created by the GTT common framework, and the GTT to Correlator Layer 1 link. Following the interface document, there are 4 links in total represented in these new files. The links contain words for jets/sums, hadronic taus, light mesons, and isolated tracks/vertices. Some of the formats specified in the interface document have not been written yet. In those cases, 64-bit packets willed with 0s were added in place of the words.

In order to check that the 64-bit hexadecimal packets written to the file were correct, a few more branches were added to the L1TrackObjectsNtuple.

#### PR validation:

A set of test vectors was created for the GTT. These test vectors were then compared to the emulator outputs saved in the L1TrackObjectNtuples. I checked by hand that the hexadecimal values saved in the test vectors corresponded to the floating point values saved in the ROOT ntuple (after appropriate un-digitization). I also compared these values to the floating point simulation values in the ROOT ntuple to make sure the simulation and emulation values were close. Everything seems to check out. 

The code has also passed the recommended code checks:
```bash
scram b code-checks
scram b code-format
```
