### PR TITLE
Phase 2 GTT MET cos LUT update (backport)

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -28,6 +28,9 @@ namespace l1tmetemu {
   const unsigned int kGlobalPhiExtra{4};
   const unsigned int kCosLUTSize{10};
   const unsigned int kCosLUTMagSize{1};
+  const unsigned int kCosLUTTableSize{10};
+  const unsigned int kCosLUTBins{1 << kCosLUTTableSize};
+  const unsigned int kCosLUTShift{TTTrack_TrackWord::TrackBitWidths::kPhiSize - kCosLUTTableSize};
   const unsigned int kAtanLUTSize{64};
   const unsigned int kAtanLUTMagSize{2};
 
@@ -61,7 +64,7 @@ namespace l1tmetemu {
     METWordphi_t Phi;
   };
 
-  std::vector<cos_lut_fixed_t> generateCosLUT(unsigned int size);
+  std::vector<cos_lut_fixed_t> generateCosLUT();
 
   global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift);
 

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -3,15 +3,16 @@
 using namespace std;
 
 namespace l1tmetemu {
-  std::vector<cos_lut_fixed_t> generateCosLUT(unsigned int size) {  // Fill cosine LUT with integer values
+  std::vector<cos_lut_fixed_t> generateCosLUT() {  // Fill cosine LUT with integer values
     float phi = 0;
     std::vector<cos_lut_fixed_t> cosLUT;
-    for (unsigned int LUT_idx = 0; LUT_idx < size; LUT_idx++) {
+    double stepPhi = TTTrack_TrackWord::stepPhi0 * (1 << l1tmetemu::kCosLUTShift);
+    for (unsigned int LUT_idx = 0; LUT_idx < l1tmetemu::kCosLUTBins; LUT_idx++) {
       cosLUT.push_back((cos_lut_fixed_t)(cos(phi)));
-      phi += TTTrack_TrackWord::stepPhi0;
+      phi += stepPhi;
       //std::cout << LUT_idx << "," << (cos_lut_fixed_t)(cos(phi)) << std::endl;
     }
-    cosLUT.push_back((cos_lut_fixed_t)(0));  //Prevent overflow in last bin
+    cosLUT[1023] = (cos_lut_fixed_t)(0);  //Match F/W for Integration Tests
     return cosLUT;
   }
 


### PR DESCRIPTION
#### PR description:

This PR brings the emulation into agreement with the firmware, where a harder cap on the LUT for cos (sin) function lookups (of tracks' phi value entering the L1T MET algorithm) is imposed to meet timing. This reduction in granularity is not expected to produce notable changes in the MET, as the changes merely depopulate the LUT of duplicate values (see https://gitlab.cern.ch/GTT/LibHLS/-/commit/4152f378fc26b06abe6541396c95717ee643ef7c).

This PR corresponds to the gtt/LibHLS PR for the branch here:
https://gitlab.cern.ch/GTT/LibHLS/-/tree/met_cosLUT_update

and to the PR in master
https://github.com/cms-sw/cmssw/pull/42347

#### PR validation:

compiles
scram b code-checks; scram b code-format pass
runs GTT test vector generation successfully, indicating no breaking changes introduced
test vectors generated with this PR match corresponding firmware simulation in the above branch of the HLS repository

This PR is the backport to the cms-l1t-offline Phase 2 integration branch
