### PR TITLE
MET cosLUT overflow

### DIFF
--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -41,9 +41,9 @@ namespace l1t::demo::codecs {
       math::XYZTLorentzVector v(0, 0, 0, 0);
       l1t::EtSum s(v,
                    l1t::EtSum::EtSumType::kMissingEt,
-                   l1tmetemu::METWord_t(x(1 + l1tmetemu::kMETSize, 1)),
+                   l1tmetemu::METWord_t(x(l1tmetemu::kMETSize, 1)),
                    0,
-                   l1tmetemu::METWordphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(),
+                   l1tmetemu::METWordphi_t(x(l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 1 + l1tmetemu::kMETSize)).to_int(),
                    0);
       etSums.push_back(s);
     }

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -39,12 +39,13 @@ namespace l1t::demo::codecs {
         break;
 
       math::XYZTLorentzVector v(0, 0, 0, 0);
-      l1t::EtSum s(v,
-                   l1t::EtSum::EtSumType::kMissingEt,
-                   l1tmetemu::METWord_t(x(l1tmetemu::kMETSize, 1)),
-                   0,
-                   l1tmetemu::METWordphi_t(x(l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 1 + l1tmetemu::kMETSize)).to_int(),
-                   0);
+      l1t::EtSum s(
+          v,
+          l1t::EtSum::EtSumType::kMissingEt,
+          l1tmetemu::METWord_t(x(l1tmetemu::kMETSize, 1)),
+          0,
+          l1tmetemu::METWordphi_t(x(l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 1 + l1tmetemu::kMETSize)).to_int(),
+          0);
       etSums.push_back(s);
     }
 

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -29,7 +29,7 @@ namespace l1tmetemu {
   const unsigned int kCosLUTSize{10};
   const unsigned int kCosLUTMagSize{1};
   const unsigned int kCosLUTTableSize{10};
-  const unsigned int kCosLUTBins{1 << kCosLUTTableSize};
+  const unsigned int kCosLUTBins{(1 << kCosLUTTableSize) + 1};
   const unsigned int kCosLUTShift{TTTrack_TrackWord::TrackBitWidths::kPhiSize - kCosLUTTableSize};
   const unsigned int kAtanLUTSize{64};
   const unsigned int kAtanLUTMagSize{2};

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -227,9 +227,6 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
               << " Emu Cos(Phi): " << cosLUT_[(phiQuadrants_[4] - 1 - globalPhi) >> l1tmetemu::kCosLUTShift]
               << " Emu Sin(Phi): -" << cosLUT_[(globalPhi - phiQuadrants_[3]) >> l1tmetemu::kCosLUTShift] << "\n";
         }
-      } else {
-        temppx = 0;
-        temppy = 0;
       }
 
       int link_number = (track->phiSector() * 2) + ((EtaSector) ? 0 : 1);

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -12,7 +12,6 @@ namespace l1tmetemu {
       phi += stepPhi;
       //std::cout << LUT_idx << "," << (cos_lut_fixed_t)(cos(phi)) << std::endl;
     }
-    cosLUT[1023] = (cos_lut_fixed_t)(0);  //Match F/W for Integration Tests
     return cosLUT;
   }
 


### PR DESCRIPTION
#### PR description:

This PR backports two commits from @NJManganelli that were already merged into central CMSSW in cms-sw/cmssw#42553. It also removes the artificial assignment of `cosLUT[1023] = 0`.

This corresponds to [PR #31 in the LibHLS repo](https://gitlab.cern.ch/GTT/LibHLS/-/merge_requests/31).

Unrelated, but it also fixes a couple of minor off-by-one bugs in `l1t::demo::codecs::decodeEtSums`.

#### PR validation:

The code compiles and was run using L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py, all without error. And the usual code-checks and code-format targets were run.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial backport of cms-sw/cmssw#42553.
