### PR TITLE
Add jet collections

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -60,7 +60,7 @@ public:
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
 
   explicit L1TruthTrackFastJetProducer(const edm::ParameterSet&);
-  ~L1TruthTrackFastJetProducer() override;
+  ~L1TruthTrackFastJetProducer() = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -100,9 +100,6 @@ L1TruthTrackFastJetProducer::L1TruthTrackFastJetProducer(const edm::ParameterSet
   else
     produces<TkJetCollection>("L1TruthTrackFastJets");
 }
-
-// destructor
-L1TruthTrackFastJetProducer::~L1TruthTrackFastJetProducer() {}
 
 // producer
 void L1TruthTrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -60,7 +60,7 @@ public:
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
 
   explicit L1TruthTrackFastJetProducer(const edm::ParameterSet&);
-  ~L1TruthTrackFastJetProducer() = default;
+  ~L1TruthTrackFastJetProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -204,11 +204,18 @@ void L1TruthTrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSe
 }
 
 void L1TruthTrackFastJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
+  // The following says we do not know what parameters are allowed so do no validation
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("L1TrackInputTag", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));
+  desc.add<edm::InputTag>("MCTruthTrackInputTag", edm::InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"));
+  desc.add<double>("trk_zMax", 15.);
+  desc.add<double>("trk_ptMin", 2.0);
+  desc.add<double>("trk_etaMax", 2.4);
+  desc.add<int>("trk_nStubMin", 4);
+  desc.add<int>("trk_nPSStubMin", -1);
+  desc.add<double>("coneSize", 0.4);
+  desc.add<bool>("displaced", false);
+  descriptions.add("l1tTruthTrackFastJets", desc);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -68,13 +68,13 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // track selection criteria
-  const float trkZMax_;          // in [cm]
-  const float trkPtMin_;         // in [GeV]
-  const float trkEtaMax_;        // in [rad]
-  const int trkNStubMin_;        // minimum number of stubs
-  const int trkNPSStubMin_;      // minimum number of PS stubs
-  const double coneSize_;        // Use anti-kt with this cone size
-  const bool displaced_;         //use prompt/displaced tracks
+  const float trkZMax_;      // in [cm]
+  const float trkPtMin_;     // in [GeV]
+  const float trkEtaMax_;    // in [rad]
+  const int trkNStubMin_;    // minimum number of stubs
+  const int trkNPSStubMin_;  // minimum number of PS stubs
+  const double coneSize_;    // Use anti-kt with this cone size
+  const bool displaced_;     //use prompt/displaced tracks
 
   const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
@@ -95,7 +95,6 @@ L1TruthTrackFastJetProducer::L1TruthTrackFastJetProducer(const edm::ParameterSet
       tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
       ttTrackMCTruthToken_(consumes<TTTrackAssociationMap<Ref_Phase2TrackerDigi_> >(
           iConfig.getParameter<edm::InputTag>("MCTruthTrackInputTag"))) {
-
   if (displaced_)
     produces<TkJetCollection>("L1TruthTrackFastJetsExtended");
   else
@@ -162,10 +161,10 @@ void L1TruthTrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSe
 
     // check that trk is real and from hard interaction
     edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(l1track_ptr);
-    if (my_tp.isNull()) // there is no tp match so the track is fake
+    if (my_tp.isNull())  // there is no tp match so the track is fake
       continue;
     int tp_eventid = my_tp->eventId().event();
-    if (tp_eventid > 0) // matched tp is from pileup
+    if (tp_eventid > 0)  // matched tp is from pileup
       continue;
 
     fastjet::PseudoJet psuedoJet(iterL1Track->momentum().x(),

--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -124,19 +124,17 @@ void L1TruthTrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSe
   for (iterL1Track = TTTrackHandle->begin(); iterL1Track != TTTrackHandle->end(); iterL1Track++) {
     edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > l1track_ptr(TTTrackHandle, this_l1track);
     this_l1track++;
-    float trk_pt = iterL1Track->momentum().perp();
-    float trk_z0 = iterL1Track->z0();
     std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
         theStubs = iterL1Track->getStubRefs();
-    int trk_nstub = (int)theStubs.size();
-
+    
     // standard quality cuts
-    if (std::abs(trk_z0) > trkZMax_)
+    if (std::abs(iterL1Track->z0()) > trkZMax_)
       continue;
     if (std::abs(iterL1Track->momentum().eta()) > trkEtaMax_)
       continue;
-    if (trk_pt < trkPtMin_)
+    if (iterL1Track->momentum().perp() < trkPtMin_)
       continue;
+    int trk_nstub = (int)theStubs.size();
     if (trk_nstub < trkNStubMin_)
       continue;
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -126,7 +126,7 @@ void L1TruthTrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSe
     this_l1track++;
     std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
         theStubs = iterL1Track->getStubRefs();
-    
+
     // standard quality cuts
     if (std::abs(iterL1Track->z0()) > trkZMax_)
       continue;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TruthTrackFastJetProducer.cc
@@ -1,0 +1,219 @@
+///////////////////////////////////////////////////////////////////////////
+//                                                                       //
+// Producer of TruTrkFastJet,                                            //
+// Cluster L1 tracks with truth info using fastjet                       //
+//                                                                       //
+// Created by: Claire Savard (Oct. 2023)                                 //
+//                                                                       //
+///////////////////////////////////////////////////////////////////////////
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+// L1 objects
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TCorrelator/interface/TkJet.h"
+#include "DataFormats/L1TCorrelator/interface/TkJetFwd.h"
+#include "DataFormats/L1Trigger/interface/Vertex.h"
+
+// MC
+#include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+
+// geometry
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include <fastjet/JetDefinition.hh>
+
+#include <string>
+#include "TMath.h"
+#include "TH1.h"
+
+using namespace l1t;
+using namespace edm;
+using namespace std;
+
+//////////////////////////////
+//                          //
+//     CLASS DEFINITION     //
+//                          //
+//////////////////////////////
+
+class L1TruthTrackFastJetProducer : public edm::stream::EDProducer<> {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
+
+  explicit L1TruthTrackFastJetProducer(const edm::ParameterSet&);
+  ~L1TruthTrackFastJetProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // track selection criteria
+  const float trkZMax_;          // in [cm]
+  const float trkPtMin_;         // in [GeV]
+  const float trkEtaMax_;        // in [rad]
+  const int trkNStubMin_;        // minimum number of stubs
+  const int trkNPSStubMin_;      // minimum number of PS stubs
+  const double coneSize_;        // Use anti-kt with this cone size
+  const bool displaced_;         //use prompt/displaced tracks
+
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::EDGetTokenT<TTTrackAssociationMap<Ref_Phase2TrackerDigi_> > ttTrackMCTruthToken_;
+};
+
+// constructor
+L1TruthTrackFastJetProducer::L1TruthTrackFastJetProducer(const edm::ParameterSet& iConfig)
+    : trkZMax_((float)iConfig.getParameter<double>("trk_zMax")),
+      trkPtMin_((float)iConfig.getParameter<double>("trk_ptMin")),
+      trkEtaMax_((float)iConfig.getParameter<double>("trk_etaMax")),
+      trkNStubMin_((int)iConfig.getParameter<int>("trk_nStubMin")),
+      trkNPSStubMin_((int)iConfig.getParameter<int>("trk_nPSStubMin")),
+      coneSize_((float)iConfig.getParameter<double>("coneSize")),
+      displaced_(iConfig.getParameter<bool>("displaced")),
+      trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
+      tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
+      ttTrackMCTruthToken_(consumes<TTTrackAssociationMap<Ref_Phase2TrackerDigi_> >(
+          iConfig.getParameter<edm::InputTag>("MCTruthTrackInputTag"))) {
+
+  if (displaced_)
+    produces<TkJetCollection>("L1TruthTrackFastJetsExtended");
+  else
+    produces<TkJetCollection>("L1TruthTrackFastJets");
+}
+
+// destructor
+L1TruthTrackFastJetProducer::~L1TruthTrackFastJetProducer() {}
+
+// producer
+void L1TruthTrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::unique_ptr<TkJetCollection> L1TrackFastJets(new TkJetCollection);
+
+  // L1 tracks
+  edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > TTTrackHandle;
+  iEvent.getByToken(trackToken_, TTTrackHandle);
+  std::vector<TTTrack<Ref_Phase2TrackerDigi_> >::const_iterator iterL1Track;
+
+  // MC truth
+  edm::Handle<TTTrackAssociationMap<Ref_Phase2TrackerDigi_> > MCTruthTTTrackHandle;
+  iEvent.getByToken(ttTrackMCTruthToken_, MCTruthTTTrackHandle);
+
+  // Tracker Topology
+  const TrackerTopology& tTopo = iSetup.getData(tTopoToken_);
+
+  fastjet::JetDefinition jet_def(fastjet::antikt_algorithm, coneSize_);
+  std::vector<fastjet::PseudoJet> JetInputs;
+
+  unsigned int this_l1track = 0;
+  for (iterL1Track = TTTrackHandle->begin(); iterL1Track != TTTrackHandle->end(); iterL1Track++) {
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > l1track_ptr(TTTrackHandle, this_l1track);
+    this_l1track++;
+    float trk_pt = iterL1Track->momentum().perp();
+    float trk_z0 = iterL1Track->z0();
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+        theStubs = iterL1Track->getStubRefs();
+    int trk_nstub = (int)theStubs.size();
+
+    // standard quality cuts
+    if (std::abs(trk_z0) > trkZMax_)
+      continue;
+    if (std::abs(iterL1Track->momentum().eta()) > trkEtaMax_)
+      continue;
+    if (trk_pt < trkPtMin_)
+      continue;
+    if (trk_nstub < trkNStubMin_)
+      continue;
+
+    int trk_nPS = 0;
+    for (int istub = 0; istub < trk_nstub; istub++) {
+      DetId detId(theStubs.at(istub)->getDetId());
+      bool tmp_isPS = false;
+      if (detId.det() == DetId::Detector::Tracker) {
+        if (detId.subdetId() == StripSubdetector::TOB && tTopo.tobLayer(detId) <= 3)
+          tmp_isPS = true;
+        else if (detId.subdetId() == StripSubdetector::TID && tTopo.tidRing(detId) <= 9)
+          tmp_isPS = true;
+      }
+      if (tmp_isPS)
+        trk_nPS++;
+    }
+    if (trk_nPS < trkNPSStubMin_)
+      continue;
+
+    // check that trk is real and from hard interaction
+    edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(l1track_ptr);
+    if (my_tp.isNull()) // there is no tp match so the track is fake
+      continue;
+    int tp_eventid = my_tp->eventId().event();
+    if (tp_eventid > 0) // matched tp is from pileup
+      continue;
+
+    fastjet::PseudoJet psuedoJet(iterL1Track->momentum().x(),
+                                 iterL1Track->momentum().y(),
+                                 iterL1Track->momentum().z(),
+                                 iterL1Track->momentum().mag());
+    JetInputs.push_back(psuedoJet);                     // input tracks for clustering
+    JetInputs.back().set_user_index(this_l1track - 1);  // save track index in the collection
+  }                                                     // end loop over tracks
+
+  fastjet::ClusterSequence cs(JetInputs, jet_def);  // define the output jet collection
+  std::vector<fastjet::PseudoJet> JetOutputs =
+      fastjet::sorted_by_pt(cs.inclusive_jets(0));  // output jet collection, pT-ordered
+
+  for (unsigned int ijet = 0; ijet < JetOutputs.size(); ++ijet) {
+    math::XYZTLorentzVector jetP4(
+        JetOutputs[ijet].px(), JetOutputs[ijet].py(), JetOutputs[ijet].pz(), JetOutputs[ijet].modp());
+    float sumpt = 0;
+    float avgZ = 0;
+    std::vector<edm::Ptr<L1TTTrackType> > L1TrackPtrs;
+    std::vector<fastjet::PseudoJet> fjConstituents = fastjet::sorted_by_pt(cs.constituents(JetOutputs[ijet]));
+
+    for (unsigned int i = 0; i < fjConstituents.size(); ++i) {
+      auto index = fjConstituents[i].user_index();
+      edm::Ptr<L1TTTrackType> trkPtr(TTTrackHandle, index);
+      L1TrackPtrs.push_back(trkPtr);  // L1Tracks in the jet
+      sumpt = sumpt + trkPtr->momentum().perp();
+      avgZ = avgZ + trkPtr->momentum().perp() * trkPtr->z0();
+    }
+    avgZ = avgZ / sumpt;
+    edm::Ref<JetBxCollection> jetRef;
+    TkJet trkJet(jetP4, jetRef, L1TrackPtrs, avgZ);
+    L1TrackFastJets->push_back(trkJet);
+  }  //end loop over Jet Outputs
+
+  if (displaced_)
+    iEvent.put(std::move(L1TrackFastJets), "L1TruthTrackFastJetsExtended");
+  else
+    iEvent.put(std::move(L1TrackFastJets), "L1TruthTrackFastJets");
+}
+
+void L1TruthTrackFastJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TruthTrackFastJetProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -57,7 +57,6 @@ using namespace std;
 
 class TPFastJetProducer : public edm::stream::EDProducer<> {
 public:
-
   explicit TPFastJetProducer(const edm::ParameterSet&);
   ~TPFastJetProducer() override;
 
@@ -72,10 +71,10 @@ private:
   const float tpZMax_;
   const int tpNStubMin_;
   const int tpNStubLayerMin_;
-  const float coneSize_;        // Use anti-kt with this cone size
+  const float coneSize_;  // Use anti-kt with this cone size
 
-  edm::EDGetTokenT<std::vector<TrackingParticle> > trackingParticleToken_;
-  edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_> > ttStubMCTruthToken_;
+  edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticleToken_;
+  edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> ttStubMCTruthToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
 };
 
@@ -87,8 +86,10 @@ TPFastJetProducer::TPFastJetProducer(const edm::ParameterSet& iConfig)
       tpNStubMin_((int)iConfig.getParameter<int>("tp_nStubMin")),
       tpNStubLayerMin_((int)iConfig.getParameter<int>("tp_nStubLayerMin")),
       coneSize_((float)iConfig.getParameter<double>("coneSize")),
-      trackingParticleToken_(consumes<std::vector<TrackingParticle> >(iConfig.getParameter<edm::InputTag>("TrackingParticleInputTag"))),
-      ttStubMCTruthToken_(consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_> >(iConfig.getParameter<edm::InputTag>("MCTruthStubInputTag"))),
+      trackingParticleToken_(
+          consumes<std::vector<TrackingParticle>>(iConfig.getParameter<edm::InputTag>("TrackingParticleInputTag"))),
+      ttStubMCTruthToken_(consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>(
+          iConfig.getParameter<edm::InputTag>("MCTruthStubInputTag"))),
       tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))) {
   produces<TkJetCollection>("TPFastJets");
 }
@@ -106,7 +107,7 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   std::vector<TrackingParticle>::const_iterator iterTP;
 
   // MC truth association maps
-  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_> > MCTruthTTStubHandle;
+  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTStubHandle;
   iEvent.getByToken(ttStubMCTruthToken_, MCTruthTTStubHandle);
 
   // Tracker Topology
@@ -127,8 +128,8 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     float tp_z0 = iterTP->z0();
     int tp_eventid = iterTP->eventId().event();
 
-    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
-      theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+        theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
     int nStubTP = (int)theStubRefs.size();
 
     // how many layers/disks have stubs?
@@ -170,18 +171,15 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       continue;
     if (fabs(tp_z0) > tpZMax_)
       continue;
-    if (tp_charge == 0.) // extra check that all tps are charged  
+    if (tp_charge == 0.)  // extra check that all tps are charged
       continue;
-    if (tp_eventid>0) // only select hard interaction tps
+    if (tp_eventid > 0)  // only select hard interaction tps
       continue;
 
-    fastjet::PseudoJet psuedoJet(iterTP->px(),
-                                 iterTP->py(),
-                                 iterTP->pz(),
-                                 iterTP->energy());
-    JetInputs.push_back(psuedoJet);                     // input tps for clustering
+    fastjet::PseudoJet psuedoJet(iterTP->px(), iterTP->py(), iterTP->pz(), iterTP->energy());
+    JetInputs.push_back(psuedoJet);                // input tps for clustering
     JetInputs.back().set_user_index(this_tp - 1);  // save tp index in the collection
-  }                                                     // end loop over tps
+  }                                                // end loop over tps
 
   fastjet::ClusterSequence cs(JetInputs, jet_def);  // define the output jet collection
   std::vector<fastjet::PseudoJet> JetOutputs =
