### PR TITLE
emulator for Phase-2 Calo PF clusters using GCT firmware

### DIFF
--- a/DataFormats/L1TCalorimeterPhase2/interface/CaloPFCluster.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/CaloPFCluster.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <algorithm>
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace l1tp2 {
 

--- a/DataFormats/L1TCalorimeterPhase2/interface/CaloPFCluster.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/CaloPFCluster.h
@@ -1,0 +1,63 @@
+#ifndef DataFormats_L1TCalorimeterPhase2_CaloPFCluster_h
+#define DataFormats_L1TCalorimeterPhase2_CaloPFCluster_h
+
+#include <vector>
+#include <map>
+#include <string>
+#include <algorithm>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace l1tp2 {
+
+  class CaloPFCluster : public l1t::L1Candidate {
+  public:
+    CaloPFCluster()
+        : l1t::L1Candidate(),
+          clusterEt_(0.),
+          clusterIEta_(-99),
+          clusterIPhi_(-99),
+          clusterEta_(-99.),
+          clusterPhi_(-99.){};
+
+    CaloPFCluster(const PolarLorentzVector& p4,
+                  float clusterEt,
+                  int clusterIEta,
+                  int clusterIPhi,
+                  float clusterEta,
+                  float clusterPhi)
+        : l1t::L1Candidate(p4),
+          clusterEt_(clusterEt),
+          clusterIEta_(clusterIEta),
+          clusterIPhi_(clusterIPhi),
+          clusterEta_(clusterEta),
+          clusterPhi_(clusterPhi){};
+
+    inline float clusterEt() const { return clusterEt_; };
+    inline int clusterIEta() const { return clusterIEta_; };
+    inline int clusterIPhi() const { return clusterIPhi_; };
+    inline float clusterEta() const { return clusterEta_; };
+    inline float clusterPhi() const { return clusterPhi_; };
+    void setClusterEt(float clusterEtIn) { clusterEt_ = clusterEtIn; };
+    void setClusterIEta(int clusterIEtaIn) { clusterIEta_ = clusterIEtaIn; };
+    void setClusterIPhi(int clusterIPhiIn) { clusterIPhi_ = clusterIPhiIn; };
+    void setClusterEta(float clusterEtaIn) { clusterEta_ = clusterEtaIn; };
+    void setClusterPhi(float clusterPhiIn) { clusterPhi_ = clusterPhiIn; };
+
+  private:
+    // ET
+    float clusterEt_;
+    // GCT ieta
+    int clusterIEta_;
+    // GCT iphi
+    int clusterIPhi_;
+    // Tower (real) eta
+    float clusterEta_;
+    // Tower (real) phi
+    float clusterPhi_;
+  };
+
+  // Concrete collection of output objects (with extra tuning information)
+  typedef std::vector<l1tp2::CaloPFCluster> CaloPFClusterCollection;
+}  // namespace l1tp2
+#endif

--- a/DataFormats/L1TCalorimeterPhase2/src/classes.h
+++ b/DataFormats/L1TCalorimeterPhase2/src/classes.h
@@ -14,3 +14,4 @@
 #include "DataFormats/L1TCalorimeterPhase2/interface/DigitizedClusterCorrelator.h"
 #include "DataFormats/L1TCalorimeterPhase2/interface/DigitizedTowerCorrelator.h"
 #include "DataFormats/L1TCalorimeterPhase2/interface/DigitizedClusterGT.h"
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloPFCluster.h"

--- a/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
+++ b/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
@@ -43,8 +43,8 @@
   <class name="l1tp2::DigitizedClusterGTCollection" />
   <class name="edm::Wrapper<l1tp2::DigitizedClusterGTCollection>" /> 
 
-  <class name="l1tp2::CaloPFCluster"  ClassVersion="4">
-         <version ClassVersion="4" checksum="4176166177"/>
+  <class name="l1tp2::CaloPFCluster"  ClassVersion="3">
+         <version ClassVersion="3" checksum="4176166177"/>
   </class>
   <class name="std::vector<l1tp2::CaloPFCluster>" />
   <class name="l1tp2::CaloPFClusterCollection" />

