### PR TITLE
Remove hackConditions from calo only re-emulation config

### DIFF
--- a/L1Trigger/Configuration/python/SimL1CaloEmulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1CaloEmulator_cff.py
@@ -7,4 +7,4 @@ SimL1CaloEmulator = cms.Sequence( SimL1TCalorimeter )
 
 # Emulators are configured from DB (GlobalTags)
 # but in the integration branch conffigure from static hackConditions
-from L1Trigger.L1TCalorimeter.hackConditions_cff import *
+#from L1Trigger.L1TCalorimeter.hackConditions_cff import *


### PR DESCRIPTION
This PR comments out a line in the calo only re-emulation config that overrides the GT with the caloParams in hackConditions_cff.py

This means the calo only re-emulation will take the conditions from the global tag if this isn't overridden with the caloParams customisation