### PR TITLE
Fix of the L1uGTTreeProducer to handle exceptions in case of a missing collection (backport of 40597)

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -87,8 +87,13 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
 
   edm::Handle<GlobalAlgBlkBxCollection> ugt;
   event.getByToken(ugtToken_, ugt);
-  if (ugt.isValid()) {
+  if (ugt.isValid() && ugt.product()->size() != 0) {
     results_ = &ugt->at(0, 0);
+  } else {
+    edm::LogWarning("MissingProduct")
+        << "L1uGTTree or L1uGTTestcrateTree GlobalAlgBlkBxCollection not found. Branch will not be filled.\n"
+        << "Please note that the L1uGTTestcrateTree is not expected to exist in MC, so this warning can be ignored!"
+        << std::endl;
   }
 
   tree_->Fill();


### PR DESCRIPTION
Fix of an error related the inclusion of l1uGTTestcrateTree in the L1NtupleRAW sequence equally for data and MC was occurring. In fact, the emulation for the uGT test crate does not exist and the l1uGTTestcrateTree is not present in MC. 

Backport of https://github.com/cms-sw/cmssw/pull/40597