--- a/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
+++ b/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
@@ -42,5 +42,13 @@
   </class>
   <class name="l1tp2::DigitizedClusterGTCollection" />
   <class name="edm::Wrapper<l1tp2::DigitizedClusterGTCollection>" /> 
+
+  <class name="l1tp2::CaloPFCluster"  ClassVersion="4">
+         <version ClassVersion="4" checksum="4176166177"/>
+  </class>
+  <class name="std::vector<l1tp2::CaloPFCluster>" />
+  <class name="l1tp2::CaloPFClusterCollection" />
+  <class name="edm::Wrapper<l1tp2::CaloPFClusterCollection>" />
+
 </lcgdict>
 

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
@@ -1,0 +1,197 @@
+#ifndef _PHASE_2_L1_CALO_PFCLUSTER_EMULATOR_H_
+#define _PHASE_2_L1_CALO_PFCLUSTER_EMULATOR_H_
+
+#include <cstdlib>
+
+//    eta:  0  1  2  3  4   5  6  7  8   9 10 11 12  13 14 15 16  17 18 19 20
+// 0             |                                                     |
+// 1             |                                                     |
+//               |-----------------------------------------------------|
+// 2             |                                                     |
+// 3             |                                                     |
+// 4             |                                                     |
+// 5             |                                                     |
+//               | ----------------------------------------------------|
+// 6             |                                                     |
+// 7             |                                                     |
+//
+// 8 PFclusters are created in one 21x8 (2+17+2 x 2+4+2)
+
+static constexpr int nTowerEta = 34;
+static constexpr int nTowerPhi = 72;
+static constexpr int nSLR = 36;
+static constexpr int nTowerEtaSLR = 21;  // including overlap: 2+17+2
+static constexpr int nTowerPhiSLR = 8;   // including overlap: 2+4+2
+static constexpr int nPFClusterSLR = 8;
+
+namespace gctpf {
+
+  typedef struct {
+    float et;
+    int eta;
+    int phi;
+  } GCTpfcluster_t;
+
+  typedef struct {
+    GCTpfcluster_t GCTpfclusters[nPFClusterSLR];
+  } GCTPfcluster_t;
+
+  typedef struct {
+    float et;
+    int eta;
+    int phi;
+  } GCTint_t;
+
+  typedef struct {
+    GCTint_t t[nTowerPhiSLR];
+  } gctEtaStrip_t;
+
+  typedef struct {
+    GCTint_t p[nTowerEtaSLR - 2];
+  } gctEtaStripPeak_t;
+
+  typedef struct {
+    gctEtaStrip_t s[nTowerEtaSLR];
+  } region_t;
+
+  GCTint_t bestOf2(const GCTint_t& t0, const GCTint_t& t1) {
+    GCTint_t x;
+    x = (t0.et > t1.et) ? t0 : t1;
+
+    return x;
+  }
+
+  GCTint_t getPeakOfStrip(const gctEtaStrip_t& etaStrip) {
+    GCTint_t best12 = bestOf2(etaStrip.t[1], etaStrip.t[2]);
+    GCTint_t best34 = bestOf2(etaStrip.t[3], etaStrip.t[4]);
+    GCTint_t best56 = bestOf2(etaStrip.t[5], etaStrip.t[6]);
+    GCTint_t best1234 = bestOf2(best12, best34);
+    GCTint_t bestAll = bestOf2(best1234, best56);
+
+    return bestAll;
+  }
+
+  GCTint_t getPeakBin(const gctEtaStripPeak_t& etaStripPeak) {
+    GCTint_t best01 = bestOf2(etaStripPeak.p[0], etaStripPeak.p[1]);
+    GCTint_t best23 = bestOf2(etaStripPeak.p[2], etaStripPeak.p[3]);
+    GCTint_t best45 = bestOf2(etaStripPeak.p[4], etaStripPeak.p[5]);
+    GCTint_t best67 = bestOf2(etaStripPeak.p[6], etaStripPeak.p[7]);
+    GCTint_t best89 = bestOf2(etaStripPeak.p[8], etaStripPeak.p[9]);
+    GCTint_t best1011 = bestOf2(etaStripPeak.p[10], etaStripPeak.p[11]);
+    GCTint_t best1213 = bestOf2(etaStripPeak.p[12], etaStripPeak.p[13]);
+    GCTint_t best1415 = bestOf2(etaStripPeak.p[14], etaStripPeak.p[15]);
+    GCTint_t best1617 = bestOf2(etaStripPeak.p[16], etaStripPeak.p[17]);
+    GCTint_t best0123 = bestOf2(best01, best23);
+    GCTint_t best4567 = bestOf2(best45, best67);
+    GCTint_t best891011 = bestOf2(best89, best1011);
+    GCTint_t best12131415 = bestOf2(best1213, best1415);
+    GCTint_t best01234567 = bestOf2(best0123, best4567);
+    GCTint_t best01234567891011 = bestOf2(best01234567, best891011);
+    GCTint_t best121314151617 = bestOf2(best12131415, best1617);
+    GCTint_t best12131415161718 = bestOf2(best121314151617, etaStripPeak.p[18]);
+    GCTint_t bestAll = bestOf2(best01234567891011, best12131415161718);
+
+    return bestAll;
+  }
+
+  GCTint_t getPeakPosition(const region_t& region) {
+    gctEtaStripPeak_t etaPeak;
+    for (int i = 0; i < 19; i++) {
+      etaPeak.p[i] = getPeakOfStrip(region.s[i + 1]);
+    }
+    GCTint_t max = getPeakBin(etaPeak);
+
+    return max;
+  }
+
+  region_t initStructure(float temp[nTowerEtaSLR][nTowerPhiSLR]) {
+    region_t r;
+
+    for (int i = 0; i < nTowerPhiSLR; i++) {
+      for (int j = 0; j < nTowerEtaSLR; j++) {
+        r.s[j].t[i].et = temp[j][i];
+        r.s[j].t[i].eta = j;
+        r.s[j].t[i].phi = i;
+      }
+    }
+
+    return r;
+  }
+
+  float getEt(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
+    float et_sumEta[3];
+
+    for (int i = 0; i < (nTowerEtaSLR - 2); i++) {
+      for (int j = 0; j < (nTowerPhiSLR - 2); j++) {
+        if (i + 1 == eta && j + 1 == phi) {
+          for (int k = 0; k < 3; k++) {
+            et_sumEta[k] = temp[i + k][j] + temp[i + k][j + 1] + temp[i + k][j + 2];
+          }
+        }
+      }
+    }
+
+    float pfcluster_et = et_sumEta[0] + et_sumEta[1] + et_sumEta[2];
+
+    return pfcluster_et;
+  }
+
+  void RemoveTmp(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
+    for (int i = 0; i < nTowerEtaSLR; i++) {
+      if (i + 1 >= eta && i <= eta + 1) {
+        for (int j = 0; j < nTowerPhiSLR; j++) {
+          if (j + 1 >= phi && j <= phi + 1) {
+            temp[i][j] = 0;
+          }
+        }
+      }
+    }
+
+    return;
+  }
+
+  GCTpfcluster_t recoPfcluster(float temporary[nTowerEtaSLR][nTowerPhiSLR], int etaoffset, int phioffset) {
+    GCTpfcluster_t pfclusterReturn;
+
+    region_t region;
+
+    region = initStructure(temporary);
+
+    GCTint_t regionMax = getPeakPosition(region);
+
+    float pfcluster_et = getEt(temporary, regionMax.eta, regionMax.phi);
+
+    RemoveTmp(temporary, regionMax.eta, regionMax.phi);
+
+    if (!(regionMax.eta >= 2 && regionMax.eta < (nTowerEtaSLR - 2) && regionMax.phi >= 2 &&
+          regionMax.phi < (nTowerPhiSLR - 2)))
+      pfcluster_et = 0;
+
+    pfclusterReturn.et = pfcluster_et;
+    pfclusterReturn.eta = regionMax.eta - 2 + etaoffset;
+    pfclusterReturn.phi = regionMax.phi - 2 + phioffset;
+
+    return pfclusterReturn;
+  }
+
+  GCTPfcluster_t pfcluster(float temporary[nTowerEtaSLR][nTowerPhiSLR], int etaoffset, int phioffset) {
+    GCTpfcluster_t pfcluster[nPFClusterSLR];
+
+    for (int i = 0; i < nPFClusterSLR; i++) {
+      pfcluster[i] = recoPfcluster(temporary, etaoffset, phioffset);
+    }
+
+    GCTPfcluster_t GCTPfclusters;
+
+    for (int i = 0; i < nPFClusterSLR; i++) {
+      GCTPfclusters.GCTpfclusters[i].et = pfcluster[i].et;
+      GCTPfclusters.GCTpfclusters[i].eta = pfcluster[i].eta;
+      GCTPfclusters.GCTpfclusters[i].phi = pfcluster[i].phi;
+    }
+
+    return GCTPfclusters;
+  }
+
+}  // namespace gctpf
+
+#endif

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
@@ -34,7 +34,7 @@ namespace gctpf {
 
   typedef struct {
     GCTpfcluster_t GCTpfclusters[nPFClusterSLR];
-  } GCTPfcluster_t;
+  } PFcluster_t;
 
   typedef struct {
     float et;
@@ -44,24 +44,24 @@ namespace gctpf {
 
   typedef struct {
     GCTint_t t[nTowerPhiSLR];
-  } gctEtaStrip_t;
+  } GCTEtaStrip_t;
 
   typedef struct {
     GCTint_t p[nTowerEtaSLR - 2];
-  } gctEtaStripPeak_t;
+  } GCTEtaStripPeak_t;
 
   typedef struct {
-    gctEtaStrip_t s[nTowerEtaSLR];
-  } region_t;
+    GCTEtaStrip_t s[nTowerEtaSLR];
+  } Region_t;
 
-  GCTint_t bestOf2(const GCTint_t& t0, const GCTint_t& t1) {
+  inline GCTint_t bestOf2(const GCTint_t& t0, const GCTint_t& t1) {
     GCTint_t x;
     x = (t0.et > t1.et) ? t0 : t1;
 
     return x;
   }
 
-  GCTint_t getPeakOfStrip(const gctEtaStrip_t& etaStrip) {
+  inline GCTint_t getPeakOfStrip(const GCTEtaStrip_t& etaStrip) {
     GCTint_t best12 = bestOf2(etaStrip.t[1], etaStrip.t[2]);
     GCTint_t best34 = bestOf2(etaStrip.t[3], etaStrip.t[4]);
     GCTint_t best56 = bestOf2(etaStrip.t[5], etaStrip.t[6]);
@@ -71,7 +71,7 @@ namespace gctpf {
     return bestAll;
   }
 
-  GCTint_t getPeakBin(const gctEtaStripPeak_t& etaStripPeak) {
+  inline GCTint_t getPeakBin(const GCTEtaStripPeak_t& etaStripPeak) {
     GCTint_t best01 = bestOf2(etaStripPeak.p[0], etaStripPeak.p[1]);
     GCTint_t best23 = bestOf2(etaStripPeak.p[2], etaStripPeak.p[3]);
     GCTint_t best45 = bestOf2(etaStripPeak.p[4], etaStripPeak.p[5]);
@@ -94,9 +94,9 @@ namespace gctpf {
     return bestAll;
   }
 
-  GCTint_t getPeakPosition(const region_t& region) {
-    gctEtaStripPeak_t etaPeak;
-    for (int i = 0; i < 19; i++) {
+  inline GCTint_t getPeakPosition(const Region_t& region) {
+    GCTEtaStripPeak_t etaPeak;
+    for (int i = 0; i < nTowerEtaSLR - 2; i++) {
       etaPeak.p[i] = getPeakOfStrip(region.s[i + 1]);
     }
     GCTint_t max = getPeakBin(etaPeak);
@@ -104,8 +104,8 @@ namespace gctpf {
     return max;
   }
 
-  region_t initStructure(float temp[nTowerEtaSLR][nTowerPhiSLR]) {
-    region_t r;
+  inline Region_t initStructure(float temp[nTowerEtaSLR][nTowerPhiSLR]) {
+    Region_t r;
 
     for (int i = 0; i < nTowerPhiSLR; i++) {
       for (int j = 0; j < nTowerEtaSLR; j++) {
@@ -118,7 +118,7 @@ namespace gctpf {
     return r;
   }
 
-  float getEt(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
+  inline float getEt(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
     float et_sumEta[3];
 
     for (int i = 0; i < (nTowerEtaSLR - 2); i++) {
@@ -136,7 +136,7 @@ namespace gctpf {
     return pfcluster_et;
   }
 
-  void RemoveTmp(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
+  inline void RemoveTmp(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
     for (int i = 0; i < nTowerEtaSLR; i++) {
       if (i + 1 >= eta && i <= eta + 1) {
         for (int j = 0; j < nTowerPhiSLR; j++) {
@@ -150,10 +150,10 @@ namespace gctpf {
     return;
   }
 
-  GCTpfcluster_t recoPfcluster(float temporary[nTowerEtaSLR][nTowerPhiSLR], int etaoffset, int phioffset) {
+  inline GCTpfcluster_t recoPfcluster(float temporary[nTowerEtaSLR][nTowerPhiSLR], int etaoffset, int phioffset) {
     GCTpfcluster_t pfclusterReturn;
 
-    region_t region;
+    Region_t region;
 
     region = initStructure(temporary);
 
@@ -174,14 +174,14 @@ namespace gctpf {
     return pfclusterReturn;
   }
 
-  GCTPfcluster_t pfcluster(float temporary[nTowerEtaSLR][nTowerPhiSLR], int etaoffset, int phioffset) {
+  inline PFcluster_t pfcluster(float temporary[nTowerEtaSLR][nTowerPhiSLR], int etaoffset, int phioffset) {
     GCTpfcluster_t pfcluster[nPFClusterSLR];
 
     for (int i = 0; i < nPFClusterSLR; i++) {
       pfcluster[i] = recoPfcluster(temporary, etaoffset, phioffset);
     }
 
-    GCTPfcluster_t GCTPfclusters;
+    PFcluster_t GCTPfclusters;
 
     for (int i = 0; i < nPFClusterSLR; i++) {
       GCTPfclusters.GCTpfclusters[i].et = pfcluster[i].et;

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
@@ -95,8 +95,6 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
   float realEta[nTowerEta][nTowerPhi];
   float realPhi[nTowerEta][nTowerPhi];
   for (const l1tp2::CaloTower& i : *caloTowerCollection) {
-    //std::cout << "Phase2L1CaloPFClusterEmulator: GCT FULL tower energy " << i.ecalTowerEt()
-    //          << " at eta, phi: (" << i.towerIEta() << ", " << i.towerIPhi() << ")" << std::endl;
 
     int ieta = i.towerIEta();
     int iphi = i.towerIPhi();
@@ -166,9 +164,6 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
       int gctphi = tempPfclusters.GCTpfclusters[i].phi;
       float towereta = realEta[gcteta][gctphi];
       float towerphi = realPhi[gcteta][gctphi];
-      //std::cout << "Phase2L1CaloPFClusterEmulator: GCT Pfclusters energy " << tempPfclusters.GCTpfclusters[i].et
-      //          << " at ieta, iphi: (" << tempPfclusters.GCTpfclusters[i].eta << ", " << tempPfclusters.GCTpfclusters[i].phi << ")"
-      //          << " at eta, phi: (" << towereta << ", " << towerphi << ")" << std::endl;
       l1tp2::CaloPFCluster l1CaloPFCluster;
       l1CaloPFCluster.setClusterEt(tempPfclusters.GCTpfclusters[i].et);
       l1CaloPFCluster.setClusterIEta(gcteta);

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
@@ -88,14 +88,13 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
 
   edm::Handle<std::vector<l1tp2::CaloTower>> caloTowerCollection;
   if (!iEvent.getByToken(caloTowerToken_, caloTowerCollection))
-    edm::LogError("Phase2L1CaloPFClusterEmulator") << "Failed to get towers from caloTowerCollection!";
+    cms::Exception("Phase2L1CaloPFClusterEmulator") << "Failed to get towers from caloTowerCollection!";
 
   iEvent.getByToken(caloTowerToken_, caloTowerCollection);
   float GCTintTowers[nTowerEta][nTowerPhi];
   float realEta[nTowerEta][nTowerPhi];
   float realPhi[nTowerEta][nTowerPhi];
   for (const l1tp2::CaloTower& i : *caloTowerCollection) {
-
     int ieta = i.towerIEta();
     int iphi = i.towerIPhi();
     GCTintTowers[ieta][iphi] = i.ecalTowerEt();
@@ -179,11 +178,9 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void Phase2L1CaloPFClusterEmulator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("gctFullTowers", edm::InputTag("l1tPhase2L1CaloEGammaEmulator", "GCTFullTowers"));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
@@ -1,0 +1,195 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1CaloTrigger
+// Class:      Phase2L1CaloPFClusterEmulator
+//
+/**\class Phase2L1CaloPFClusterEmulator Phase2L1CaloPFClusterEmulator.cc L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+
+ Description: Creates 3x3 PF clusters from GCTintTowers to be sent to correlator. Follows firmware logic, creates 8 clusters per (2+17+2)x(2+4+2).
+
+ Implementation: To be run together with Phase2L1CaloEGammaEmulator.
+
+*/
+//
+// Original Author:  Pallabi Das
+//         Created:  Wed, 21 Sep 2022 14:54:20 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h"
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloTower.h"
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloPFCluster.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
+#include <ap_int.h>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdio.h>
+#include "L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h"
+
+//
+// class declaration
+//
+
+class Phase2L1CaloPFClusterEmulator : public edm::stream::EDProducer<> {
+public:
+  explicit Phase2L1CaloPFClusterEmulator(const edm::ParameterSet&);
+  ~Phase2L1CaloPFClusterEmulator();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<l1tp2::CaloTowerCollection> caloTowerToken_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+Phase2L1CaloPFClusterEmulator::Phase2L1CaloPFClusterEmulator(const edm::ParameterSet& iConfig)
+    : caloTowerToken_(consumes<l1tp2::CaloTowerCollection>(iConfig.getParameter<edm::InputTag>("gctFullTowers"))) {
+  produces<l1tp2::CaloPFClusterCollection>("GCTPFCluster");
+}
+
+Phase2L1CaloPFClusterEmulator::~Phase2L1CaloPFClusterEmulator() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  std::unique_ptr<l1tp2::CaloPFClusterCollection> pfclusterCands(make_unique<l1tp2::CaloPFClusterCollection>());
+
+  edm::Handle<std::vector<l1tp2::CaloTower>> caloTowerCollection;
+  if (!iEvent.getByToken(caloTowerToken_, caloTowerCollection))
+    edm::LogError("Phase2L1CaloPFClusterEmulator") << "Failed to get towers from caloTowerCollection!";
+
+  iEvent.getByToken(caloTowerToken_, caloTowerCollection);
+  float GCTintTowers[nTowerEta][nTowerPhi];
+  float realEta[nTowerEta][nTowerPhi];
+  float realPhi[nTowerEta][nTowerPhi];
+  for (const l1tp2::CaloTower& i : *caloTowerCollection) {
+    //std::cout << "Phase2L1CaloPFClusterEmulator: GCT FULL tower energy " << i.ecalTowerEt()
+    //          << " at eta, phi: (" << i.towerIEta() << ", " << i.towerIPhi() << ")" << std::endl;
+
+    int ieta = i.towerIEta();
+    int iphi = i.towerIPhi();
+    GCTintTowers[ieta][iphi] = i.ecalTowerEt();
+    realEta[ieta][iphi] = i.towerEta();
+    realPhi[ieta][iphi] = i.towerPhi();
+  }
+
+  float regions[nSLR][nTowerEtaSLR][nTowerPhiSLR];
+
+  for (int ieta = 0; ieta < nTowerEtaSLR; ieta++) {
+    for (int iphi = 0; iphi < nTowerPhiSLR; iphi++) {
+      for (int k = 0; k < nSLR; k++) {
+        regions[k][ieta][iphi] = 0.;
+      }
+    }
+  }
+
+  //Assign ETs to 36 21x8 regions
+
+  for (int ieta = 0; ieta < nTowerEtaSLR; ieta++) {
+    for (int iphi = 0; iphi < nTowerPhiSLR; iphi++) {
+      if (ieta > 1) {
+        if (iphi > 1)
+          regions[0][ieta][iphi] = GCTintTowers[ieta - 2][iphi - 2];
+        for (int k = 1; k < 17; k++) {
+          regions[k * 2][ieta][iphi] = GCTintTowers[ieta - 2][iphi + k * 4 - 2];
+        }
+        if (iphi < 6)
+          regions[34][ieta][iphi] = GCTintTowers[ieta - 2][iphi + 66];
+      }
+      if (ieta < 19) {
+        if (iphi > 1)
+          regions[1][ieta][iphi] = GCTintTowers[ieta + 15][iphi - 2];
+        for (int k = 1; k < 17; k++) {
+          regions[k * 2 + 1][ieta][iphi] = GCTintTowers[ieta + 15][iphi + k * 4 - 2];
+        }
+        if (iphi < 6)
+          regions[35][ieta][iphi] = GCTintTowers[ieta + 15][iphi + 66];
+      }
+    }
+  }
+
+  float temporary[nTowerEtaSLR][nTowerPhiSLR];
+  int etaoffset = 0;
+  int phioffset = 0;
+
+  //Use same code from firmware for finding clusters
+  for (int k = 0; k < nSLR; k++) {
+    for (int ieta = 0; ieta < nTowerEtaSLR; ieta++) {
+      for (int iphi = 0; iphi < nTowerPhiSLR; iphi++) {
+        temporary[ieta][iphi] = regions[k][ieta][iphi];
+      }
+    }
+    if (k % 2 == 0)
+      etaoffset = 0;
+    else
+      etaoffset = 17;
+    if (k > 1 && k % 2 == 0)
+      phioffset = phioffset + 4;
+
+    gctpf::GCTPfcluster_t tempPfclusters;
+    tempPfclusters = gctpf::pfcluster(temporary, etaoffset, phioffset);
+
+    for (int i = 0; i < nPFClusterSLR; i++) {
+      int gcteta = tempPfclusters.GCTpfclusters[i].eta;
+      int gctphi = tempPfclusters.GCTpfclusters[i].phi;
+      float towereta = realEta[gcteta][gctphi];
+      float towerphi = realPhi[gcteta][gctphi];
+      //std::cout << "Phase2L1CaloPFClusterEmulator: GCT Pfclusters energy " << tempPfclusters.GCTpfclusters[i].et
+      //          << " at ieta, iphi: (" << tempPfclusters.GCTpfclusters[i].eta << ", " << tempPfclusters.GCTpfclusters[i].phi << ")"
+      //          << " at eta, phi: (" << towereta << ", " << towerphi << ")" << std::endl;
+      l1tp2::CaloPFCluster l1CaloPFCluster;
+      l1CaloPFCluster.setClusterEt(tempPfclusters.GCTpfclusters[i].et);
+      l1CaloPFCluster.setClusterIEta(gcteta);
+      l1CaloPFCluster.setClusterIPhi(gctphi);
+      l1CaloPFCluster.setClusterEta(towereta);
+      l1CaloPFCluster.setClusterPhi(towerphi);
+      pfclusterCands->push_back(l1CaloPFCluster);
+    }
+  }
+
+  iEvent.put(std::move(pfclusterCands), "GCTPFCluster");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void Phase2L1CaloPFClusterEmulator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(Phase2L1CaloPFClusterEmulator);

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
@@ -38,7 +38,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 #include "L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h"
 
 //
@@ -48,7 +48,7 @@
 class Phase2L1CaloPFClusterEmulator : public edm::stream::EDProducer<> {
 public:
   explicit Phase2L1CaloPFClusterEmulator(const edm::ParameterSet&);
-  ~Phase2L1CaloPFClusterEmulator();
+  ~Phase2L1CaloPFClusterEmulator() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -56,16 +56,8 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // ----------member data ---------------------------
-  edm::EDGetTokenT<l1tp2::CaloTowerCollection> caloTowerToken_;
+  const edm::EDGetTokenT<l1tp2::CaloTowerCollection> caloTowerToken_;
 };
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
@@ -74,8 +66,6 @@ Phase2L1CaloPFClusterEmulator::Phase2L1CaloPFClusterEmulator(const edm::Paramete
     : caloTowerToken_(consumes<l1tp2::CaloTowerCollection>(iConfig.getParameter<edm::InputTag>("gctFullTowers"))) {
   produces<l1tp2::CaloPFClusterCollection>("GCTPFCluster");
 }
-
-Phase2L1CaloPFClusterEmulator::~Phase2L1CaloPFClusterEmulator() {}
 
 //
 // member functions
@@ -87,10 +77,10 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
   std::unique_ptr<l1tp2::CaloPFClusterCollection> pfclusterCands(make_unique<l1tp2::CaloPFClusterCollection>());
 
   edm::Handle<std::vector<l1tp2::CaloTower>> caloTowerCollection;
-  if (!iEvent.getByToken(caloTowerToken_, caloTowerCollection))
+  iEvent.getByToken(caloTowerToken_, caloTowerCollection);
+  if (!caloTowerCollection.isValid())
     cms::Exception("Phase2L1CaloPFClusterEmulator") << "Failed to get towers from caloTowerCollection!";
 
-  iEvent.getByToken(caloTowerToken_, caloTowerCollection);
   float GCTintTowers[nTowerEta][nTowerPhi];
   float realEta[nTowerEta][nTowerPhi];
   float realPhi[nTowerEta][nTowerPhi];
@@ -155,7 +145,7 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
     if (k > 1 && k % 2 == 0)
       phioffset = phioffset + 4;
 
-    gctpf::GCTPfcluster_t tempPfclusters;
+    gctpf::PFcluster_t tempPfclusters;
     tempPfclusters = gctpf::pfcluster(temporary, etaoffset, phioffset);
 
     for (int i = 0; i < nPFClusterSLR; i++) {

--- a/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloPFClusterEmulator_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloPFClusterEmulator_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tPhase2CaloPFClusterEmulator = cms.EDProducer("Phase2L1CaloPFClusterEmulator",
+						gctFullTowers = cms.InputTag("l1tPhase2L1CaloEGammaEmulator","GCTFullTowers"),
+)


### PR DESCRIPTION
#### PR description:

  - adds a data format: l1tp2::CaloPFClusterCollection 
  - depends on PR [Devel phase2eg standalone barrel emulator #1069](https://github.com/cms-l1t-offline/cmssw/pull/1069) for input GCT towers collection (ECAL clusters + HCAL towers)
  - refer to presentation here: https://indico.cern.ch/event/1209727/#2-pf-clusters-from-gct

#### PR validation:

has passed code checks in draft PR [#1075](https://github.com/cms-l1t-offline/cmssw/pull/1075) and validation plots look ok for the collections created.

![resolution_genPt_barrel](https://user-images.githubusercontent.com/10830679/229558600-0cb9157c-bfd6-440f-9ea3-ea52a9bbf7e1.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

not a backport

