### PR TITLE
Fix hwEta/Phi in L1NNTauProducer.cc for GT emulator

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -278,8 +278,8 @@ void L1NNTauProducer::makeTau_HW(const l1t::PFCandidate& seed,
   //Firmware Tau
   l1ct::Tau l1ctTau;
   l1ctTau.hwPt = l1ct::pt_t(pt);  //l1gt is <16,11> and currently <16,14>
- l1ctTau.hwEta = l1ct::Scales::makeGlbEta(float(eta));
- l1ctTau.hwPhi = l1ct::Scales::makeGlbPhi(float(phi));
+  l1ctTau.hwEta = l1ct::Scales::makeGlbEta(seed.eta());
+  l1ctTau.hwPhi = l1ct::Scales::makeGlbPhi(seed.phi());
 
   l1ctTau.hwSeedPt = seed.pt();
   l1ctTau.hwSeedZ0 = seed.hwZ0();


### PR DESCRIPTION
#### PR description:

As per [discussion in mattermost](https://mattermost.web.cern.ch/cms-l1t-dpg/pl/4bwk6eoiyfyzdpbi1suhdwowye), Emyr suggested a fix for the `hwEta/Phi` of the Taus.

#### PR validation:

This fix indeed resolved the discrepancy between the April and current Snapshot3 version for the GT emulator, see the [plots in here](https://alobanov.web.cern.ch/L1T/Phase2/menu/Validation/compare_branches/GT_19Apr_vs_GT_15May_v2/L1/CL2Taus_hw/)