### PR TITLE
Ensure cluster ecal_eta/phi are set when not running CombinedCaloLinker.

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
@@ -589,6 +589,8 @@ void l1tpf_calo::SimpleCaloLinker::run() {
           float wecal = cluster.ecal_et / cluster.et, whcal = 1.0 - wecal;
           cluster.eta = ecal.eta * wecal + hcal.eta * whcal;
           cluster.phi = ecal.phi * wecal + hcal.phi * whcal;
+          cluster.ecal_eta = cluster.eta;
+          cluster.ecal_phi = cluster.phi;
           // wrap around phi
           cluster.phi = reco::reduceRange(cluster.phi);
           cluster.constituents.emplace_back(-i - 1, 1);
@@ -617,6 +619,8 @@ void l1tpf_calo::SimpleCaloLinker::run() {
           cluster.et = myet + etot;
           cluster.eta = hcal.eta + avg_eta / cluster.et;
           cluster.phi = hcal.phi + avg_phi / cluster.et;
+          cluster.ecal_eta = cluster.eta;
+          cluster.ecal_phi = cluster.phi;
           // wrap around phi
           cluster.phi = reco::reduceRange(cluster.phi);
         }
@@ -676,6 +680,8 @@ void l1tpf_calo::FlatCaloLinker::run() {
     dst.et = src.et;
     dst.eta = src.eta;
     dst.phi = src.phi;
+    dst.ecal_eta = src.eta;
+    dst.ecal_phi = src.phi;
     dst.ecal_et = 0;
     dst.hcal_et = 0;
     for (const auto &pair : src.constituents) {


### PR DESCRIPTION
#### PR description:

This PR fixes the issue described in #1113.  The `cluster.ecal_eta/phi` variables are set to `cluster.eta/phi` when we aren't running the `CombinedCaloLinker`.  Perhaps there is a nicer way to fix this, but I believe the calo linking will ultimately be superseded by the developments in #1095.



#### PR validation:
A before/after comparison for jet eta/phi:
![image](https://github.com/cms-l1t-offline/cmssw/assets/4438699/dce4bfb4-5476-4949-8947-57cedf10c832)
![image](https://github.com/cms-l1t-offline/cmssw/assets/4438699/d4d01dfa-d8b0-46ac-ac52-1ea1b2e90927)
Blue/yellow line - tag before/after the bug was introduced
Green line - after applying the fix on the latest tag of the integration branch.

@gpetruc 