### PR TITLE
Modify the TF to GTT Link Ordering

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -31,7 +31,7 @@ namespace l1t::demo::codecs {
       const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
       const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);
 
-  // Encodes track collection onto 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
+  // Encodes track collection onto 18 'logical' output links (2x9 eta-phi sectors; -/+ eta pairs)
   std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>&,
                                                         int debug = 0);
 
@@ -45,7 +45,7 @@ namespace l1t::demo::codecs {
   // Decodes the tracks for a single link
   std::vector<TTTrack_TrackWord> decodeTracks(const std::vector<ap_uint<64>>&);
 
-  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
+  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; , -/+ eta pairs)
   std::array<std::vector<TTTrack_TrackWord>, 18> decodeTracks(const std::array<std::vector<ap_uint<64>>, 18>&);
 
 }  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -24,7 +24,7 @@ namespace l1t::demo::codecs {
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (const auto& track : tracks) {
-      trackWords.at((track.eta() >= 0 ? 9 : 0) + track.phiSector()).push_back(encodeTrack(track));
+      trackWords.at((track.eta() >= 0 ? 1 : 0) + (2 * track.phiSector())).push_back(encodeTrack(track));
     }
     return trackWords;
   }
@@ -39,10 +39,10 @@ namespace l1t::demo::codecs {
       edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
       if (trackInCollection(referenceTrackRef, tracks)) {
-        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector())
+        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector()))
             .push_back(encodeTrack(referenceTrack));
       } else {
-        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector()).push_back(ap_uint<96>(0));
+        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector())).push_back(ap_uint<96>(0));
       }
     }
     return trackWords;
@@ -68,7 +68,7 @@ namespace l1t::demo::codecs {
     return counter;
   }
 
-  // Encodes track collection onto 18 output links (2x9 eta-phi sectors; first 9 negative eta)
+  // Encodes track collection onto 18 output links (2x9 eta-phi sectors; , -/+ eta pairs)
   std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks,
                                                         int debug) {
     if (debug > 0) {
@@ -157,6 +157,7 @@ namespace l1t::demo::codecs {
     return tracks;
   }
 
+  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; , -/+ eta pairs)
   std::array<std::vector<TTTrack_TrackWord>, 18> decodeTracks(const std::array<std::vector<ap_uint<64>>, 18>& frames) {
     std::array<std::vector<TTTrack_TrackWord>, 18> tracks;
 

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -79,6 +79,7 @@ process.L1TrackSelectionProducer.processSimulatedTracks = cms.bool(False)
 process.L1TrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
 process.L1TrackJetsEmulation.VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
 process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+process.L1TrackerEmuEtMiss.debug = options.debug
 
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -272,11 +272,13 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
       sumPy[link_number] += temppy;
       if (debug_ == 4) {
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
-              << "Sector: " << EtTrack.Sector << " Eta: " << EtTrack.EtaSector << "\n"
-              << "Int Track Px: " << temppx << " Int Track Py: " << temppy << "\n"
-              << "Float Track Px: " << (float)temppx * l1tmetemu::kStepPt << " Float Track Py:" << (float)temppy * l1tmetemu::kStepPt << "\n"
-              << "Int Sector Sum Px: " << sumPx[link_number] << " Int Sector Sum Py: " << sumPy[link_number] << "\n"
-              << "Float Sector Sum Px: " << (float)sumPx[link_number] * l1tmetemu::kStepPt << " Float Sector Sum Py: " << (float) sumPy[link_number] * l1tmetemu::kStepPt << "\n";
+            << "Sector: " << EtTrack.Sector << " Eta: " << EtTrack.EtaSector << "\n"
+            << "Int Track Px: " << temppx << " Int Track Py: " << temppy << "\n"
+            << "Float Track Px: " << (float)temppx * l1tmetemu::kStepPt
+            << " Float Track Py:" << (float)temppy * l1tmetemu::kStepPt << "\n"
+            << "Int Sector Sum Px: " << sumPx[link_number] << " Int Sector Sum Py: " << sumPy[link_number] << "\n"
+            << "Float Sector Sum Px: " << (float)sumPx[link_number] * l1tmetemu::kStepPt
+            << " Float Sector Sum Py: " << (float)sumPy[link_number] * l1tmetemu::kStepPt << "\n";
       }
     }
 
@@ -338,7 +340,8 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
     edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
         << "====Sector Pt====\n"
         << "Float Px: " << flpxarray.str() << "\nFloat Py: " << flpyarray.str() << "\nInteger Px: " << intpyarray.str()
-        << "\nInteger Px: " << intpyarray.str() << "\nLink Totals: " << linksarray.str() << "\nSector Totals: " << totalsarray.str() << "\n"
+        << "\nInteger Px: " << intpyarray.str() << "\nLink Totals: " << linksarray.str()
+        << "\nSector Totals: " << totalsarray.str() << "\n"
 
         << "====Global Pt====\n"
         << "Integer Global Px: " << GlobalPx << "| Integer Global Py: " << GlobalPy << "\n"


### PR DESCRIPTION
#### PR description:

Right now the L1TrackerEtMissEmulationProducer and the DemonstratorTools package assume a TF to GTT link ordering of the 18 links to have the first 9 be from all of the phi sectors and to care the -eta tracks. The second 9 links would carry the positive eta tracks. However, the GTT firmware and the TF group have been assuming that the -eta and +eta links would be paired, where the first two carry -eta and +eta for sector 0, the second pair does the same for sector 1, and so on. This PR converts the code to using the latter scheme.

#### PR validation:

A set of test vectors was created to make sure that only the files printing the tracks changes, and in the expected way. This also allowed me to check that the MET  word didn't change.

The code has also passed the recommended code checks:
```
scram b code-checks
scram b code-format
```

Prerequisites

This PR needs to be rebased on top of https://github.com/cms-l1t-offline/cmssw/pull/1042 and https://github.com/cms-l1t-offline/cmssw/pull/1043 before it will be ready for review.