### PR TITLE
P2GMT: Disable hard-coding of debug printout

### DIFF
--- a/L1Trigger/Phase2L1GMT/plugins/Isolation.h
+++ b/L1Trigger/Phase2L1GMT/plugins/Isolation.h
@@ -65,7 +65,6 @@ namespace Phase2L1GMT {
         reliso_thrT(iConfig.getParameter<double>("RelIsoThresholdT")),
         verbose_(iConfig.getParameter<int>("verbose")),
         dumpForHLS_(iConfig.getParameter<int>("IsodumpForHLS")) {
-    dumpForHLS_ = true;
     if (dumpForHLS_) {
       dumpInput.open("Isolation_Mu_Track_infolist.txt", std::ofstream::out);
       dumpOutput.open("Isolation_Mu_Isolation.txt", std::ofstream::out);


### PR DESCRIPTION
I'd request removing this line that override the configuration switch for the isolation dump (maybe it was left there by mistake?). 
Otherwise, when running on many events one can end up with huge debug textfiles, that were probably meant anyway only for the use of the GMT developers.

@zhenbinwu @folguera