@@ -192,7 +190,7 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
         JetOutputs[ijet].px(), JetOutputs[ijet].py(), JetOutputs[ijet].pz(), JetOutputs[ijet].modp());
     float sumpt = 0;
     float avgZ = 0;
-    std::vector<edm::Ptr<TrackingParticle> > tpPtrs;
+    std::vector<edm::Ptr<TrackingParticle>> tpPtrs;
     std::vector<fastjet::PseudoJet> fjConstituents = fastjet::sorted_by_pt(cs.constituents(JetOutputs[ijet]));
 
     for (unsigned int i = 0; i < fjConstituents.size(); ++i) {
@@ -204,7 +202,7 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     }
     avgZ = avgZ / sumpt;
     edm::Ref<JetBxCollection> jetRef;
-    std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> > dummyL1TrackPtrs; // can't create TkJet with tp references
+    std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>> dummyL1TrackPtrs;  // can't create TkJet with tp references
     TkJet tpJet(jetP4, dummyL1TrackPtrs, avgZ, fjConstituents.size(), 0, 0, 0, false);
     TPFastJets->push_back(tpJet);
   }  //end loop over Jet Outputs

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -1,0 +1,224 @@
+///////////////////////////////////////////////////////////////////////////
+//                                                                       //
+// Producer of TPFastJets,                                               //
+// Cluster tracking particles using fastjet                              //
+//                                                                       //
+// Created by: Claire Savard (Oct. 2023)                                 //
+//                                                                       //
+///////////////////////////////////////////////////////////////////////////
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+// L1 objects
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TCorrelator/interface/TkJet.h"
+#include "DataFormats/L1TCorrelator/interface/TkJetFwd.h"
+#include "DataFormats/L1Trigger/interface/Vertex.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+
+// truth object
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
+
+// geometry
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include <fastjet/JetDefinition.hh>
+
+#include <string>
+#include "TMath.h"
+#include "TH1.h"
+
+using namespace l1t;
+using namespace edm;
+using namespace std;
+
+//////////////////////////////
+//                          //
+//     CLASS DEFINITION     //
+//                          //
+//////////////////////////////
+
+class TPFastJetProducer : public edm::stream::EDProducer<> {
+public:
+
+  explicit TPFastJetProducer(const edm::ParameterSet&);
+  ~TPFastJetProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // track selection criteria
+  const float tpPtMin_;
+  const float tpEtaMax_;
+  const float tpZMax_;
+  const int tpNStubMin_;
+  const int tpNStubLayerMin_;
+  const float coneSize_;        // Use anti-kt with this cone size
+
+  edm::EDGetTokenT<std::vector<TrackingParticle> > trackingParticleToken_;
+  edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_> > ttStubMCTruthToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+};
+
+// constructor
+TPFastJetProducer::TPFastJetProducer(const edm::ParameterSet& iConfig)
+    : tpPtMin_((float)iConfig.getParameter<double>("tp_ptMin")),
+      tpEtaMax_((float)iConfig.getParameter<double>("tp_etaMax")),
+      tpZMax_((float)iConfig.getParameter<double>("tp_zMax")),
+      tpNStubMin_((int)iConfig.getParameter<int>("tp_nStubMin")),
+      tpNStubLayerMin_((int)iConfig.getParameter<int>("tp_nStubLayerMin")),
+      coneSize_((float)iConfig.getParameter<double>("coneSize")),
+      trackingParticleToken_(consumes<std::vector<TrackingParticle> >(iConfig.getParameter<edm::InputTag>("TrackingParticleInputTag"))),
+      ttStubMCTruthToken_(consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_> >(iConfig.getParameter<edm::InputTag>("MCTruthStubInputTag"))),
+      tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))) {
+  produces<TkJetCollection>("TPFastJets");
+}
+
+// destructor
+TPFastJetProducer::~TPFastJetProducer() {}
+
+// producer
+void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::unique_ptr<TkJetCollection> TPFastJets(new TkJetCollection);
+
+  // Tracking particles
+  edm::Handle<std::vector<TrackingParticle>> TrackingParticleHandle;
+  iEvent.getByToken(trackingParticleToken_, TrackingParticleHandle);
+  std::vector<TrackingParticle>::const_iterator iterTP;
+
+  // MC truth association maps
+  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_> > MCTruthTTStubHandle;
+  iEvent.getByToken(ttStubMCTruthToken_, MCTruthTTStubHandle);
+
+  // Tracker Topology
+  const TrackerTopology& tTopo = iSetup.getData(tTopoToken_);
+
+  fastjet::JetDefinition jet_def(fastjet::antikt_algorithm, coneSize_);
+  std::vector<fastjet::PseudoJet> JetInputs;
+
+  // loop over tps
+  unsigned int this_tp = 0;
+  for (iterTP = TrackingParticleHandle->begin(); iterTP != TrackingParticleHandle->end(); iterTP++) {
+    edm::Ptr<TrackingParticle> tp_ptr(TrackingParticleHandle, this_tp);
+    this_tp++;
+
+    float tp_pt = iterTP->pt();
+    float tp_eta = iterTP->eta();
+    float tp_charge = iterTP->charge();
+    float tp_z0 = iterTP->z0();
+    int tp_eventid = iterTP->eventId().event();
+
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+      theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
+    int nStubTP = (int)theStubRefs.size();
+
+    // how many layers/disks have stubs?
+    int hasStubInLayer[11] = {0};
+    for (auto& theStubRef : theStubRefs) {
+      DetId detid(theStubRef->getDetId());
+
+      int layer = -1;
+      if (detid.subdetId() == StripSubdetector::TOB) {
+        layer = static_cast<int>(tTopo.layer(detid)) - 1;  //fill in array as entries 0-5
+      } else if (detid.subdetId() == StripSubdetector::TID) {
+        layer = static_cast<int>(tTopo.layer(detid)) + 5;  //fill in array as entries 6-10
+      }
+
+      //treat genuine stubs separately (==2 is genuine, ==1 is not)
+      if (MCTruthTTStubHandle->findTrackingParticlePtr(theStubRef).isNull() && hasStubInLayer[layer] < 2)
+        hasStubInLayer[layer] = 1;
+      else
+        hasStubInLayer[layer] = 2;
+    }
+
+    int nStubLayerTP = 0;
+    int nStubLayerTP_g = 0;
+    for (int isum : hasStubInLayer) {
+      if (isum >= 1)
+        nStubLayerTP += 1;
+      if (isum == 2)
+        nStubLayerTP_g += 1;
+    }
+
+    // tp quality cuts to match L1 tracks
+    if (tp_pt < tpPtMin_)
+      continue;
+    if (fabs(tp_eta) > tpEtaMax_)
+      continue;
+    if (nStubTP < tpNStubMin_)
+      continue;
+    if (nStubLayerTP < tpNStubLayerMin_)
+      continue;
+    if (fabs(tp_z0) > tpZMax_)
+      continue;
+    if (tp_charge == 0.) // extra check that all tps are charged  
+      continue;
+    if (tp_eventid>0) // only select hard interaction tps
+      continue;
+
+    fastjet::PseudoJet psuedoJet(iterTP->px(),
+                                 iterTP->py(),
+                                 iterTP->pz(),
+                                 iterTP->energy());
+    JetInputs.push_back(psuedoJet);                     // input tps for clustering
+    JetInputs.back().set_user_index(this_tp - 1);  // save tp index in the collection
+  }                                                     // end loop over tps
+
+  fastjet::ClusterSequence cs(JetInputs, jet_def);  // define the output jet collection
+  std::vector<fastjet::PseudoJet> JetOutputs =
+      fastjet::sorted_by_pt(cs.inclusive_jets(0));  // output jet collection, pT-ordered
+
+  for (unsigned int ijet = 0; ijet < JetOutputs.size(); ++ijet) {
+    math::XYZTLorentzVector jetP4(
+        JetOutputs[ijet].px(), JetOutputs[ijet].py(), JetOutputs[ijet].pz(), JetOutputs[ijet].modp());
+    float sumpt = 0;
+    float avgZ = 0;
+    std::vector<edm::Ptr<TrackingParticle> > tpPtrs;
+    std::vector<fastjet::PseudoJet> fjConstituents = fastjet::sorted_by_pt(cs.constituents(JetOutputs[ijet]));
+
+    for (unsigned int i = 0; i < fjConstituents.size(); ++i) {
+      auto index = fjConstituents[i].user_index();
+      edm::Ptr<TrackingParticle> tpPtr(TrackingParticleHandle, index);
+      tpPtrs.push_back(tpPtr);  // tracking particles in the jet
+      sumpt = sumpt + tpPtr->pt();
+      avgZ = avgZ + tpPtr->pt() * tpPtr->z0();
+    }
+    avgZ = avgZ / sumpt;
+    edm::Ref<JetBxCollection> jetRef;
+    std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> > dummyL1TrackPtrs; // can't create TkJet with tp references
+    TkJet tpJet(jetP4, dummyL1TrackPtrs, avgZ, fjConstituents.size(), 0, 0, 0, false);
+    TPFastJets->push_back(tpJet);
+  }  //end loop over Jet Outputs
+
+  iEvent.put(std::move(TPFastJets), "TPFastJets");
+}
+
+void TPFastJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(TPFastJetProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -208,11 +208,17 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 }
 
 void TPFastJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
