### PR TITLE
Phase 2 match GTTFileWriter cfi and source parameter name

### DIFF
--- a/L1Trigger/DemonstratorTools/python/l1tGTTFileWriter_cfi.py
+++ b/L1Trigger/DemonstratorTools/python/l1tGTTFileWriter_cfi.py
@@ -15,6 +15,6 @@ l1tGTTFileWriter = cms.EDAnalyzer('GTTFileWriter',
   vertexAssociatedTracksFilename = cms.untracked.string("L1GTTVertexAssociatedTracksFile"),
   outputCorrelatorFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
   outputGlobalTriggerFilename = cms.untracked.string("L1GTTOutputToGlobalTriggerFile"),
-  FileExtension = cms.untracked.string("txt"),
+  fileExtension = cms.untracked.string("txt"),
   format = cms.untracked.string("APx")
 )


### PR DESCRIPTION
Fixes capitalization in parameter ```FileExtension``` -> ```fileExtension``` to match ```L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc```