### PR TITLE
Phase2 hps tau 13 3

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
@@ -12,7 +12,7 @@ namespace L1HPSPFTauEmu {
 
   //mapping the eta phi onto bits
 
-  static float etaphi_base = 720. / 3.14159;
+  static float etaphi_base = 720. / M_PI;
   static float dz_base = 0.05;
   typedef ap_ufixed<16, 14> pt_t;
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
@@ -8,501 +8,432 @@
 #include <numeric>
 #include <algorithm>
 
-
 namespace L1HPSPFTauEmu {
-    
-    
-    
+
   //mapping the eta phi onto bits
 
-  
-  static float etaphi_base = 720. /3.14159;
+  static float etaphi_base = 720. / 3.14159;
   static float dz_base = 0.05;
   typedef ap_ufixed<16, 14> pt_t;
-  
+
   typedef ap_int<12> etaphi_t;
-  
+
   typedef ap_int<12> detaphi_t;
-  
+
   typedef ap_uint<20> detaphi2_t;
-  typedef ap_uint<5> count_t; //type for multiplicity
-  typedef ap_uint<3> type_t; //type for particle type
-  typedef ap_int<10> dz_t; //type for z0 cut
-  
-    
-    
-    class Particle {
-    public:
-      pt_t hwPt;
-      etaphi_t hwEta;
-      etaphi_t hwPhi;
-      type_t hwId;
-      dz_t hwZ0;
-      
-      Particle() : hwPt(0), hwEta(0), hwPhi(0), hwId(0), hwZ0() {}
-      Particle( pt_t pt, etaphi_t eta, etaphi_t phi, type_t id, dz_t z0 ) : hwPt(pt), hwEta(eta), hwPhi(phi), hwId(id), hwZ0(z0) {}
-      
-      
-      pt_t pt() const{
-          return hwPt;
-      }
-      
-      etaphi_t phi() const{
-          return hwPhi;          
-      }
-      
-      etaphi_t eta() const{
-          return hwEta;
-      }
-      type_t id() const{
-          return hwId;
-      }
-      dz_t z0() const{
-          return hwZ0;
-      }
-    };
-    
-    //template classes
-  class Tau : public Particle {
-    public:
-      Tau(pt_t pt, etaphi_t eta, etaphi_t phi, type_t id, dz_t z0) : Particle(pt, eta, phi, id, z0) {} 
-      ap_uint<5> seed_index;
-      pt_t seed_pt;
-      etaphi_t seed_eta;      
-      etaphi_t seed_phi;
-      dz_t seed_z0;
-      
-  
+  typedef ap_uint<5> count_t;  //type for multiplicity
+  typedef ap_uint<3> type_t;   //type for particle type
+  typedef ap_int<10> dz_t;     //type for z0 cut
+
+  class Particle {
+  public:
+    pt_t hwPt;
+    etaphi_t hwEta;
+    etaphi_t hwPhi;
+    type_t hwId;
+    dz_t hwZ0;
+
+    Particle() : hwPt(0), hwEta(0), hwPhi(0), hwId(0), hwZ0() {}
+    Particle(pt_t pt, etaphi_t eta, etaphi_t phi, type_t id, dz_t z0)
+        : hwPt(pt), hwEta(eta), hwPhi(phi), hwId(id), hwZ0(z0) {}
+
+    pt_t pt() const { return hwPt; }
+
+    etaphi_t phi() const { return hwPhi; }
+
+    etaphi_t eta() const { return hwEta; }
+    type_t id() const { return hwId; }
+    dz_t z0() const { return hwZ0; }
   };
-   
+
+  //template classes
+  class Tau : public Particle {
+  public:
+    Tau(pt_t pt, etaphi_t eta, etaphi_t phi, type_t id, dz_t z0) : Particle(pt, eta, phi, id, z0) {}
+    ap_uint<5> seed_index;
+    pt_t seed_pt;
+    etaphi_t seed_eta;
+    etaphi_t seed_phi;
+    dz_t seed_z0;
+  };
+
   //constants
-    static const detaphi_t TWOPI = 3.14159 * 2. * etaphi_base;
-    static const detaphi_t PI = 3.14159 * etaphi_base;
-    
-    static const detaphi_t strip_phi = 0.20* etaphi_base;
-    static const detaphi_t strip_eta = 0.05* etaphi_base;
-    
-    static const pt_t min_leadChargedPfCand_pt = 4;
-    static const detaphi_t isoConeSize = 0.4 * etaphi_base;
-    static const detaphi_t delta_Rclean = 0.4 * etaphi_base;
-    static const dz_t dzCut = 0.4 / dz_base;
-    static const detaphi_t isoConeSizeRound = 92; 
-    static const etaphi_t etaCutoff = 2.4 * etaphi_base;
-   
+  static const detaphi_t TWOPI = 3.14159 * 2. * etaphi_base;
+  static const detaphi_t PI = 3.14159 * etaphi_base;
 
-    
- template <int W, int I, ap_q_mode _AP_Q, ap_o_mode _AP_O>
-    ap_ufixed<W,I> fp_abs(ap_fixed<W,I, _AP_Q, _AP_O> x) {
-	 ap_ufixed<W,I> result;
-	  if (x < 0) {
-		result = -x;
-	  } else {
-		result = x;
-	  }
-	return result;
-}
+  static const detaphi_t strip_phi = 0.20 * etaphi_base;
+  static const detaphi_t strip_eta = 0.05 * etaphi_base;
 
-ap_uint<12> int_abs(ap_int<12> x){
-   ap_uint<12> result;
-   if (x < 0){ result = -x;}
-   else{ result = x;}
-   return result;
-}
+  static const pt_t min_leadChargedPfCand_pt = 4;
+  static const detaphi_t isoConeSize = 0.4 * etaphi_base;
+  static const detaphi_t delta_Rclean = 0.4 * etaphi_base;
+  static const dz_t dzCut = 0.4 / dz_base;
+  static const detaphi_t isoConeSizeRound = 92;
+  static const etaphi_t etaCutoff = 2.4 * etaphi_base;
 
-ap_uint<10> dz_abs(ap_int<10> x){
-    ap_uint<10> result;
-    if(x < 0){ result = -x;}
-    else{ result = x;}
-    return result;
-}
-   
-  
-    
-   bool is_charged(Particle part) {
-     bool charge = false;
-     if((part.hwId ==0) || (part.hwId == 1) || (part.hwId == 4)){
-       charge = true;
-     }
-     else{
-       charge = false;
-     }
-   return charge;
-  }   
-  
-  ap_uint<20> setSConeSize2(pt_t total_pt) {
-            
-      ap_uint<20> SignalConeSizeSquare;
-      ap_uint<10> SignalConeSize;
-      if ( total_pt < 115 ){
-            SignalConeSizeSquare = 23*23;
-            }
-          else if ( total_pt < 120 ){
-            SignalConeSizeSquare = 22*22;
-            }
-          else if ( total_pt < 126 ){
-            SignalConeSizeSquare = 21*21;
-            }
-	  else if ( total_pt < 132 ){
-            SignalConeSizeSquare = 20*20;
-            }
-	  else if ( total_pt < 139 ){
-            SignalConeSizeSquare = 19*19;
-            }
-	  else if ( total_pt < 147 ){
-            SignalConeSizeSquare = 18*18;
-            }
-	  else if ( total_pt < 156 ){
-            SignalConeSizeSquare = 17*17;
-            }
-	  else if ( total_pt < 166 ){
-            SignalConeSizeSquare = 16*16;
-            }
-	  else if ( total_pt < 178 ){
-            SignalConeSizeSquare = 15*15;
-            }
-	  else if ( total_pt < 191 ){
-            SignalConeSizeSquare = 14*14;    
-            }
-	  else if ( total_pt < 206 ){
-            SignalConeSizeSquare = 13*13;
-            }
-	  else if ( total_pt < 224 ){
-	    SignalConeSizeSquare = 12*12;}
-	  else{
-	    SignalConeSizeSquare = 12*12;
-            }
-    return SignalConeSizeSquare;     
-      
-  }    
-    
-  bool inIsolationCone(Particle part, Particle seed){
-      
-      bool inCone = false;
-      detaphi2_t isoConeSize2 = isoConeSize * isoConeSize;
-      
-    if(part.pt() != 0){
-       detaphi_t deltaEta = part.eta() - seed.eta();    
-       detaphi_t deltaPhi = part.phi() - seed.phi();    
-        if( (deltaEta*deltaEta + deltaPhi*deltaPhi) < isoConeSize2){
-            inCone = true;
-        }
-        else{
-        inCone = false;}
+  template <int W, int I, ap_q_mode _AP_Q, ap_o_mode _AP_O>
+  ap_ufixed<W, I> fp_abs(ap_fixed<W, I, _AP_Q, _AP_O> x) {
+    ap_ufixed<W, I> result;
+    if (x < 0) {
+      result = -x;
+    } else {
+      result = x;
     }
-    else{
+    return result;
+  }
+
+  template <int W>
+  inline ap_uint<W> int_abs(ap_int<W> x) {
+    ap_uint<W> result;
+    if (x < 0) {
+      result = -x;
+    } else {
+      result = x;
+    }
+    return result;
+  }
+
+  template <class inP>
+  inline bool is_charged(inP part) {
+    bool charge = false;
+    if ((part.hwId == 0) || (part.hwId == 1) || (part.hwId == 4)) {
+      charge = true;
+    } else {
+      charge = false;
+    }
+    return charge;
+  }
+
+  inline ap_uint<20> setSConeSize2(pt_t total_pt) {
+    ap_uint<20> SignalConeSizeSquare;
+    ap_uint<10> SignalConeSize;
+    if (total_pt < 115) {
+      SignalConeSizeSquare = 23 * 23;
+    } else if (total_pt < 120) {
+      SignalConeSizeSquare = 22 * 22;
+    } else if (total_pt < 126) {
+      SignalConeSizeSquare = 21 * 21;
+    } else if (total_pt < 132) {
+      SignalConeSizeSquare = 20 * 20;
+    } else if (total_pt < 139) {
+      SignalConeSizeSquare = 19 * 19;
+    } else if (total_pt < 147) {
+      SignalConeSizeSquare = 18 * 18;
+    } else if (total_pt < 156) {
+      SignalConeSizeSquare = 17 * 17;
+    } else if (total_pt < 166) {
+      SignalConeSizeSquare = 16 * 16;
+    } else if (total_pt < 178) {
+      SignalConeSizeSquare = 15 * 15;
+    } else if (total_pt < 191) {
+      SignalConeSizeSquare = 14 * 14;
+    } else if (total_pt < 206) {
+      SignalConeSizeSquare = 13 * 13;
+    } else if (total_pt < 224) {
+      SignalConeSizeSquare = 12 * 12;
+    } else {
+      SignalConeSizeSquare = 12 * 12;
+    }
+    return SignalConeSizeSquare;
+  }
+
+  inline bool inIsolationCone(Particle part, Particle seed) {
+    bool inCone = false;
+    detaphi2_t isoConeSize2 = isoConeSize * isoConeSize;
+
+    if (part.pt() != 0) {
+      detaphi_t deltaEta = part.eta() - seed.eta();
+      detaphi_t deltaPhi = part.phi() - seed.phi();
+      if ((deltaEta * deltaEta + deltaPhi * deltaPhi) < isoConeSize2) {
+        inCone = true;
+      } else {
+        inCone = false;
+      }
+    } else {
       inCone = false;
     }
-  return inCone;
+    return inCone;
+  }
 
-  }      
-    
-  bool inSignalCone(Particle part, Particle seed, const int track_count, ap_uint<20> cone2, pt_t& iso_pt, bool& isLead) {
-      //finds the signal cone candidates (including strip pt check 
-      
-        bool isPotentialLead = 0;
- 
-        isPotentialLead = is_charged(part) && part.id() != 4 && part.pt() > min_leadChargedPfCand_pt && int_abs(part.eta()) < etaCutoff;
-        
-        //calculate the deta and dphi
-        bool inCone = false;
-        
-        
-        if(part.pt() !=0){
-           detaphi_t deltaEta = part.eta() - seed.eta();    
-           detaphi_t deltaPhi = part.phi() - seed.phi(); 
-           detaphi2_t deltaEta2 = deltaEta * deltaEta;           
-           detaphi2_t deltaPhi2 = deltaPhi * deltaPhi;     
-           dz_t deltaZ = 0;
-           if(part.z0() && seed.z0()){ 
-           dz_t deltaZ = part.z0() - seed.z0();     
-           }
-          
-          if( (int_abs(deltaEta) < strip_eta) && (int_abs(deltaPhi) < strip_phi) && 
-              ( part.id() == 3 || (part.id() == 1)) ){
-              if(isPotentialLead){isLead = true;} 
-              inCone = true;
-            
-            }
-          else if( ((deltaEta2 + deltaPhi2) < cone2) && !( (part.id() == 0) && ( track_count >3)) && !(is_charged(part) && dz_abs(deltaZ) > dzCut)){
-              if(isPotentialLead){isLead = true;}
-              inCone = true;
-          }
-          else{
-            
-            if( is_charged(part) && dz_abs(deltaZ) > dzCut){
-               iso_pt += part.pt();
-               inCone = false;
-            }                
-              
-          }
-  
+  inline bool inSignalCone(
+      Particle part, Particle seed, const int track_count, ap_uint<20> cone2, pt_t& iso_pt, bool& isLead) {
+    //finds the signal cone candidates (including strip pt check
+
+    bool isPotentialLead = false;
+
+    isPotentialLead =
+        is_charged(part) && part.id() != 4 && part.pt() > min_leadChargedPfCand_pt && int_abs(part.eta()) < etaCutoff;
+
+    //calculate the deta and dphi
+    bool inCone = false;
+
+    if (part.pt() != 0) {
+      detaphi_t deltaEta = part.eta() - seed.eta();
+      detaphi_t deltaPhi = part.phi() - seed.phi();
+      detaphi2_t deltaEta2 = deltaEta * deltaEta;
+      detaphi2_t deltaPhi2 = deltaPhi * deltaPhi;
+      dz_t deltaZ = 0;
+      if (part.z0() && seed.z0()) {
+        dz_t deltaZ = part.z0() - seed.z0();
+      }
+
+      if ((int_abs(deltaEta) < strip_eta) && (int_abs(deltaPhi) < strip_phi) && (part.id() == 3 || (part.id() == 1))) {
+        if (isPotentialLead) {
+          isLead = true;
         }
-     return inCone;     
-  }    
-   
-  Tau makeHPSTauHW(const std::vector<Particle>& parts, const Particle seed, const pt_t total_pt/*, Config config*/){
-   
-   
-    using namespace L1HPSPFTauEmu;   
-    
+        inCone = true;
+
+      } else if (((deltaEta2 + deltaPhi2) < cone2) && !((part.id() == 0) && (track_count > 3)) &&
+                 !(is_charged(part) && int_abs(deltaZ) > dzCut)) {
+        if (isPotentialLead) {
+          isLead = true;
+        }
+        inCone = true;
+      } else {
+        if (is_charged(part) && int_abs(deltaZ) > dzCut) {
+          iso_pt += part.pt();
+          inCone = false;
+        }
+      }
+    }
+    return inCone;
+  }
+
+  inline Tau makeHPSTauHW(const std::vector<Particle>& parts,
+                          const Particle seed,
+                          const pt_t total_pt /*, Config config*/) {
+    using namespace L1HPSPFTauEmu;
+
     ap_uint<20> scone2 = setSConeSize2(total_pt);
 
     pt_t isocone_pt = 0;
-    
-    
+
     pt_t sum_pt = 0;
-    
-    ap_fixed<22,20> sum_eta = 0;
-    ap_fixed<22,20> sum_phi = 0;    
+
+    ap_fixed<22, 20> sum_eta = 0;
+    ap_fixed<22, 20> sum_phi = 0;
 
     pt_t tau_pt = 0;
     etaphi_t tau_eta = 0;
     etaphi_t tau_phi = 0;
-   
 
-    pt_t chargedIsoPileup = 0; 
+    pt_t chargedIsoPileup = 0;
     std::vector<Particle> signalParts;
     std::vector<Particle> outsideParts;
-    
+
     int trct = 0;
     bool leadCand = false;
     bool leadSet = false;
     Particle lead;
-    for(std::vector<int>::size_type i = 0; i != parts.size(); i++){
-        bool isSignal = inSignalCone(parts.at(i), seed, trct, scone2, isocone_pt, leadCand);
-        if(isSignal){
-            
-            signalParts.push_back(parts.at(i));
-            if(parts[i].id() == 0){trct++;}
-            if(leadCand){
-                
-                if(leadSet == false){
-                   lead = parts[i];
-                   leadCand = false;
-                   leadSet = true;
-                }
-                else{
-                  if(parts[i].pt() > lead.pt()){
-                   lead = parts[i];
-                   leadCand = false;
-                    }
-                  else{
-                    leadCand = false;
-                  }
-               }             
-   
+    for (std::vector<int>::size_type i = 0; i != parts.size(); i++) {
+      bool isSignal = inSignalCone(parts.at(i), seed, trct, scone2, isocone_pt, leadCand);
+      if (isSignal) {
+        signalParts.push_back(parts.at(i));
+        if (parts[i].id() == 0) {
+          trct++;
+        }
+        if (leadCand) {
+          if (leadSet == false) {
+            lead = parts[i];
+            leadCand = false;
+            leadSet = true;
+          } else {
+            if (parts[i].pt() > lead.pt()) {
+              lead = parts[i];
+              leadCand = false;
+            } else {
+              leadCand = false;
             }
+          }
         }
-        else{
-           
-            outsideParts.push_back(parts.at(i));
-        }
-        
-        
-        
+      } else {
+        outsideParts.push_back(parts.at(i));
+      }
     }
-   
-    for(std::vector<int>::size_type i = 0; i != signalParts.size(); i++){
-        Particle sigP = signalParts.at(i);
-        if(is_charged(sigP) || (sigP.id() == 3)){
-            sum_pt += sigP.pt();
-            sum_eta += sigP.pt()*sigP.eta();
-            sum_phi += sigP.pt()*sigP.phi();
-        }
+
+    for (std::vector<int>::size_type i = 0; i != signalParts.size(); i++) {
+      Particle sigP = signalParts.at(i);
+      if (is_charged(sigP) || (sigP.id() == 3)) {
+        sum_pt += sigP.pt();
+        sum_eta += sigP.pt() * sigP.eta();
+        sum_phi += sigP.pt() * sigP.phi();
+      }
     }
-    
-    
+
     pt_t div_pt = 1;
-    if(sum_pt == 0){
-       div_pt = 1;}
-    else{
-       div_pt = sum_pt;
-    }        
-    
+    if (sum_pt == 0) {
+      div_pt = 1;
+    } else {
+      div_pt = sum_pt;
+    }
 
     tau_pt = sum_pt;
     tau_eta = sum_eta / div_pt;
     tau_phi = sum_phi / div_pt;
-     
-    if(tau_pt > 80. && int_abs(tau_eta) < etaCutoff && leadSet == true && isocone_pt < tau_pt){
-    Tau tau(tau_pt, tau_eta, tau_phi, 0, 0);
-    return tau;}
-    else{
-    Tau tau(0., 0., 0., 0, 0.); 
-    return tau;}
-      
-  }
-  
-std::vector<Tau> emulateEvent(std::vector<Particle>& parts, std::vector<Particle>& jets, bool jEnable){  
-   using namespace L1HPSPFTauEmu;
-   
-   std::vector<Particle> parts_copy;
-   parts_copy.resize(parts.size());
-   std::transform(parts.begin(), parts.end(), parts_copy.begin(), [](const Particle& part) {return part;});
-   //sorting by pt
-   std::sort(parts_copy.begin(), parts_copy.end(), [](Particle i, Particle j){
-         return( i.pt() > j.pt());
-   });
- 
-  //sorting jets by pt
-  std::vector<Particle> jets_copy;
-  jets_copy.resize(jets.size());
-  std::transform(jets.begin(), jets.end(), jets_copy.begin(), [](const Particle& jet) {return jet;});
-  std::sort(jets_copy.begin(), jets_copy.end(), [](Particle i, Particle j){
-      return(i.pt() > j.pt());
-  });
 
- 
-   std::vector<Tau> taus;
-   std::vector<Tau> cleaned_taus;
-   taus.reserve(20); 
-   std::vector<Particle> preseed;
-   preseed.reserve(144);
-   
-   //jet seeds reserve
-   //4 for now
-   int jets_index =0;
-   int jets_max = jets_copy.size();
-  
-   std::vector<Particle> jseeds;
-   jseeds.reserve(4);  
-
- 
-   int parts_index = 0;
-   int parts_max = parts_copy.size();
-   //first find the seeds
-   while(preseed.size() < 128 && parts_index != parts_max){
-
-      Particle pSeed = parts_copy.at(parts_index);
-      
-      if( pSeed.pt() > 20. && is_charged(pSeed) && int_abs(pSeed.eta()) < etaCutoff){
-        preseed.push_back(pSeed);
-
-      }          
-       
-      parts_index++;
-   }
-   
-   std::vector<Particle> seeds;
-   seeds.reserve(16); //up to 16 track + 4 jet seeds right now
-   std::vector<int>::size_type pseed_index = 0;
-   while(seeds.size() <16 && pseed_index < preseed.size()){
-       seeds.push_back(preseed.at(pseed_index));
-       pseed_index++;
-   }
-
-   //With jets
-   if(jEnable){
-   while(jseeds.size() < 4 && jets_index != jets_max){
-    Particle jSeed =  jets_copy.at(jets_index);
-    
-    if(jSeed.pt() > 80. && int_abs(jSeed.eta()) < etaCutoff){
-      jseeds.push_back(jSeed);
+    if (tau_pt > 80. && int_abs(tau_eta) < etaCutoff && leadSet == true && isocone_pt < tau_pt) {
+      Tau tau(tau_pt, tau_eta, tau_phi, 0, 0);
+      return tau;
+    } else {
+      Tau tau(0., 0., 0., 0, 0.);
+      return tau;
     }
-   jets_index++;
-   }  
-  } 
-  for(std::vector<int>::size_type i =0; i != seeds.size(); i++){
-    
-    Particle seed = seeds.at(i);
-    
-    std::vector<Particle> iso_parts;
-    
-    iso_parts.reserve(30);  
-    pt_t total_pt = 0;
-    std::vector<int>::size_type iso_index = 0;    
-    while(iso_index < parts_copy.size() && iso_parts.size() < 30){  
-       Particle isoCand = parts_copy.at(iso_index);
-       if(inIsolationCone(isoCand, seed)){
-           iso_parts.push_back(isoCand);
-           total_pt += isoCand.pt();
-          
-       }
-       iso_index++;
-     }     
-    
-    taus.push_back(makeHPSTauHW(iso_parts, seed, total_pt)); 
   }
- 
-//add in the jet taus 
-  if(jEnable){ 
-  
-  for(std::vector<int>::size_type i = 0; i != jseeds.size(); i++){
-   
-   Particle jseed = jseeds.at(i);
-   std::vector<Particle> iso_parts;
-   iso_parts.reserve(30);
-   pt_t total_pt =0;
-   std::vector<int>::size_type iso_index = 0;
-  
-   pt_t max_pt_j = 0;
-   while(iso_index < parts_copy.size()){
-     Particle isoCand = parts_copy.at(iso_index);
 
-     if(inIsolationCone(isoCand, jseed)  ){
-       if(is_charged(isoCand) && isoCand.pt() > max_pt_j){
-         if(isoCand.z0()){jseed.z0() = isoCand.z0();}
-         max_pt_j = isoCand.pt();
-       }
-  
-       if(iso_parts.size() < 30){
+  inline std::vector<Tau> emulateEvent(std::vector<Particle>& parts, std::vector<Particle>& jets, bool jEnable) {
+    using namespace L1HPSPFTauEmu;
+
+    std::vector<Particle> parts_copy;
+    parts_copy.resize(parts.size());
+    std::transform(parts.begin(), parts.end(), parts_copy.begin(), [](const Particle& part) { return part; });
+    //sorting by pt
+    std::sort(parts_copy.begin(), parts_copy.end(), [](Particle i, Particle j) { return (i.pt() > j.pt()); });
+
+    //sorting jets by pt
+    std::vector<Particle> jets_copy;
+    jets_copy.resize(jets.size());
+    std::transform(jets.begin(), jets.end(), jets_copy.begin(), [](const Particle& jet) { return jet; });
+    std::sort(jets_copy.begin(), jets_copy.end(), [](Particle i, Particle j) { return (i.pt() > j.pt()); });
+
+    std::vector<Tau> taus;
+    std::vector<Tau> cleaned_taus;
+    taus.reserve(20);
+    std::vector<Particle> preseed;
+    preseed.reserve(144);
+
+    //jet seeds reserve
+    //4 for now
+    int jets_index = 0;
+    int jets_max = jets_copy.size();
+
+    std::vector<Particle> jseeds;
+    jseeds.reserve(4);
+
+    int parts_index = 0;
+    int parts_max = parts_copy.size();
+    //first find the seeds
+    while (preseed.size() < 128 && parts_index != parts_max) {
+      Particle pSeed = parts_copy.at(parts_index);
+
+      if (pSeed.pt() > 20. && is_charged(pSeed) && int_abs(pSeed.eta()) < etaCutoff) {
+        preseed.push_back(pSeed);
+      }
+
+      parts_index++;
+    }
+
+    std::vector<Particle> seeds;
+    seeds.reserve(16);  //up to 16 track + 4 jet seeds right now
+    std::vector<int>::size_type pseed_index = 0;
+    while (seeds.size() < 16 && pseed_index < preseed.size()) {
+      seeds.push_back(preseed.at(pseed_index));
+      pseed_index++;
+    }
+
+    //With jets
+    if (jEnable) {
+      while (jseeds.size() < 4 && jets_index != jets_max) {
+        Particle jSeed = jets_copy.at(jets_index);
+
+        if (jSeed.pt() > 80. && int_abs(jSeed.eta()) < etaCutoff) {
+          jseeds.push_back(jSeed);
+        }
+        jets_index++;
+      }
+    }
+    for (std::vector<int>::size_type i = 0; i != seeds.size(); i++) {
+      Particle seed = seeds.at(i);
+
+      std::vector<Particle> iso_parts;
+
+      iso_parts.reserve(30);
+      pt_t total_pt = 0;
+      std::vector<int>::size_type iso_index = 0;
+      while (iso_index < parts_copy.size() && iso_parts.size() < 30) {
+        Particle isoCand = parts_copy.at(iso_index);
+        if (inIsolationCone(isoCand, seed)) {
           iso_parts.push_back(isoCand);
           total_pt += isoCand.pt();
-       }
-     }  
-    iso_index++;
+        }
+        iso_index++;
+      }
+
+      taus.push_back(makeHPSTauHW(iso_parts, seed, total_pt));
     }
-   taus.push_back(makeHPSTauHW(iso_parts, jseed, total_pt));
-   }
-   }
 
-  
-   std::sort(taus.begin(), taus.end(), [](Tau i, Tau j){
-      return(i.pt() > j.pt());
-   } );      
-    
+    //add in the jet taus
+    if (jEnable) {
+      for (std::vector<int>::size_type i = 0; i != jseeds.size(); i++) {
+        Particle jseed = jseeds.at(i);
+        std::vector<Particle> iso_parts;
+        iso_parts.reserve(30);
+        pt_t total_pt = 0;
+        std::vector<int>::size_type iso_index = 0;
 
-   int taus_max = taus.size();
+        pt_t max_pt_j = 0;
+        while (iso_index < parts_copy.size()) {
+          Particle isoCand = parts_copy.at(iso_index);
 
-   bool matrix[380];
- 
-   for(int i = 0; i < (taus_max-1); i++){
-       for(int j = i+1; j < taus_max; j++){   
-         etaphi_t deltaE = taus[i].eta() - taus[j].eta();  
-         etaphi_t deltaP = taus[i].phi() - taus[j].phi();
-         if((deltaE*deltaE + deltaP*deltaP) < (delta_Rclean *delta_Rclean)){          
-           matrix[i*19 + j] = true;
-         }
-         else{matrix[i*19 + j] = false;}
-       }    
-   }
-   
-   if(taus.size() > 0){
-     if( taus[0].pt() > 0){
-       cleaned_taus.push_back(taus.at(0));   
-     } 
-   
-     bool clean[20];
-   
-     for(int i = 0; i < 20; i++){
-       clean[i] = false;       
-     }
-     for(int i = 1; i < taus_max; i++){       
-       for(int j = i-1; j>= 0; j--){
-         clean[i] |= (matrix[j*15 + i] && !clean[j]);
-       }           
-       if(!clean[i] && taus[i].pt() > 0){
-          cleaned_taus.push_back(taus.at(i));         
-       }           
-       
-     }
-   }
-  
-  return cleaned_taus;
+          if (inIsolationCone(isoCand, jseed)) {
+            if (is_charged(isoCand) && isoCand.pt() > max_pt_j) {
+              if (isoCand.z0()) {
+                jseed.z0() = isoCand.z0();
+              }
+              max_pt_j = isoCand.pt();
+            }
 
+            if (iso_parts.size() < 30) {
+              iso_parts.push_back(isoCand);
+              total_pt += isoCand.pt();
+            }
+          }
+          iso_index++;
+        }
+        taus.push_back(makeHPSTauHW(iso_parts, jseed, total_pt));
+      }
+    }
+
+    std::sort(taus.begin(), taus.end(), [](Tau i, Tau j) { return (i.pt() > j.pt()); });
+
+    int taus_max = taus.size();
+
+    bool matrix[380];
+
+    for (int i = 0; i < (taus_max - 1); i++) {
+      for (int j = i + 1; j < taus_max; j++) {
+        etaphi_t deltaE = taus[i].eta() - taus[j].eta();
+        etaphi_t deltaP = taus[i].phi() - taus[j].phi();
+        if ((deltaE * deltaE + deltaP * deltaP) < (delta_Rclean * delta_Rclean)) {
+          matrix[i * 19 + j] = true;
+        } else {
+          matrix[i * 19 + j] = false;
+        }
+      }
+    }
+
+    if (!taus.empty()) {
+      if (taus[0].pt() > 0) {
+        cleaned_taus.push_back(taus.at(0));
+      }
+
+      bool clean[20];
+
+      for (int i = 0; i < 20; i++) {
+        clean[i] = false;
+      }
+      for (int i = 1; i < taus_max; i++) {
+        for (int j = i - 1; j >= 0; j--) {
+          clean[i] |= (matrix[j * 15 + i] && !clean[j]);
+        }
+        if (!clean[i] && taus[i].pt() > 0) {
+          cleaned_taus.push_back(taus.at(i));
+        }
+      }
+    }
+
+    return cleaned_taus;
   }
 
-
-};
+};  // namespace L1HPSPFTauEmu
 
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h
@@ -1,0 +1,508 @@
+#ifndef L1HPSPFTAUEMULATOR_H
+#define L1HPSPFTAUEMULATOR_H
+
+#include "ap_int.h"
+#include "ap_fixed.h"
+#include <iostream>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+
+
+namespace L1HPSPFTauEmu {
+    
+    
+    
+  //mapping the eta phi onto bits
+
+  
+  static float etaphi_base = 720. /3.14159;
+  static float dz_base = 0.05;
+  typedef ap_ufixed<16, 14> pt_t;
+  
+  typedef ap_int<12> etaphi_t;
+  
+  typedef ap_int<12> detaphi_t;
+  
+  typedef ap_uint<20> detaphi2_t;
+  typedef ap_uint<5> count_t; //type for multiplicity
+  typedef ap_uint<3> type_t; //type for particle type
+  typedef ap_int<10> dz_t; //type for z0 cut
+  
+    
+    
+    class Particle {
+    public:
+      pt_t hwPt;
+      etaphi_t hwEta;
+      etaphi_t hwPhi;
+      type_t hwId;
+      dz_t hwZ0;
+      
+      Particle() : hwPt(0), hwEta(0), hwPhi(0), hwId(0), hwZ0() {}
+      Particle( pt_t pt, etaphi_t eta, etaphi_t phi, type_t id, dz_t z0 ) : hwPt(pt), hwEta(eta), hwPhi(phi), hwId(id), hwZ0(z0) {}
+      
+      
+      pt_t pt() const{
+          return hwPt;
+      }
+      
+      etaphi_t phi() const{
+          return hwPhi;          
+      }
+      
+      etaphi_t eta() const{
+          return hwEta;
+      }
+      type_t id() const{
+          return hwId;
+      }
+      dz_t z0() const{
+          return hwZ0;
+      }
+    };
+    
+    //template classes
+  class Tau : public Particle {
+    public:
+      Tau(pt_t pt, etaphi_t eta, etaphi_t phi, type_t id, dz_t z0) : Particle(pt, eta, phi, id, z0) {} 
+      ap_uint<5> seed_index;
+      pt_t seed_pt;
+      etaphi_t seed_eta;      
+      etaphi_t seed_phi;
+      dz_t seed_z0;
+      
+  
+  };
+   
+  //constants
+    static const detaphi_t TWOPI = 3.14159 * 2. * etaphi_base;
+    static const detaphi_t PI = 3.14159 * etaphi_base;
+    
+    static const detaphi_t strip_phi = 0.20* etaphi_base;
+    static const detaphi_t strip_eta = 0.05* etaphi_base;
+    
+    static const pt_t min_leadChargedPfCand_pt = 4;
+    static const detaphi_t isoConeSize = 0.4 * etaphi_base;
+    static const detaphi_t delta_Rclean = 0.4 * etaphi_base;
+    static const dz_t dzCut = 0.4 / dz_base;
+    static const detaphi_t isoConeSizeRound = 92; 
+    static const etaphi_t etaCutoff = 2.4 * etaphi_base;
+   
+
+    
+ template <int W, int I, ap_q_mode _AP_Q, ap_o_mode _AP_O>
+    ap_ufixed<W,I> fp_abs(ap_fixed<W,I, _AP_Q, _AP_O> x) {
+	 ap_ufixed<W,I> result;
+	  if (x < 0) {
+		result = -x;
+	  } else {
+		result = x;
+	  }
+	return result;
+}
+
+ap_uint<12> int_abs(ap_int<12> x){
+   ap_uint<12> result;
+   if (x < 0){ result = -x;}
+   else{ result = x;}
+   return result;
+}
+
+ap_uint<10> dz_abs(ap_int<10> x){
+    ap_uint<10> result;
+    if(x < 0){ result = -x;}
+    else{ result = x;}
+    return result;
+}
+   
+  
+    
+   bool is_charged(Particle part) {
+     bool charge = false;
+     if((part.hwId ==0) || (part.hwId == 1) || (part.hwId == 4)){
+       charge = true;
+     }
+     else{
+       charge = false;
+     }
+   return charge;
+  }   
+  
+  ap_uint<20> setSConeSize2(pt_t total_pt) {
+            
+      ap_uint<20> SignalConeSizeSquare;
+      ap_uint<10> SignalConeSize;
+      if ( total_pt < 115 ){
+            SignalConeSizeSquare = 23*23;
+            }
+          else if ( total_pt < 120 ){
+            SignalConeSizeSquare = 22*22;
+            }
+          else if ( total_pt < 126 ){
+            SignalConeSizeSquare = 21*21;
+            }
+	  else if ( total_pt < 132 ){
+            SignalConeSizeSquare = 20*20;
+            }
+	  else if ( total_pt < 139 ){
+            SignalConeSizeSquare = 19*19;
+            }
+	  else if ( total_pt < 147 ){
+            SignalConeSizeSquare = 18*18;
+            }
+	  else if ( total_pt < 156 ){
+            SignalConeSizeSquare = 17*17;
+            }
+	  else if ( total_pt < 166 ){
+            SignalConeSizeSquare = 16*16;
+            }
+	  else if ( total_pt < 178 ){
+            SignalConeSizeSquare = 15*15;
+            }
+	  else if ( total_pt < 191 ){
+            SignalConeSizeSquare = 14*14;    
+            }
+	  else if ( total_pt < 206 ){
+            SignalConeSizeSquare = 13*13;
+            }
+	  else if ( total_pt < 224 ){
+	    SignalConeSizeSquare = 12*12;}
+	  else{
+	    SignalConeSizeSquare = 12*12;
+            }
+    return SignalConeSizeSquare;     
+      
+  }    
+    
+  bool inIsolationCone(Particle part, Particle seed){
+      
+      bool inCone = false;
+      detaphi2_t isoConeSize2 = isoConeSize * isoConeSize;
+      
+    if(part.pt() != 0){
+       detaphi_t deltaEta = part.eta() - seed.eta();    
+       detaphi_t deltaPhi = part.phi() - seed.phi();    
+        if( (deltaEta*deltaEta + deltaPhi*deltaPhi) < isoConeSize2){
+            inCone = true;
+        }
+        else{
+        inCone = false;}
+    }
+    else{
+      inCone = false;
+    }
+  return inCone;
+
+  }      
+    
+  bool inSignalCone(Particle part, Particle seed, const int track_count, ap_uint<20> cone2, pt_t& iso_pt, bool& isLead) {
+      //finds the signal cone candidates (including strip pt check 
+      
+        bool isPotentialLead = 0;
+ 
+        isPotentialLead = is_charged(part) && part.id() != 4 && part.pt() > min_leadChargedPfCand_pt && int_abs(part.eta()) < etaCutoff;
+        
+        //calculate the deta and dphi
+        bool inCone = false;
+        
+        
+        if(part.pt() !=0){
+           detaphi_t deltaEta = part.eta() - seed.eta();    
+           detaphi_t deltaPhi = part.phi() - seed.phi(); 
+           detaphi2_t deltaEta2 = deltaEta * deltaEta;           
+           detaphi2_t deltaPhi2 = deltaPhi * deltaPhi;     
+           dz_t deltaZ = 0;
+           if(part.z0() && seed.z0()){ 
+           dz_t deltaZ = part.z0() - seed.z0();     
+           }
+          
+          if( (int_abs(deltaEta) < strip_eta) && (int_abs(deltaPhi) < strip_phi) && 
+              ( part.id() == 3 || (part.id() == 1)) ){
+              if(isPotentialLead){isLead = true;} 
+              inCone = true;
+            
+            }
+          else if( ((deltaEta2 + deltaPhi2) < cone2) && !( (part.id() == 0) && ( track_count >3)) && !(is_charged(part) && dz_abs(deltaZ) > dzCut)){
+              if(isPotentialLead){isLead = true;}
+              inCone = true;
+          }
+          else{
+            
+            if( is_charged(part) && dz_abs(deltaZ) > dzCut){
+               iso_pt += part.pt();
+               inCone = false;
+            }                
+              
+          }
+  
+        }
+     return inCone;     
+  }    
+   
+  Tau makeHPSTauHW(const std::vector<Particle>& parts, const Particle seed, const pt_t total_pt/*, Config config*/){
+   
+   
+    using namespace L1HPSPFTauEmu;   
+    
+    ap_uint<20> scone2 = setSConeSize2(total_pt);
+
+    pt_t isocone_pt = 0;
+    
+    
+    pt_t sum_pt = 0;
+    
+    ap_fixed<22,20> sum_eta = 0;
+    ap_fixed<22,20> sum_phi = 0;    
+
+    pt_t tau_pt = 0;
+    etaphi_t tau_eta = 0;
+    etaphi_t tau_phi = 0;
+   
+
+    pt_t chargedIsoPileup = 0; 
+    std::vector<Particle> signalParts;
+    std::vector<Particle> outsideParts;
+    
+    int trct = 0;
+    bool leadCand = false;
+    bool leadSet = false;
+    Particle lead;
+    for(std::vector<int>::size_type i = 0; i != parts.size(); i++){
+        bool isSignal = inSignalCone(parts.at(i), seed, trct, scone2, isocone_pt, leadCand);
+        if(isSignal){
+            
+            signalParts.push_back(parts.at(i));
+            if(parts[i].id() == 0){trct++;}
+            if(leadCand){
+                
+                if(leadSet == false){
+                   lead = parts[i];
+                   leadCand = false;
+                   leadSet = true;
+                }
+                else{
+                  if(parts[i].pt() > lead.pt()){
+                   lead = parts[i];
+                   leadCand = false;
+                    }
+                  else{
+                    leadCand = false;
+                  }
+               }             
+   
+            }
+        }
+        else{
+           
+            outsideParts.push_back(parts.at(i));
+        }
+        
+        
+        
+    }
+   
+    for(std::vector<int>::size_type i = 0; i != signalParts.size(); i++){
+        Particle sigP = signalParts.at(i);
+        if(is_charged(sigP) || (sigP.id() == 3)){
+            sum_pt += sigP.pt();
+            sum_eta += sigP.pt()*sigP.eta();
+            sum_phi += sigP.pt()*sigP.phi();
+        }
+    }
+    
+    
+    pt_t div_pt = 1;
+    if(sum_pt == 0){
+       div_pt = 1;}
+    else{
+       div_pt = sum_pt;
+    }        
+    
+
+    tau_pt = sum_pt;
+    tau_eta = sum_eta / div_pt;
+    tau_phi = sum_phi / div_pt;
+     
+    if(tau_pt > 80. && int_abs(tau_eta) < etaCutoff && leadSet == true && isocone_pt < tau_pt){
+    Tau tau(tau_pt, tau_eta, tau_phi, 0, 0);
+    return tau;}
+    else{
+    Tau tau(0., 0., 0., 0, 0.); 
+    return tau;}
+      
+  }
+  
+std::vector<Tau> emulateEvent(std::vector<Particle>& parts, std::vector<Particle>& jets, bool jEnable){  
+   using namespace L1HPSPFTauEmu;
+   
+   std::vector<Particle> parts_copy;
+   parts_copy.resize(parts.size());
+   std::transform(parts.begin(), parts.end(), parts_copy.begin(), [](const Particle& part) {return part;});
+   //sorting by pt
+   std::sort(parts_copy.begin(), parts_copy.end(), [](Particle i, Particle j){
+         return( i.pt() > j.pt());
+   });
+ 
+  //sorting jets by pt
+  std::vector<Particle> jets_copy;
+  jets_copy.resize(jets.size());
+  std::transform(jets.begin(), jets.end(), jets_copy.begin(), [](const Particle& jet) {return jet;});
+  std::sort(jets_copy.begin(), jets_copy.end(), [](Particle i, Particle j){
+      return(i.pt() > j.pt());
+  });
+
+ 
+   std::vector<Tau> taus;
+   std::vector<Tau> cleaned_taus;
+   taus.reserve(20); 
+   std::vector<Particle> preseed;
+   preseed.reserve(144);
+   
+   //jet seeds reserve
+   //4 for now
+   int jets_index =0;
+   int jets_max = jets_copy.size();
+  
+   std::vector<Particle> jseeds;
+   jseeds.reserve(4);  
+
+ 
+   int parts_index = 0;
+   int parts_max = parts_copy.size();
+   //first find the seeds
+   while(preseed.size() < 128 && parts_index != parts_max){
+
+      Particle pSeed = parts_copy.at(parts_index);
+      
+      if( pSeed.pt() > 20. && is_charged(pSeed) && int_abs(pSeed.eta()) < etaCutoff){
+        preseed.push_back(pSeed);
+
+      }          
+       
+      parts_index++;
+   }
+   
+   std::vector<Particle> seeds;
+   seeds.reserve(16); //up to 16 track + 4 jet seeds right now
+   std::vector<int>::size_type pseed_index = 0;
+   while(seeds.size() <16 && pseed_index < preseed.size()){
+       seeds.push_back(preseed.at(pseed_index));
+       pseed_index++;
+   }
+
+   //With jets
+   if(jEnable){
+   while(jseeds.size() < 4 && jets_index != jets_max){
+    Particle jSeed =  jets_copy.at(jets_index);
+    
+    if(jSeed.pt() > 80. && int_abs(jSeed.eta()) < etaCutoff){
+      jseeds.push_back(jSeed);
+    }
+   jets_index++;
+   }  
+  } 
+  for(std::vector<int>::size_type i =0; i != seeds.size(); i++){
+    
+    Particle seed = seeds.at(i);
+    
+    std::vector<Particle> iso_parts;
+    
+    iso_parts.reserve(30);  
+    pt_t total_pt = 0;
+    std::vector<int>::size_type iso_index = 0;    
+    while(iso_index < parts_copy.size() && iso_parts.size() < 30){  
+       Particle isoCand = parts_copy.at(iso_index);
+       if(inIsolationCone(isoCand, seed)){
+           iso_parts.push_back(isoCand);
+           total_pt += isoCand.pt();
+          
+       }
+       iso_index++;
+     }     
+    
+    taus.push_back(makeHPSTauHW(iso_parts, seed, total_pt)); 
+  }
+ 
+//add in the jet taus 
+  if(jEnable){ 
+  
+  for(std::vector<int>::size_type i = 0; i != jseeds.size(); i++){
+   
+   Particle jseed = jseeds.at(i);
+   std::vector<Particle> iso_parts;
+   iso_parts.reserve(30);
+   pt_t total_pt =0;
+   std::vector<int>::size_type iso_index = 0;
+  
+   pt_t max_pt_j = 0;
+   while(iso_index < parts_copy.size()){
+     Particle isoCand = parts_copy.at(iso_index);
+
+     if(inIsolationCone(isoCand, jseed)  ){
+       if(is_charged(isoCand) && isoCand.pt() > max_pt_j){
+         if(isoCand.z0()){jseed.z0() = isoCand.z0();}
+         max_pt_j = isoCand.pt();
+       }
+  
+       if(iso_parts.size() < 30){
+          iso_parts.push_back(isoCand);
+          total_pt += isoCand.pt();
+       }
+     }  
+    iso_index++;
+    }
+   taus.push_back(makeHPSTauHW(iso_parts, jseed, total_pt));
+   }
+   }
+
+  
+   std::sort(taus.begin(), taus.end(), [](Tau i, Tau j){
+      return(i.pt() > j.pt());
+   } );      
+    
+
+   int taus_max = taus.size();
+
+   bool matrix[380];
+ 
+   for(int i = 0; i < (taus_max-1); i++){
+       for(int j = i+1; j < taus_max; j++){   
+         etaphi_t deltaE = taus[i].eta() - taus[j].eta();  
+         etaphi_t deltaP = taus[i].phi() - taus[j].phi();
+         if((deltaE*deltaE + deltaP*deltaP) < (delta_Rclean *delta_Rclean)){          
+           matrix[i*19 + j] = true;
+         }
+         else{matrix[i*19 + j] = false;}
+       }    
+   }
+   
+   if(taus.size() > 0){
+     if( taus[0].pt() > 0){
+       cleaned_taus.push_back(taus.at(0));   
+     } 
+   
+     bool clean[20];
+   
+     for(int i = 0; i < 20; i++){
+       clean[i] = false;       
+     }
+     for(int i = 1; i < taus_max; i++){       
+       for(int j = i-1; j>= 0; j--){
+         clean[i] |= (matrix[j*15 + i] && !clean[j]);
+       }           
+       if(!clean[i] && taus[i].pt() > 0){
+          cleaned_taus.push_back(taus.at(i));         
+       }           
+       
+     }
+   }
+  
+  return cleaned_taus;
+
+  }
+
+
+};
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
@@ -22,7 +22,7 @@ class L1HPSPFTauProducer : public edm::global::EDProducer<> {
     
 public:
   explicit L1HPSPFTauProducer(const edm::ParameterSet&);
-  ~L1HPSPFTauProducer() override;
+  ~L1HPSPFTauProducer() {};
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 
@@ -120,8 +120,6 @@ void L1HPSPFTauProducer::produce(edm::StreamID,
   iEvent.put(std::move(newPFTauCollection), "HPSTaus");
 
 }
-
-L1HPSPFTauProducer::~L1HPSPFTauProducer() {}
 
 
 std::vector<l1t::PFTau> L1HPSPFTauProducer::processEvent_HW(std::vector<edm::Ptr<l1t::PFCandidate>>& work, std::vector<edm::Ptr<reco::CaloJet>>& jwork) const{

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
@@ -106,7 +106,7 @@ void L1HPSPFTauProducer::produce(edm::StreamID,
 
 
   //add iterator to add particles to selParticles collection
-  for(auto l1PFCand : particles){
+  for(const auto& l1PFCand : particles){
 
     selParticles->push_back(*l1PFCand);
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
@@ -1,0 +1,216 @@
+#include <vector>
+#include <numeric>
+
+////////////////////
+// FRAMEWORK HEADERS
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+// bitwise emulation headers
+#include "L1Trigger/Phase2L1ParticleFlow/interface/taus/L1HPSPFTauEmulator.h"
+
+
+class L1HPSPFTauProducer : public edm::global::EDProducer<> {
+    
+public:
+  explicit L1HPSPFTauProducer(const edm::ParameterSet&);
+  ~L1HPSPFTauProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+
+private:
+  
+  
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  
+
+  //various needed vars
+  int _nTaus;
+  bool _HW;
+  bool fUseJets_;
+  bool _debug;
+  
+  edm::InputTag srcL1PFCands_;
+  edm::EDGetTokenT<l1t::PFCandidateCollection> tokenL1PFCands_;    
+  //jets
+  edm::InputTag srcL1PFJets_;
+  edm::EDGetTokenT<std::vector<reco::CaloJet>> tokenL1PFJets_;
+  //functions
+  std::vector<l1t::PFTau> processEvent_HW(std::vector<edm::Ptr<l1t::PFCandidate>>& parts, std::vector<edm::Ptr<reco::CaloJet>>&  jets) const;
+
+  static std::vector<L1HPSPFTauEmu::Particle> convertJetsToHW(std::vector<edm::Ptr<reco::CaloJet>>& edmJets); 
+  static std::vector<L1HPSPFTauEmu::Particle> convertEDMToHW(std::vector<edm::Ptr<l1t::PFCandidate>>& edmParticles);
+  static std::vector<l1t::PFTau> convertHWToEDM(std::vector<L1HPSPFTauEmu::Tau> hwTaus);
+  
+};
+
+L1HPSPFTauProducer::L1HPSPFTauProducer(const edm::ParameterSet& cfg)
+   : _nTaus(cfg.getParameter<int>("nTaus")),
+     _HW(cfg.getParameter<bool>("HW")),
+     fUseJets_(cfg.getParameter<bool>("useJets")),
+     _debug(cfg.getParameter<bool>("debug")){ //,
+      srcL1PFCands_ = cfg.getParameter<edm::InputTag>("srcL1PFCands");
+      tokenL1PFCands_ = consumes<l1t::PFCandidateCollection>(srcL1PFCands_);   
+      
+      srcL1PFJets_ = cfg.getParameter<edm::InputTag>("srcL1PFJets");
+      tokenL1PFJets_ = consumes<std::vector<reco::CaloJet>>(srcL1PFJets_); 
+      produces<l1t::PFTauCollection>("HPSTaus");
+      
+      produces<l1t::PFCandidateCollection>("SelPFCands");
+
+     }
+
+void L1HPSPFTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+  edm::ParameterSetDescription desc;    
+  
+  desc.add<edm::InputTag>("srcL1PFCands", edm::InputTag("l1tLayer1","Puppi"));    
+  desc.add<int>("nTaus", 16);
+  desc.add<bool>("HW", true);
+  desc.add<bool>("useJets",false);
+  desc.add<bool>("debug", false);   
+  desc.add<edm::InputTag>("srcL1PFJets", edm::InputTag("l1tPhase1JetProducer","UncalibratedPhase1L1TJetFromPfCandidates"));
+  descriptions.add("L1HPSPFTauProducer", desc);
+}
+
+
+void L1HPSPFTauProducer::produce(edm::StreamID,
+                                 edm::Event& iEvent,
+                                 const edm::EventSetup& iSetup) const {
+
+  std::unique_ptr<l1t::PFTauCollection> newPFTauCollection(new l1t::PFTauCollection);
+  std::unique_ptr<l1t::PFCandidateCollection> selParticles(new l1t::PFCandidateCollection);
+  edm::Handle<l1t::PFCandidateCollection> l1PFCandidates;
+  iEvent.getByToken(tokenL1PFCands_, l1PFCandidates);
+  //add jets even if not used, for simplicity
+  edm::Handle<std::vector<reco::CaloJet>> l1PFJets;
+  iEvent.getByToken(tokenL1PFJets_, l1PFJets);
+  //
+
+  //adding collection
+  std::vector<edm::Ptr<l1t::PFCandidate>> particles;
+  for(unsigned i = 0; i < (*l1PFCandidates).size(); i++) {
+
+    particles.push_back(edm::Ptr<l1t::PFCandidate>(l1PFCandidates, i));  
+    
+  }
+
+ 
+
+
+  //add iterator to add particles to selParticles collection
+  for(auto l1PFCand : particles){
+
+    selParticles->push_back(*l1PFCand);
+
+    }
+
+  //get the jets
+  std::vector<edm::Ptr<reco::CaloJet>> jets;
+  for(unsigned int i = 0; i < (*l1PFJets).size(); i++){
+    jets.push_back(edm::Ptr<reco::CaloJet>(l1PFJets, i));  
+  //
+  }
+
+  std::vector<l1t::PFTau> taus;
+ 
+  taus = processEvent_HW(particles, jets);
+  
+
+  std::sort(taus.begin(), taus.end(), [](l1t::PFTau i, l1t::PFTau j) { return (i.pt() > j.pt()); });
+  newPFTauCollection->swap(taus);
+  iEvent.put(std::move(newPFTauCollection), "HPSTaus");
+  iEvent.put(std::move(selParticles), "SelPFCands");
+
+}
+
+L1HPSPFTauProducer::~L1HPSPFTauProducer() {}
+
+
+std::vector<l1t::PFTau> L1HPSPFTauProducer::processEvent_HW(std::vector<edm::Ptr<l1t::PFCandidate>>& work, std::vector<edm::Ptr<reco::CaloJet>>& jwork) const{
+    //convert and call emulator
+    
+ 
+    using namespace L1HPSPFTauEmu;
+    
+    std::vector<Particle> particles = convertEDMToHW(work);
+    
+    std::vector<Particle> jets = convertJetsToHW(jwork);
+    //also need to pass the jet enabler
+    
+    
+    bool jEnable = fUseJets_;
+    
+    std::vector<Tau> taus = emulateEvent(particles, jets, jEnable);
+    
+    return convertHWToEDM(taus);
+    
+}
+
+std::vector<L1HPSPFTauEmu::Particle> L1HPSPFTauProducer::convertJetsToHW(std::vector<edm::Ptr<reco::CaloJet>>& edmJets){
+  using namespace L1HPSPFTauEmu;
+  std::vector<Particle> hwJets;
+  std::for_each(edmJets.begin(), edmJets.end(), [&](edm::Ptr<reco::CaloJet>& edmJet){
+  	hwJets.push_back(L1HPSPFTauEmu::Particle(edmJet->pt()*4.,
+  	                                         edmJet->eta() * etaphi_base,
+  	                                         edmJet->phi() * etaphi_base,
+  	                                         0.,
+  	                                         0.));
+  });
+  return hwJets;
+}
+
+
+//conversion to and from HW bitwise 
+std::vector<L1HPSPFTauEmu::Particle> L1HPSPFTauProducer::convertEDMToHW(std::vector<edm::Ptr<l1t::PFCandidate>>& edmParticles){
+    using namespace L1HPSPFTauEmu;
+    std::vector<Particle> hwParticles;
+    
+    std::for_each(edmParticles.begin(), edmParticles.end(), [&](edm::Ptr<l1t::PFCandidate>& edmParticle){
+
+   if(edmParticle->z0()){
+    hwParticles.push_back(L1HPSPFTauEmu::Particle(edmParticle->pt() * 4.,
+                                               edmParticle->eta() * etaphi_base,
+                                               edmParticle->phi() * etaphi_base,
+                                               edmParticle->id(),
+                                               edmParticle->z0() / dz_base));
+     }
+   else{
+    hwParticles.push_back(L1HPSPFTauEmu::Particle(edmParticle->pt() *4,
+                                                  edmParticle->eta() * etaphi_base,
+                                                  edmParticle->phi() * etaphi_base,
+                                                  edmParticle->id(),
+                                                  0));
+    }
+
+ });
+  return hwParticles;
+    
+}
+
+std::vector<l1t::PFTau> L1HPSPFTauProducer::convertHWToEDM(std::vector<L1HPSPFTauEmu::Tau> hwTaus){
+    using namespace L1HPSPFTauEmu;
+    std::vector<l1t::PFTau> edmTaus;
+
+    //empty array for the PFTau format, since it's used for PuppiTaus but not here
+    float tauArray[80] = {0};
+    std::for_each(hwTaus.begin(), hwTaus.end(), [&](Tau tau){
+       
+    edmTaus.push_back(l1t::PFTau(reco::Candidate::PolarLorentzVector(float(tau.hwPt) / 4,
+                                 float(tau.hwEta) / etaphi_base,
+                                 float(tau.hwPhi) / etaphi_base,
+                                 0), tauArray,  0, 0, 0, tau.hwPt, tau.hwEta, tau.hwPhi));
+  });
+  return edmTaus;
+}  
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1HPSPFTauProducer);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
@@ -185,11 +185,16 @@ std::vector<l1t::PFTau> L1HPSPFTauProducer::convertHWToEDM(std::vector<L1HPSPFTa
     //empty array for the PFTau format, since it's used for PuppiTaus but not here
     float tauArray[80] = {0};
     std::for_each(hwTaus.begin(), hwTaus.end(), [&](Tau tau){
-       
-    edmTaus.push_back(l1t::PFTau(reco::Candidate::PolarLorentzVector(l1ct::Scales::floatPt(tau.hwPt),
+    l1gt::Tau gtTau = tau.toGT();
+    l1gt::PackedTau packTau = gtTau.pack();
+
+           
+    l1t::PFTau pTau(reco::Candidate::PolarLorentzVector(l1ct::Scales::floatPt(tau.hwPt),
                                  float(tau.hwEta) / etaphi_base,
                                  float(tau.hwPhi) / etaphi_base,
-                                 0), tauArray,  0, 0, 0, tau.hwPt, tau.hwEta, tau.hwPhi));
+                                 0), tauArray,  0, 0, 0, tau.hwPt, tau.hwEta, tau.hwPhi);
+    pTau.set_encodedTau(packTau);
+    edmTaus.push_back(pTau);
   });
   return edmTaus;
 }  

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1HPSPFTauProducer.cxx
@@ -102,15 +102,6 @@ void L1HPSPFTauProducer::produce(edm::StreamID,
     
   }
 
- 
-
-
-  //add iterator to add particles to selParticles collection
-  for(const auto& l1PFCand : particles){
-
-    selParticles->push_back(*l1PFCand);
-
-    }
 
   //get the jets
   std::vector<edm::Ptr<reco::CaloJet>> jets;
@@ -127,7 +118,6 @@ void L1HPSPFTauProducer::produce(edm::StreamID,
   std::sort(taus.begin(), taus.end(), [](l1t::PFTau i, l1t::PFTau j) { return (i.pt() > j.pt()); });
   newPFTauCollection->swap(taus);
   iEvent.put(std::move(newPFTauCollection), "HPSTaus");
-  iEvent.put(std::move(selParticles), "SelPFCands");
 
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/python/L1HPSPFTauProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1HPSPFTauProducer_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+l1HPSPFTauEmuProducer = cms.EDProducer("L1HPSPFTauProducer",
+                         srcL1PFCands = cms.InputTag("l1tLayer1:Puppi"),
+                         nTaus        = cms.int32(16),
+                         debug        = cms.bool(False),
+                         useJets      = cms.bool(False),
+                         srcL1PFJets = cms.InputTag("l1tPhase1JetProducer:UncalibratedPhase1L1TJetFromPfCandidates")
+                        )


### PR DESCRIPTION
#### PR description:

This PR adds the Phase-2 HPS Tau emulator - this is the updated, firmware-based version of the Phase2L1Taus package.
The emulator uses a modified version of the HPS (Hadron-plus-strips) algorithm to identify and reconstruct tau candidates for the L1 Trigger, and outputs a standard vector of PFTau objects. 

#### PR validation:

Basic validation has been done with standard commands:
`scram build code-checks` and `scram build code format`
with no warnings or errors due to this code.