+  // The following says we do not know what parameters are allowed so do no validation
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("TrackingParticleInputTag", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("MCTruthStubInputTag", edm::InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"));
+  desc.add<double>("tp_ptMin", 2.0);
+  desc.add<double>("tp_etaMax", 2.4);
+  desc.add<double>("tp_zMax", 15.);
+  desc.add<int>("tp_nStubMin", 4);
+  desc.add<int>("tp_nStubLayerMin", 4);
+  desc.add<double>("coneSize", 0.4);
+  descriptions.add("tpFastJets", desc);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -119,12 +119,6 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     edm::Ptr<TrackingParticle> tp_ptr(TrackingParticleHandle, this_tp);
     this_tp++;
 
-    float tp_pt = iterTP->pt();
-    float tp_eta = iterTP->eta();
-    float tp_charge = iterTP->charge();
-    float tp_z0 = iterTP->z0();
-    int tp_eventid = iterTP->eventId().event();
-
     std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
         theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
     int nStubTP = (int)theStubRefs.size();
@@ -158,19 +152,19 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     }
 
     // tp quality cuts to match L1 tracks
-    if (tp_pt < tpPtMin_)
+    if (iterTP->pt() < tpPtMin_)
       continue;
-    if (fabs(tp_eta) > tpEtaMax_)
+    if (fabs(iterTP->eta()) > tpEtaMax_)
       continue;
     if (nStubTP < tpNStubMin_)
       continue;
     if (nStubLayerTP < tpNStubLayerMin_)
       continue;
-    if (fabs(tp_z0) > tpZMax_)
+    if (fabs(iterTP->z0()) > tpZMax_)
       continue;
-    if (tp_charge == 0.)  // extra check that all tps are charged
+    if (iterTP->charge() == 0.)  // extra check that all tps are charged
       continue;
-    if (tp_eventid > 0)  // only select hard interaction tps
+    if (iterTP->eventId().event() > 0)  // only select hard interaction tps
       continue;
 
     fastjet::PseudoJet psuedoJet(iterTP->px(), iterTP->py(), iterTP->pz(), iterTP->energy());

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -58,7 +58,7 @@ using namespace std;
 class TPFastJetProducer : public edm::stream::EDProducer<> {
 public:
   explicit TPFastJetProducer(const edm::ParameterSet&);
-  ~TPFastJetProducer() override;
+  ~TPFastJetProducer() = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -93,9 +93,6 @@ TPFastJetProducer::TPFastJetProducer(const edm::ParameterSet& iConfig)
       tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))) {
   produces<TkJetCollection>("TPFastJets");
 }
