### PR TITLE
Update Track MET and MHT Output 

### DIFF
--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -5,11 +5,11 @@ namespace l1t::demo::codecs {
 
   ap_uint<64> encodeEtSum(const l1t::EtSum& etSum) {
     l1tmetemu::EtMiss etMiss;
-    etMiss.Et = etSum.hwPt();
+    ap_uint<l1tmetemu::kMETSize> ET = etSum.hwPt();
     etMiss.Phi = etSum.hwPhi();
     ap_uint<1> valid = (etSum.hwQual() > 0);
     ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
-    ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
+    ap_uint<64> etSumWord = (unassigned, etMiss.Phi, ET, valid);
     return etSumWord;
   }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -5,11 +5,11 @@ namespace l1t::demo::codecs {
 
   ap_uint<64> encodeEtSum(const l1t::EtSum& etSum) {
     l1tmetemu::EtMiss etMiss;
-    ap_uint<l1tmetemu::kMETSize> ET = etSum.hwPt();
+    etMiss.Et.V = etSum.hwPt();
     etMiss.Phi = etSum.hwPhi();
     ap_uint<1> valid = (etSum.hwQual() > 0);
     ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
-    ap_uint<64> etSumWord = (unassigned, etMiss.Phi, ET, valid);
+    ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et.range(), valid);
     return etSumWord;
   }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -6,11 +6,12 @@ namespace l1t::demo::codecs {
   ap_uint<64> encodeHtSum(const l1t::EtSum& htSum) {
     l1tmhtemu::EtMiss htMiss;
     htMiss.Et = htSum.p4().energy();
+    ap_uint<l1tmhtemu::kMHTSize> ET = htMiss.Et.to_uint();
     htMiss.Phi = htSum.hwPhi();
-    l1tmhtemu::Et_t HT = htSum.hwPt();
+    ap_uint<l1tmhtemu::kMHTSize> HT = htSum.hwPt();
     ap_uint<l1tmhtemu::kValidSize> valid = (htSum.hwQual() > 0);
     ap_uint<l1tmhtemu::kUnassignedSize> unassigned = 0;
-    ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
+    ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, ET, valid);
     return htSumWord;
   }
 
@@ -42,7 +43,7 @@ namespace l1t::demo::codecs {
       math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTMSB, l1tmhtemu::kMHTLSB)).to_int());
       l1t::EtSum s(v,
                    l1t::EtSum::EtSumType::kMissingHt,
-                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTMSB, l1tmhtemu::kHTLSB)).to_int(),
+                   l1tmhtemu::MHT_t(x(l1tmhtemu::kHTMSB, l1tmhtemu::kHTLSB)).to_int(),
                    0,
                    l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiMSB, l1tmhtemu::kMHTPhiLSB)).to_int(),
                    0);

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -40,12 +40,14 @@ namespace l1tmetemu {
   typedef ap_int<kInternalPtWidth + kEtExtra> Et_t;
 
   //Output format
-  const float kMaxMET{4096};  // 4 TeV
+  const float kMaxMET{2048};  // 2 TeV
   const float kMaxMETPhi{2 * M_PI};
-  const unsigned int kMETSize{15};     // For output Magnitude default 15
-  const unsigned int kMETPhiSize{14};  // For Output Phi default 14
+  const unsigned int kMETSize{16};     // For output Magnitude default 16
+  const unsigned int kMETPhiSize{13};  // For Output Phi default 13
+  // Output definition as per interface document, only used when creating output format
+  const unsigned int kMETIntSize{11};
 
-  typedef ap_uint<kMETSize> MET_t;
+  typedef ap_ufixed<kMETSize,kMETIntSize> MET_t;
   // Cordic means this is evaluated between 0 and 2Pi rather than -pi to pi so
   // unsigned
   typedef ap_uint<kMETPhiSize> METphi_t;

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -8,7 +8,7 @@
 
 #include <cmath>
 #include <cstdint>
-#include <filesystem>
+#iniclude <filesystem>
 #include <fstream>
 #include <iostream>
 #include <numeric>
@@ -28,8 +28,9 @@ namespace l1tmhtemu {
   const unsigned int kEtExtra{10};
 
   const unsigned int kValidSize{1};
-  const unsigned int kMHTSize{15};     // For output Magnitude default 15
-  const unsigned int kMHTPhiSize{14};  // For output Phi default 14
+  const unsigned int kMHTSize{16};     // For output Magnitude default 16
+  const unsigned int kMHTIntSize{11};  // For output Integer default 11
+  const unsigned int kMHTPhiSize{13};  // For output Phi default 13
   const unsigned int kHTSize{kInternalPtWidth + kEtExtra};
   const unsigned int kUnassignedSize{64 - (kHTSize + kMHTSize + kMHTPhiSize + kValidSize)};
 
@@ -47,7 +48,7 @@ namespace l1tmhtemu {
     kUnassignedMSB = kUnassignedLSB + kUnassignedSize - 1
   };
 
-  const float kMaxMHT{4096};  // 4 TeV
+  const float kMaxMHT{2048};  // 4 TeV
   const float kMaxMHTPhi{2 * M_PI};
 
   typedef ap_uint<5> ntracks_t;
@@ -56,7 +57,7 @@ namespace l1tmhtemu {
   typedef ap_int<kInternalPhiWidth> phi_t;
 
   typedef ap_int<kHTSize> Et_t;
-  typedef ap_uint<kMHTSize> MHT_t;
+  typedef ap_ufixed<kMHTSize,kMHTIntSize> MHT_t;
   typedef ap_uint<kMHTPhiSize> MHTphi_t;
 
   const unsigned int kMHTBins = 1 << kMHTSize;
@@ -175,9 +176,8 @@ namespace l1tmhtemu {
       phi = new_phi;
     }
 
-    float sqrtval = (float(x * magNormalisationLUT[cordicSteps - 1]) / float(kMHTBins)) * float(kStepPt * kStepPhi);
-
-    ret_etmiss.Et = std::floor(sqrtval / l1tmhtemu::kStepMHT);
+    float sqrtval = (float(x * magNormalisationLUT[cordicSteps - 1]) / (float)kMHTBins) * float(kStepPt * kStepPhi);
+    ret_etmiss.Et = sqrtval;
     ret_etmiss.Phi = phi;
 
     return ret_etmiss;

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -8,7 +8,7 @@
 
 #include <cmath>
 #include <cstdint>
-#iniclude <filesystem>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <numeric>

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
@@ -126,7 +126,7 @@ void L1TkHTMissEmulatorProducer::produce(edm::Event& iEvent, const edm::EventSet
 
   l1tmhtemu::Et_t sumPx = 0;
   l1tmhtemu::Et_t sumPy = 0;
-  l1tmhtemu::Et_t HT = 0;
+  l1tmhtemu::MHT_t HT = 0;
 
   // loop over jets
   int jetn = 0;
@@ -250,12 +250,14 @@ void L1TkHTMissEmulatorProducer::produce(edm::Event& iEvent, const edm::EventSet
         << "====MHT AP_INTS TO FLOATS====\n"
         << "sumPx: " << (float)sumPx * l1tmhtemu::kStepPt * l1tmhtemu::kStepPhi
         << "| sumPy: " << (float)sumPy * l1tmhtemu::kStepPt * l1tmhtemu::kStepPhi
-        << "| ET: " << (float)EtMiss.Et * l1tmhtemu::kStepMHT << "| HT: " << (float)HT * l1tmhtemu::kStepPt
+        << "| ET: " << EtMiss.Et.to_double() << "| HT: " << (float)HT * l1tmhtemu::kStepPt
         << "| PHI: " << (float)phi * l1tmhtemu::kStepMHTPhi - M_PI << "\n"
         << "-------------------------------------------------------------------------\n";
   }
+  //rescale HT to correct output range
+  HT = HT / (int)(1/l1tmhtemu::kStepPt);
 
-  EtSum L1HTSum(missingEt, EtSum::EtSumType::kMissingHt, (int)HT, 0, (int)phi, (int)jetn);
+  EtSum L1HTSum(missingEt, EtSum::EtSumType::kMissingHt, (int)HT.range(), 0, (int)phi, (int)jetn);
 
   MHTCollection->push_back(L1HTSum);
   iEvent.put(std::move(MHTCollection), L1MHTCollectionName_);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -63,8 +63,6 @@ private:
   std::vector<l1tmetemu::global_phi_t> phiQuadrants_;
   std::vector<l1tmetemu::global_phi_t> phiShifts_;
 
-  l1tmetemu::z_t deltaZ0_ = 0;
-
   int cordicSteps_;
   int debug_;
   bool cordicDebug_ = false;
@@ -316,44 +314,31 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
   else if ((GlobalPx < 0) && (GlobalPy >= 0))
     tempPhi = EtMiss.Phi - 3 * l1tmetemu::kMETPhiBins / 2;
 
-  if (debug_ == 4 || debug_ == 6) {
-    std::stringstream flpxarray;
-    std::stringstream flpyarray;
+  if (debug_ == 6) {
 
-    std::stringstream intpxarray;
-    std::stringstream intpyarray;
-
-    std::stringstream totalsarray;
-    std::stringstream linksarray;
+    edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
+        << "====Sector Pt====\n";
 
     for (unsigned int i = 0; i < l1tmetemu::kNSector * 2; i++) {
-      flpxarray << to_string(sumPx[i] * l1tmetemu::kStepPt) + "|";
-      flpyarray << to_string(sumPy[i] * l1tmetemu::kStepPt) + "|";
-      intpxarray << to_string(floor((float)sumPx[i] / (float)l1tmetemu::kGlobalPhiBins)) + "|";
-      intpyarray << to_string(floor((float)sumPy[i] / (float)l1tmetemu::kGlobalPhiBins)) + "|";
-      linksarray << to_string(link_totals[i]) + "|";
-      if (i < l1tmetemu::kNSector) {
-        totalsarray << to_string(sector_totals[i]) + "|";
-      }
+
+      edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
+        << "Sector " << i << "\n"
+        << "Float Px: " << sumPx[i] * l1tmetemu::kStepPt << " | Float Py: " << sumPy[i] * l1tmetemu::kStepPt 
+        << " | Integer Px: " << floor((float)sumPx[i] / (float)l1tmetemu::kGlobalPhiBins)
+        << " | Integer Py: " << floor((float)sumPy[i] / (float)l1tmetemu::kGlobalPhiBins) 
+        << " | Sector Totals: " << sector_totals[(int)(i/2)] << "\n";
     }
 
     edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
-        << "====Sector Pt====\n"
-        << "Float Px: " << flpxarray.str() << "\nFloat Py: " << flpyarray.str() << "\nInteger Px: " << intpyarray.str()
-        << "\nInteger Px: " << intpyarray.str() << "\nLink Totals: " << linksarray.str()
-        << "\nSector Totals: " << totalsarray.str() << "\n"
-
         << "====Global Pt====\n"
         << "Integer Global Px: " << GlobalPx << "| Integer Global Py: " << GlobalPy << "\n"
         << "Float Global Px: " << GlobalPx * l1tmetemu::kStepPt
         << "| Float Global Py: " << GlobalPy * l1tmetemu::kStepPt << "\n";
-  }
 
-  if (debug_ == 4 || debug_ == 6) {
     edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
         << "====MET===\n"
         << "Integer MET: " << EtMiss.Et << "| Integer MET phi: " << EtMiss.Phi << "\n"
-        << "Float MET: " << (EtMiss.Et) * l1tmetemu::kStepMET
+        << "Float MET: " << EtMiss.Et.to_double() 
         << "| Float MET phi: " << (float)tempPhi * l1tmetemu::kStepMETPhi - M_PI << "\n"
         << "# Tracks after Quality Cuts: " << num_quality_tracks << "\n"
         << "# Tracks Associated to Vertex: " << num_assoc_tracks << "\n"
@@ -361,7 +346,7 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
   }
 
   math::XYZTLorentzVector missingEt(-GlobalPx, -GlobalPy, 0, EtMiss.Et);
-  EtSum L1EtSum(missingEt, EtSum::EtSumType::kMissingEt, (int)EtMiss.Et, 0, (int)tempPhi, (int)num_assoc_tracks);
+  EtSum L1EtSum(missingEt, EtSum::EtSumType::kMissingEt, (int)EtMiss.Et.range(), 0, (int)tempPhi, (int)num_assoc_tracks);
 
   METCollection->push_back(L1EtSum);
 

--- a/L1Trigger/L1TTrackMatch/src/Cordic.cc
+++ b/L1Trigger/L1TTrackMatch/src/Cordic.cc
@@ -104,7 +104,7 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
 
   // emulate fw rounding with float division then floor
   float tempMET = (float)(x * magNormalisationLUT[cordicSteps - 1] * kMaxTrackPt) / ((float)kMaxMET);
-  ret_etmiss.Et = (int)floor(tempMET) >> (mMagnitudeBits + TTTrack_TrackWord::TrackBitWidths::kRinvSize - kMETSize);
+  ret_etmiss.Et = tempMET / pow(2,(mMagnitudeBits + TTTrack_TrackWord::TrackBitWidths::kRinvSize - kMETIntSize ));
   ret_etmiss.Phi = phi;
   return ret_etmiss;
 }

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2416,8 +2416,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         edm::LogWarning("DataNotFound") << "\nWarning: tkMHT handle not found" << std::endl;
 
       if (L1TkMHTEmuHandle.isValid()) {
-        trkMHTEmu = L1TkMHTEmuHandle->begin()->p4().energy() * l1tmhtemu::kStepMHT;
-        trkHTEmu = L1TkMHTEmuHandle->begin()->hwPt() * l1tmhtemu::kStepPt;
+        trkMHTEmu = L1TkMHTEmuHandle->begin()->p4().energy();
+        trkHTEmu = L1TkMHTEmuHandle->begin()->hwPt() * l1tmhtemu::kStepMHT;
         trkMHTEmuPhi = L1TkMHTEmuHandle->begin()->hwPhi() * l1tmhtemu::kStepMHTPhi - M_PI;
       } else
         edm::LogWarning("DataNotFound") << "\nWarning: tkMHTEmu handle not found" << std::endl;
@@ -2439,8 +2439,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       }
 
       if (L1TkMHTEmuExtendedHandle.isValid()) {
-        trkMHTEmuExt = L1TkMHTEmuExtendedHandle->begin()->p4().energy() * l1tmhtemu::kStepMHT;
-        trkHTEmuExt = L1TkMHTEmuExtendedHandle->begin()->hwPt() * l1tmhtemu::kStepPt;
+        trkMHTEmuExt = L1TkMHTEmuExtendedHandle->begin()->p4().energy();
+        trkHTEmuExt = L1TkMHTEmuExtendedHandle->begin()->hwPt() * l1tmhtemu::kStepMHT;
         trkMHTEmuPhiExt = L1TkMHTEmuExtendedHandle->begin()->hwPhi() * l1tmhtemu::kStepMHTPhi - M_PI;
       } else
         edm::LogWarning("DataNotFound") << "\nWarning: tkMHTEmuExtended handle not found" << std::endl;


### PR DESCRIPTION
#### PR description:

 This PR updates the Track MET and MHT emulator output to match the interface document, moving to vector sum pT ap_ufixed<16,11> and vector sum phi ap_uint<13>

#### PR validation:

Tested on RelVal TTbar sample with no change to result


