### PR TITLE
Add b tag score to ntuples

### DIFF
--- a/L1Trigger/L1TNtuples/interface/L1AnalysisGeneratorDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisGeneratorDataFormat.h
@@ -43,6 +43,8 @@ namespace L1Analysis {
       jetEta.resize(0);
       jetPhi.resize(0);
       jetM.resize(0);
+      jetPartonFlavour.resize(0);
+      jetHadronFlavour.resize(0);
 
       genMetTrue = 0;
       genMetCalo = 0;
@@ -76,6 +78,8 @@ namespace L1Analysis {
     std::vector<float> jetEta;
     std::vector<float> jetPhi;
     std::vector<float> jetM;
+    std::vector<int> jetPartonFlavour;
+    std::vector<int> jetHadronFlavour;
 
     float genMetTrue;
     float genMetCalo;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1.h
@@ -81,6 +81,8 @@
 
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1DataFormat.h"
 
+#include "DataFormats/Common/interface/ValueMap.h"
+
 namespace L1Analysis {
   class L1AnalysisPhaseIIStep1 {
   public:
@@ -132,6 +134,7 @@ namespace L1Analysis {
                                  unsigned maxL1Extra);
 
     void SetPFJet(const edm::Handle<l1t::PFJetCollection> PFJet, unsigned maxL1Extra);
+    void SetPFJetExtended(const edm::Handle<l1t::PFJetCollection> PFJet, const edm::Handle<edm::ValueMap<float>> bJetNN, unsigned maxL1Extra);
     void SetL1seededConeMHT(const edm::Handle<std::vector<l1t::EtSum>> l1SeededConeMHT);
 
     // Add nntaus

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1.h
@@ -134,7 +134,9 @@ namespace L1Analysis {
                                  unsigned maxL1Extra);
 
     void SetPFJet(const edm::Handle<l1t::PFJetCollection> PFJet, unsigned maxL1Extra);
-    void SetPFJetExtended(const edm::Handle<l1t::PFJetCollection> PFJet, const edm::Handle<edm::ValueMap<float>> bJetNN, unsigned maxL1Extra);
+    void SetPFJetExtended(const edm::Handle<l1t::PFJetCollection> PFJet,
+                          const edm::Handle<edm::ValueMap<float>> bJetNN,
+                          unsigned maxL1Extra);
     void SetL1seededConeMHT(const edm::Handle<std::vector<l1t::EtSum>> l1SeededConeMHT);
 
     // Add nntaus

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1DataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisPhaseIIStep1DataFormat.h
@@ -245,6 +245,16 @@ namespace L1Analysis {
       seededConePuppiJetzVtx.clear();
       seededConePuppiJetEtUnCorr.clear();
 
+      nSeededConeExtendedPuppiJets = 0;
+      seededConeExtendedPuppiJetPt.clear();
+      seededConeExtendedPuppiJetEt.clear();
+      seededConeExtendedPuppiJetEta.clear();
+      seededConeExtendedPuppiJetPhi.clear();
+      seededConeExtendedPuppiJetBx.clear();
+      seededConeExtendedPuppiJetzVtx.clear();
+      seededConeExtendedPuppiJetEtUnCorr.clear();
+      seededConeExtendedPuppiJetBJetNN.clear();
+
       seededConePuppiHT = 0;
       seededConePuppiMHTEt = 0;
       seededConePuppiMHTPhi = 0;
@@ -547,6 +557,16 @@ namespace L1Analysis {
     std::vector<int> seededConePuppiJetBx;
     std::vector<double> seededConePuppiJetzVtx;
     std::vector<double> seededConePuppiJetEtUnCorr;
+
+    unsigned int nSeededConeExtendedPuppiJets;
+    std::vector<double> seededConeExtendedPuppiJetPt;
+    std::vector<double> seededConeExtendedPuppiJetEt;
+    std::vector<double> seededConeExtendedPuppiJetEta;
+    std::vector<double> seededConeExtendedPuppiJetPhi;
+    std::vector<int> seededConeExtendedPuppiJetBx;
+    std::vector<double> seededConeExtendedPuppiJetzVtx;
+    std::vector<double> seededConeExtendedPuppiJetEtUnCorr;
+    std::vector<double> seededConeExtendedPuppiJetBJetNN;
 
     double seededConePuppiHT;
     double seededConePuppiMHTEt;

--- a/L1Trigger/L1TNtuples/plugins/L1GenTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1GenTreeProducer.cc
@@ -95,7 +95,8 @@ L1GenTreeProducer::L1GenTreeProducer(const edm::ParameterSet& iConfig) {
   hepMCProductTag_ = consumes<edm::HepMCProduct>(
       iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag", edm::InputTag("generatorSmeared")));
   genJetToken_ = consumes<reco::GenJetCollection>(iConfig.getUntrackedParameter<edm::InputTag>("genJetToken"));
-  genJetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetFlavourInfosToken"));
+  genJetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>(
+      iConfig.getUntrackedParameter<edm::InputTag>("jetFlavourInfosToken"));
   genMETTrueToken_ = consumes<reco::GenMETCollection>(
       iConfig.getUntrackedParameter<edm::InputTag>("genMETTrueToken", edm::InputTag("genMetTrue")));
   genMETCaloToken_ = consumes<reco::GenMETCollection>(
@@ -140,7 +141,6 @@ void L1GenTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup&
   iEvent.getByToken(genJetToken_, genJets);
 
   const auto& jetFlavourInfosProd = iEvent.get(genJetFlavourInfosToken_);
-
 
   if (genJets.isValid()) {
     reco::GenJetCollection::const_iterator jetItr = genJets->begin();

--- a/L1Trigger/L1TNtuples/plugins/L1GenTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1GenTreeProducer.cc
@@ -41,6 +41,10 @@ Implementation:
 #include "DataFormats/METReco/interface/GenMET.h"
 #include "DataFormats/METReco/interface/GenMETFwd.h"
 
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/JetMatching/interface/JetFlavourInfo.h"
+#include "DataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
+
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 // ROOT output stuff
@@ -78,6 +82,7 @@ private:
 
   // EDM input tags
   edm::EDGetTokenT<reco::GenJetCollection> genJetToken_;
+  edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> genJetFlavourInfosToken_;
   edm::EDGetTokenT<reco::GenMETCollection> genMETTrueToken_;
   edm::EDGetTokenT<reco::GenMETCollection> genMETCaloToken_;
   edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
@@ -90,6 +95,7 @@ L1GenTreeProducer::L1GenTreeProducer(const edm::ParameterSet& iConfig) {
   hepMCProductTag_ = consumes<edm::HepMCProduct>(
       iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag", edm::InputTag("generatorSmeared")));
   genJetToken_ = consumes<reco::GenJetCollection>(iConfig.getUntrackedParameter<edm::InputTag>("genJetToken"));
+  genJetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetFlavourInfosToken"));
   genMETTrueToken_ = consumes<reco::GenMETCollection>(
       iConfig.getUntrackedParameter<edm::InputTag>("genMETTrueToken", edm::InputTag("genMetTrue")));
   genMETCaloToken_ = consumes<reco::GenMETCollection>(
@@ -133,6 +139,9 @@ void L1GenTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup&
   edm::Handle<reco::GenJetCollection> genJets;
   iEvent.getByToken(genJetToken_, genJets);
 
+  const auto& jetFlavourInfosProd = iEvent.get(genJetFlavourInfosToken_);
+
+
   if (genJets.isValid()) {
     reco::GenJetCollection::const_iterator jetItr = genJets->begin();
     reco::GenJetCollection::const_iterator jetEnd = genJets->end();
@@ -142,6 +151,18 @@ void L1GenTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup&
       l1GenData_->jetPhi.push_back(jetItr->phi());
       l1GenData_->jetM.push_back(jetItr->mass());
       l1GenData_->nJet++;
+
+      int partonFlavour = -1;
+      int hadronFlavour = -1;
+      for (const reco::JetFlavourInfoMatching& jetFlavourInfoMatching : jetFlavourInfosProd) {
+        if (deltaR(jetItr->p4(), jetFlavourInfoMatching.first->p4()) < 0.1) {
+          partonFlavour = jetFlavourInfoMatching.second.getPartonFlavour();
+          hadronFlavour = jetFlavourInfoMatching.second.getHadronFlavour();
+          break;
+        }
+      }
+      l1GenData_->jetPartonFlavour.push_back(partonFlavour);
+      l1GenData_->jetHadronFlavour.push_back(hadronFlavour);
     }
 
   } else {

--- a/L1Trigger/L1TNtuples/plugins/L1PhaseIITreeStep1Producer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1PhaseIITreeStep1Producer.cc
@@ -159,6 +159,8 @@ private:
 
   edm::EDGetTokenT<std::vector<l1t::PFJet>> scPFL1Puppi_;
   edm::EDGetTokenT<std::vector<l1t::EtSum>> scPFL1PuppiMHT_;
+  edm::EDGetTokenT<std::vector<l1t::PFJet>> scPFL1PuppiExtended_;
+  edm::EDGetTokenT<edm::ValueMap<float>> scBJetNN_;
 
   //edm::EDGetTokenT<float> z0PuppiToken_;
   //edm::EDGetTokenT<l1t::VertexCollection> l1vertextdrToken_;
@@ -210,6 +212,8 @@ L1PhaseIITreeStep1Producer::L1PhaseIITreeStep1Producer(const edm::ParameterSet& 
 
   scPFL1Puppi_ = consumes<std::vector<l1t::PFJet>>(iConfig.getParameter<edm::InputTag>("scPFL1Puppi"));
   scPFL1PuppiMHT_ = consumes<std::vector<l1t::EtSum>>(iConfig.getParameter<edm::InputTag>("scPFL1PuppiMHT"));
+  scPFL1PuppiExtended_ = consumes<std::vector<l1t::PFJet>>(iConfig.getParameter<edm::InputTag>("scPFL1PuppiExtended"));
+  scBJetNN_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("scBjetNN"));
 
   l1pfPhase1L1TJetToken_ =
       consumes<std::vector<reco::CaloJet>>(iConfig.getParameter<edm::InputTag>("l1pfPhase1L1TJetToken"));
@@ -323,8 +327,14 @@ void L1PhaseIITreeStep1Producer::analyze(const edm::Event& iEvent, const edm::Ev
   edm::Handle<std::vector<l1t::PFJet>> scPFL1Puppis;
   iEvent.getByToken(scPFL1Puppi_, scPFL1Puppis);
 
+  edm::Handle<std::vector<l1t::PFJet>> scPFL1PuppisExtended;
+  iEvent.getByToken(scPFL1PuppiExtended_, scPFL1PuppisExtended);
+
   edm::Handle<std::vector<l1t::EtSum>> scPFL1PuppiMHTs;
   iEvent.getByToken(scPFL1PuppiMHT_, scPFL1PuppiMHTs);
+
+  edm::Handle<edm::ValueMap<float>> scBJetNN;
+  iEvent.getByToken(scBJetNN_, scBJetNN);
 
   // now also fill vertices
 
@@ -498,6 +508,15 @@ void L1PhaseIITreeStep1Producer::analyze(const edm::Event& iEvent, const edm::Ev
     l1Extra->SetPFJet(scPFL1Puppis, maxL1Extra_);
   } else {
     edm::LogWarning("MissingProduct") << "L1PhaseII scJets not found. Branch will not be filled" << std::endl;
+  }
+
+  if (scPFL1PuppisExtended.isValid()) {
+    l1Extra->SetPFJetExtended(scPFL1PuppisExtended, scBJetNN, maxL1Extra_);
+    if ( !scBJetNN.isValid() ) {
+      edm::LogWarning("MissingProduct") << "L1PhaseII BJetNN ID not found. SC Jets will be filled, but B tagging NN score will be empty" << std::endl;
+    }
+  } else {
+    edm::LogWarning("MissingProduct") << "L1PhaseII scJets from Extended Puppi not found. Branch will not be filled" << std::endl;
   }
 
   if (scPFL1PuppiMHTs.isValid()) {

--- a/L1Trigger/L1TNtuples/plugins/L1PhaseIITreeStep1Producer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1PhaseIITreeStep1Producer.cc
@@ -512,11 +512,13 @@ void L1PhaseIITreeStep1Producer::analyze(const edm::Event& iEvent, const edm::Ev
 
   if (scPFL1PuppisExtended.isValid()) {
     l1Extra->SetPFJetExtended(scPFL1PuppisExtended, scBJetNN, maxL1Extra_);
-    if ( !scBJetNN.isValid() ) {
-      edm::LogWarning("MissingProduct") << "L1PhaseII BJetNN ID not found. SC Jets will be filled, but B tagging NN score will be empty" << std::endl;
+    if (!scBJetNN.isValid()) {
+      edm::LogWarning("MissingProduct")
+          << "L1PhaseII BJetNN ID not found. SC Jets will be filled, but B tagging NN score will be empty" << std::endl;
     }
   } else {
-    edm::LogWarning("MissingProduct") << "L1PhaseII scJets from Extended Puppi not found. Branch will not be filled" << std::endl;
+    edm::LogWarning("MissingProduct") << "L1PhaseII scJets from Extended Puppi not found. Branch will not be filled"
+                                      << std::endl;
   }
 
   if (scPFL1PuppiMHTs.isValid()) {

--- a/L1Trigger/L1TNtuples/python/l1GeneratorTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1GeneratorTree_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 l1GeneratorTree = cms.EDAnalyzer(
     "L1GenTreeProducer",
     genJetToken     = cms.untracked.InputTag("ak4GenJetsNoNu"),
+    jetFlavourInfosToken = cms.untracked.InputTag("slimmedGenJetsFlavourInfos"),
     genParticleToken = cms.untracked.InputTag("genParticles"),
     pileupInfoToken     = cms.untracked.InputTag("addPileupInfo"),
     genInfoToken     = cms.InputTag("generator")

--- a/L1Trigger/L1TNtuples/python/l1PhaseIITreeStep1Producer_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1PhaseIITreeStep1Producer_cfi.py
@@ -25,8 +25,10 @@ l1PhaseIITree = cms.EDAnalyzer("L1PhaseIITreeStep1Producer",
    gmtTkMuonToken = cms.InputTag("L1TkMuonsGmt",""),
 
 
-   scPFL1Puppi = cms.InputTag("scPFL1PuppiCorrectedEmulator", ""), #Emulator and corrected JEC; seededcone jets
-   scPFL1PuppiMHT = cms.InputTag("scPFL1PuppiCorrectedEmulatorMHT", ""), #Emulator for seededcone puppiMHT
+   scPFL1Puppi = cms.InputTag("l1tSCPFL1PuppiCorrectedEmulator", ""), #Emulator and corrected JEC; seededcone jets
+   scPFL1PuppiMHT = cms.InputTag("l1tSCPFL1PuppiCorrectedEmulatorMHT", ""), #Emulator for seededcone puppiMHT
+   scPFL1PuppiExtended = cms.InputTag("l1tSCPFL1PuppiExtendedCorrectedEmulator", ""), #Emulator and corrected JEC; seededcone jets from extended tracks/puppi
+   scBjetNN = cms.InputTag("l1tBJetProducerPuppiCorrectedEmulator", "L1PFBJets"), #B Jet NN ID for seededcone jets from extended tracks/puppi
 
    l1pfPhase1L1TJetToken  = cms.InputTag("Phase1L1TJetCalibrator9x9" ,   "Phase1L1TJetFromPfCandidates"), #use the 9x9 case
    l1pfPhase1L1TJetMET  = cms.InputTag("Phase1L1TJetProducer9x9" ,   "UncalibratedPhase1L1TJetFromPfCandidatesMET"), #use the 9x9 case

--- a/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc
@@ -489,6 +489,29 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetPFJet(const edm::Handle<l1t::PFJetCo
   }
 }
 
+void L1Analysis::L1AnalysisPhaseIIStep1::SetPFJetExtended(const edm::Handle<l1t::PFJetCollection> PFJet, const edm::Handle<edm::ValueMap<float>> bJetNN, unsigned maxL1Extra) {
+  bool validBJetNN = bJetNN.isValid();
+  edm::RefProd<l1t::PFJetCollection> refProdPFJet(PFJet);
+  for (l1t::PFJetCollection::const_iterator it = PFJet->begin();
+       it != PFJet->end() && l1extra_.nSeededConeExtendedPuppiJets < maxL1Extra;
+       it++) {
+    l1extra_.seededConeExtendedPuppiJetPt.push_back(it->pt());
+    l1extra_.seededConeExtendedPuppiJetEt.push_back(it->et());
+    l1extra_.seededConeExtendedPuppiJetEtUnCorr.push_back(it->rawPt());
+    l1extra_.seededConeExtendedPuppiJetEta.push_back(it->eta());
+    l1extra_.seededConeExtendedPuppiJetPhi.push_back(it->phi());
+    l1extra_.seededConeExtendedPuppiJetBx.push_back(0);
+    l1extra_.nSeededConeExtendedPuppiJets++;
+    if ( validBJetNN ) {
+      size_t index = std::distance(PFJet->begin(), it);
+      edm::Ref<l1t::PFJetCollection> pfJetRef(refProdPFJet, index);
+      l1extra_.seededConeExtendedPuppiJetBJetNN.push_back((*bJetNN)[pfJetRef]);
+
+    }
+  }
+
+}
+
 void L1Analysis::L1AnalysisPhaseIIStep1::SetL1seededConeMHT(
     const edm::Handle<std::vector<l1t::EtSum> > l1SeededConeMHT) {
   l1t::EtSum HT = l1SeededConeMHT->at(0);

--- a/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc
@@ -8,7 +8,7 @@ L1Analysis::L1AnalysisPhaseIIStep1::L1AnalysisPhaseIIStep1() {}
 L1Analysis::L1AnalysisPhaseIIStep1::~L1AnalysisPhaseIIStep1() {}
 
 void L1Analysis::L1AnalysisPhaseIIStep1::SetVertices(float z0Puppi,
-                                                     const edm::Handle<std::vector<l1t::VertexWord> > TkPrimaryVertex) {
+                                                     const edm::Handle<std::vector<l1t::VertexWord>> TkPrimaryVertex) {
   //l1extra_.z0Puppi = z0Puppi;
   l1extra_.z0L1TkPV = TkPrimaryVertex->at(0).z0();
   for (unsigned int i = 0; i < TkPrimaryVertex->size(); i++) {
@@ -416,7 +416,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetTkGlbMuon(const edm::Handle<l1t::TkG
 */
 
 void L1Analysis::L1AnalysisPhaseIIStep1::SetL1PfPhase1L1TJet(
-    const edm::Handle<std::vector<reco::CaloJet> > l1L1PFPhase1L1Jet, unsigned maxL1Extra) {
+    const edm::Handle<std::vector<reco::CaloJet>> l1L1PFPhase1L1Jet, unsigned maxL1Extra) {
   double mHT30_px = 0, mHT30_py = 0, HT30 = 0;
   double mHT30_3p5_px = 0, mHT30_3p5_py = 0, HT30_3p5 = 0;
 
@@ -456,7 +456,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetL1PfPhase1L1TJet(
 }
 
 void L1Analysis::L1AnalysisPhaseIIStep1::SetL1PfPhase1L1TJetMET(
-    const edm::Handle<std::vector<l1t::EtSum> > l1L1PFPhase1L1JetMET, unsigned maxL1Extra) {
+    const edm::Handle<std::vector<l1t::EtSum>> l1L1PFPhase1L1JetMET, unsigned maxL1Extra) {
   l1t::EtSum met = l1L1PFPhase1L1JetMET->at(0);
   //cout<<met.et()<< " and " <<met.phi()<<endl;
   l1extra_.phase1PuppiMETEt = met.et();
@@ -464,7 +464,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetL1PfPhase1L1TJetMET(
 }
 
 void L1Analysis::L1AnalysisPhaseIIStep1::SetL1PfPhase1L1TJetSums(
-    const edm::Handle<std::vector<l1t::EtSum> > l1L1PFPhase1L1JetSums, unsigned maxL1Extra) {
+    const edm::Handle<std::vector<l1t::EtSum>> l1L1PFPhase1L1JetSums, unsigned maxL1Extra) {
   //cout<<"testing the size of this sums vector:"<<l1L1PFPhase1L1JetSums<<endl;
   l1t::EtSum HT = l1L1PFPhase1L1JetSums->at(0);
   l1t::EtSum MHT = l1L1PFPhase1L1JetSums->at(1);
@@ -489,7 +489,9 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetPFJet(const edm::Handle<l1t::PFJetCo
   }
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetPFJetExtended(const edm::Handle<l1t::PFJetCollection> PFJet, const edm::Handle<edm::ValueMap<float>> bJetNN, unsigned maxL1Extra) {
+void L1Analysis::L1AnalysisPhaseIIStep1::SetPFJetExtended(const edm::Handle<l1t::PFJetCollection> PFJet,
+                                                          const edm::Handle<edm::ValueMap<float>> bJetNN,
+                                                          unsigned maxL1Extra) {
   bool validBJetNN = bJetNN.isValid();
   edm::RefProd<l1t::PFJetCollection> refProdPFJet(PFJet);
   for (l1t::PFJetCollection::const_iterator it = PFJet->begin();
@@ -502,18 +504,15 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetPFJetExtended(const edm::Handle<l1t:
     l1extra_.seededConeExtendedPuppiJetPhi.push_back(it->phi());
     l1extra_.seededConeExtendedPuppiJetBx.push_back(0);
     l1extra_.nSeededConeExtendedPuppiJets++;
-    if ( validBJetNN ) {
+    if (validBJetNN) {
       size_t index = std::distance(PFJet->begin(), it);
       edm::Ref<l1t::PFJetCollection> pfJetRef(refProdPFJet, index);
       l1extra_.seededConeExtendedPuppiJetBJetNN.push_back((*bJetNN)[pfJetRef]);
-
     }
   }
-
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetL1seededConeMHT(
-    const edm::Handle<std::vector<l1t::EtSum> > l1SeededConeMHT) {
+void L1Analysis::L1AnalysisPhaseIIStep1::SetL1seededConeMHT(const edm::Handle<std::vector<l1t::EtSum>> l1SeededConeMHT) {
   l1t::EtSum HT = l1SeededConeMHT->at(0);
   l1t::EtSum MHT = l1SeededConeMHT->at(1);
   l1extra_.seededConePuppiHT = HT.pt();
@@ -521,7 +520,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetL1seededConeMHT(
   l1extra_.seededConePuppiMHTPhi = MHT.phi();
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetL1METPF(const edm::Handle<std::vector<l1t::EtSum> > l1MetPF) {
+void L1Analysis::L1AnalysisPhaseIIStep1::SetL1METPF(const edm::Handle<std::vector<l1t::EtSum>> l1MetPF) {
   l1t::EtSum met = l1MetPF->at(0);
   l1extra_.puppiMETEt = met.et();
   l1extra_.puppiMETPhi = met.phi();
@@ -533,7 +532,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetL1METPF(const edm::Handle<std::vecto
 //  l1extra_.puppiMETRecoPhi = met.phi();
 //}
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetNNTaus(const edm::Handle<vector<l1t::PFTau> > l1nnTaus,
+void L1Analysis::L1AnalysisPhaseIIStep1::SetNNTaus(const edm::Handle<vector<l1t::PFTau>> l1nnTaus,
                                                    unsigned maxL1Extra) {
   for (unsigned int i = 0; i < l1nnTaus->size() && l1extra_.nNNTaus < maxL1Extra; i++) {
     if (l1nnTaus->at(i).pt() < 1)
@@ -559,7 +558,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetNNTaus(const edm::Handle<vector<l1t:
   }
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetNNTau2vtxs(const edm::Handle<vector<l1t::PFTau> > l1nnTau2vtxs,
+void L1Analysis::L1AnalysisPhaseIIStep1::SetNNTau2vtxs(const edm::Handle<vector<l1t::PFTau>> l1nnTau2vtxs,
                                                        unsigned maxL1Extra) {
   for (unsigned int i = 0; i < l1nnTau2vtxs->size() && l1extra_.nNNTau2vtxs < maxL1Extra; i++) {
     if (l1nnTau2vtxs->at(i).pt() < 1)
@@ -616,25 +615,25 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetTkJetDisplaced(const edm::Handle<l1t
   }
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetTkMET(const edm::Handle<std::vector<l1t::EtSum> > trackerMET) {
+void L1Analysis::L1AnalysisPhaseIIStep1::SetTkMET(const edm::Handle<std::vector<l1t::EtSum>> trackerMET) {
   l1extra_.trackerMET = trackerMET->begin()->hwPt() * l1tmetemu::kStepMETwordEt;
   l1extra_.trackerMETPhi = trackerMET->begin()->hwPhi() * l1tmetemu::kStepMETwordPhi;
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetTkMHT(const edm::Handle<std::vector<l1t::EtSum> > trackerMHT) {
+void L1Analysis::L1AnalysisPhaseIIStep1::SetTkMHT(const edm::Handle<std::vector<l1t::EtSum>> trackerMHT) {
   l1extra_.trackerMHT = trackerMHT->begin()->p4().energy() * l1tmhtemu::kStepMHT;
   l1extra_.trackerHT = trackerMHT->begin()->hwPt() * l1tmhtemu::kStepPt;
   l1extra_.trackerMHTPhi = trackerMHT->begin()->hwPhi() * l1tmhtemu::kStepMHTPhi - M_PI;
 }
 
-void L1Analysis::L1AnalysisPhaseIIStep1::SetTkMHTDisplaced(const edm::Handle<std::vector<l1t::EtSum> > trackerMHT) {
+void L1Analysis::L1AnalysisPhaseIIStep1::SetTkMHTDisplaced(const edm::Handle<std::vector<l1t::EtSum>> trackerMHT) {
   l1extra_.trackerHTDisplaced = trackerMHT->begin()->hwPt() * l1tmhtemu::kStepPt;
   l1extra_.trackerMHTDisplaced = trackerMHT->begin()->p4().energy() * l1tmhtemu::kStepMHT;
   l1extra_.trackerMHTPhiDisplaced = trackerMHT->begin()->hwPhi() * l1tmhtemu::kStepMHTPhi - M_PI;
 }
 
 //gmt muons
-void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtMuon(const edm::Handle<std::vector<l1t::SAMuon> > gmtMuon,
+void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtMuon(const edm::Handle<std::vector<l1t::SAMuon>> gmtMuon,
                                                     unsigned maxL1Extra) {
   for (unsigned int i = 0; i < gmtMuon->size() && l1extra_.nGmtMuons < maxL1Extra; i++) {
     if (lsb_pt * gmtMuon->at(i).hwPt() > 0) {
@@ -663,7 +662,7 @@ void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtMuon(const edm::Handle<std::vecto
 }
 
 //tkmuon gmt
-void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtTkMuon(const edm::Handle<std::vector<l1t::TrackerMuon> > gmtTkMuon,
+void L1Analysis::L1AnalysisPhaseIIStep1::SetGmtTkMuon(const edm::Handle<std::vector<l1t::TrackerMuon>> gmtTkMuon,
 
                                                       unsigned maxL1Extra) {
   for (unsigned int i = 0; i < gmtTkMuon->size() && l1extra_.nGmtTkMuons < maxL1Extra; i++) {


### PR DESCRIPTION
#### PR description:

This PR corresponds to the second commit of #1086 . Split up to help manage integration of changes into master.

- Add the "extended Puppi" seeded cone jet collection to the ntuples, and add the b jet NN score that's computed for each jet
- Store the parton/hadron flavour of the Gen jets in the ntuples

#### PR validation:

Checks done as part of https://github.com/cms-l1t-offline/cmssw/pull/1086