-
-// destructor
-TPFastJetProducer::~TPFastJetProducer() {}
 
 // producer
 void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -58,7 +58,7 @@ using namespace std;
 class TPFastJetProducer : public edm::stream::EDProducer<> {
 public:
   explicit TPFastJetProducer(const edm::ParameterSet&);
-  ~TPFastJetProducer() = default;
+  ~TPFastJetProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/TPFastJetProducer.cc
@@ -143,12 +143,9 @@ void TPFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     }
 
     int nStubLayerTP = 0;
-    int nStubLayerTP_g = 0;
     for (int isum : hasStubInLayer) {
       if (isum >= 1)
         nStubLayerTP += 1;
-      if (isum == 2)
-        nStubLayerTP_g += 1;
     }
 
     // tp quality cuts to match L1 tracks

--- a/L1Trigger/L1TTrackMatch/python/l1tTruthTrackFastJets_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTruthTrackFastJets_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tTruthTrackFastJets = cms.EDProducer("L1TruthTrackFastJetProducer",
+    L1TrackInputTag = cms.InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"),
+    MCTruthTrackInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"),
+    trk_zMax = cms.double(15.),       # max track z0 [cm]
+    trk_ptMin = cms.double(2.0),      # minimum track pt [GeV]
+    trk_etaMax = cms.double(2.4),     # maximum track eta
+    trk_nStubMin = cms.int32(4),      # minimum number of stubs in track
+    trk_nPSStubMin = cms.int32(-1),   # minimum number of PS stubs in track
+    coneSize = cms.double(0.4),       #cone size for anti-kt fast jet
+    displaced = cms.bool(False)       # use prompt/displaced tracks
+)
+
+l1tTruthTrackFastJetsExtended = cms.EDProducer("L1TruthTrackFastJetProducer",
+    L1TrackInputTag = cms.InputTag("l1tTTTracksFromExtendedTrackletEmulation", "Level1TTTracks"),
+    MCTruthTrackInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"),
+    trk_zMax = cms.double(15.),       # max track z0 [cm]
+    trk_ptMin = cms.double(3.0),      # minimum track pt [GeV]
+    trk_etaMax = cms.double(2.5),     # maximum track eta
+    trk_nStubMin = cms.int32(4),      # minimum number of stubs on track
+    trk_nPSStubMin = cms.int32(-1),   # minimum number of stubs in PS modules on track
+    coneSize=cms.double(0.4),         #cone size for anti-kt fast jet
+    displaced = cms.bool(True)        # use prompt/displaced tracks
+)

--- a/L1Trigger/L1TTrackMatch/python/tpFastJets_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/tpFastJets_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+tpFastJets = cms.EDProducer("TPFastJetProducer",
+    TrackingParticleInputTag = cms.InputTag("mix", "MergedTrackTruth"),
+    MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
+    tp_ptMin = cms.double(2.0),       # minimum tp pt [GeV]
+    tp_etaMax = cms.double(2.4),      # maximum tp eta
+    tp_zMax = cms.double(15.),        # max tp z0 [cm]
+    tp_nStubMin = cms.int32(4),       # minimum number of stubs
+    tp_nStubLayerMin = cms.int32(4),  # minimum number of layers with stubs 
+    coneSize=cms.double(0.4),         # cone size for anti-kt fast jet 
+)


### PR DESCRIPTION
#### PR description:

This PR adds two new jet collections for studying track jet performance:
1. tpfastjets clusters tracking particles with the fast jet algorithm
2. trutrkfastjets clusters L1 tracks with truth information with the fast jet algorithm

#### PR validation:

I have checked that the producers work correctly with the L1TrackObjectNtupleMaker and have run the necessary code checks.
