### PR TITLE
Name change of jetCalibrationLUTFile (backport of PR42705)

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/caloParams_2023_v0_4_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2023_v0_4_cfi.py
@@ -43,7 +43,7 @@ caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone(
     jetCalibrationType         = "LUT",
     jetCompressPtLUTFile       = "L1Trigger/L1TCalorimeter/data/lut_pt_compress_2017v1.txt",
     jetCompressEtaLUTFile      = "L1Trigger/L1TCalorimeter/data/lut_eta_compress_2017v1.txt",
-    jetCalibrationLUTFile      = "L1Trigger/L1TCalorimeter/data/lut_calib_2023_v0_ECALZS_PhiRingPUS.txt",
+    jetCalibrationLUTFile      = "L1Trigger/L1TCalorimeter/data/lut_calib_2023v0_ECALZS_PhiRing.txt",
 
 
     # sums: 0=ET, 1=HT, 2=MET, 3=MHT


### PR DESCRIPTION
In the context of ntuple production, this LUT file name is incorrectly named in the caloParams python code. It is meant to have the same name as it has in previous versions of the caloParams code.

Backport of https://github.com/cms-sw/cmssw/pull/42705.