### PR TITLE
Phase 2 GTT TrackVertexAssociation Firmware limit

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -15,6 +15,13 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
 namespace l1t::demo::codecs {
+  //function to get the gttLinkID from the TrackFindingProcessors
+  template<typename T>
+  unsigned int gttLinkID(T track) {
+    // use the sign bit of the tanL word to remove dependence on TTTrack eta member.
+    unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
+    return etaSector + (2 * track.phiSector());
+  }
 
   // Return true if a track is contained within a collection
   bool trackInCollection(const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,

--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -26,6 +26,12 @@ namespace l1t::demo::codecs {
     return etaSector + (2 * track.phiSector());
   }
 
+  static inline std::pair<unsigned int, unsigned int> sectorsEtaPhiFromGTTLinkID(unsigned int id) {
+    unsigned int etaSector = (id % 2);
+    unsigned int phiSector = (static_cast<unsigned int>(id) - etaSector) / 2;
+    return std::pair<unsigned int, unsigned int>(etaSector, phiSector);
+  }
+
   // Return true if a track is contained within a collection
   bool trackInCollection(const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
                          const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);

--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -16,10 +16,13 @@
 
 namespace l1t::demo::codecs {
   //function to get the gttLinkID from the TrackFindingProcessors
-  template<typename T>
+  template <typename T>
   unsigned int gttLinkID(T track) {
     // use the sign bit of the tanL word to remove dependence on TTTrack eta member.
-    unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
+    unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB,
+                                                   TTTrack_TrackWord::TrackBitLocations::kTanlMSB)
+                                  ? 0
+                                  : 1);
     return etaSector + (2 * track.phiSector());
   }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -24,9 +24,7 @@ namespace l1t::demo::codecs {
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (const auto& track : tracks) {
-      // use the sign bit of the tanL word to remove dependence on TTTrack eta member.
-      unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
-      trackWords.at(etaSector + (2 * track.phiSector())).push_back(encodeTrack(track));
+      trackWords.at(gttLinkID(track)).push_back(encodeTrack(track));
     }
     return trackWords;
   }
@@ -41,10 +39,9 @@ namespace l1t::demo::codecs {
       edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
       if (trackInCollection(referenceTrackRef, tracks)) {
-        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector()))
-            .push_back(encodeTrack(referenceTrack));
+        trackWords.at(gttLinkID(referenceTrack)).push_back(encodeTrack(referenceTrack));
       } else {
-        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector())).push_back(ap_uint<96>(0));
+        trackWords.at(gttLinkID(referenceTrack)).push_back(ap_uint<96>(0));
       }
     }
     return trackWords;

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -24,7 +24,9 @@ namespace l1t::demo::codecs {
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (const auto& track : tracks) {
-      trackWords.at((track.eta() >= 0 ? 1 : 0) + (2 * track.phiSector())).push_back(encodeTrack(track));
+      // use the sign bit of the tanL word to remove dependence on TTTrack eta member.
+      unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
+      trackWords.at(etaSector + (2 * track.phiSector())).push_back(encodeTrack(track));
     }
     return trackWords;
   }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -19,7 +19,7 @@
 // Original Author:  Alexx Perloff
 //         Created:  Thu, 16 Dec 2021 19:02:50 GMT
 // Derivative Author: Nick Manganelli
-//         Created: Thu, 16 Feb 2023 16:03:32 GMT
+//         Created: Thu, 14 Oct 2023 16:32:32 GMT
 //
 //
 
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <iostream>  //FIXME
 
 // Xilinx HLS includes
 #include <ap_fixed.h>
@@ -62,6 +63,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "L1Trigger/DemonstratorTools/interface/codecs/tracks.h"
 
 //
 // class declaration
@@ -148,9 +150,43 @@ private:
     std::vector<double> deltaZMaxEtaBounds_;
     std::vector<double> deltaZMax_;
   };
+  struct TTTrackWordLinkLimitSelector {
+    TTTrackWordLinkLimitSelector(const unsigned int fwNTrackSetsTVA) : fwNTrackSetsTVA_(fwNTrackSetsTVA) {
+      //create a counter for all 18 GTT input links, 2 per phiSector of the TrackFindingProcessors
+      for (int idx = 0; idx < 18; idx++) {
+        processedTracksPerLink_.push_back(0);
+      }
+    }
+    TTTrackWordLinkLimitSelector(const edm::ParameterSet& cfg)
+        : fwNTrackSetsTVA_(cfg.template getParameter<unsigned int>("fwNTrackSetsTVA")) {
+      for (int idx = 0; idx < 18; idx++) {
+        processedTracksPerLink_.push_back(0);
+      }
+    }
+    bool operator()(const TTTrackType& t) {
+      //use same method as in L1Trigger/DemonstratorTools/src/codecs_tracks.cc method getTrackWords(...)
+      unsigned int gttLinkID = (t.eta() >= 0 ? 1 : 0) + (2 * t.phiSector());
+      //increment the counter of processed tracks
+      processedTracksPerLink_.at(gttLinkID)++;
+      //fwNTrackSetsTVA_ tracks may be processed in firmware, no more (<= used intentionally to match the off-by-one indexing versus LibHLS)
+      return processedTracksPerLink_[gttLinkID] <= fwNTrackSetsTVA_;
+    }
+    void print() {
+      std::cout << "Processed track link counters:\t[";
+      for (int idx = 0; idx < 18; idx++) {
+        std::cout << processedTracksPerLink_.at(idx) << ", ";
+      }
+      std::cout << "]" << std::endl;
+    }
+
+  private:
+    unsigned int fwNTrackSetsTVA_;
+    std::vector<unsigned int> processedTracksPerLink_;
+  };
 
   // ----------member data ---------------------------
   const bool processSimulatedTracks_, processEmulatedTracks_;
+  const edm::EDGetTokenT<TTTrackCollectionType> l1TracksToken_;
   const edm::EDGetTokenT<l1t::VertexCollection> l1VerticesToken_;
   const edm::EDGetTokenT<TTTrackRefCollectionType> l1SelectedTracksToken_;
   const edm::EDGetTokenT<l1t::VertexWordCollection> l1VerticesEmulationToken_;
@@ -159,6 +195,8 @@ private:
   const edm::ParameterSet cutSet_;
   std::vector<double> deltaZMaxEtaBounds_, deltaZMax_;
   const double useDisplacedTracksDeltaZOverride_;
+  // corresponds to N_TRACK_SETS_TVA in LibHLS https://gitlab.cern.ch/GTT/LibHLS/-/blob/master/DataFormats/Track/interface/TrackConstants.h
+  const unsigned int fwNTrackSetsTVA_;
   int debug_;
 };
 
@@ -168,6 +206,7 @@ private:
 L1TrackVertexAssociationProducer::L1TrackVertexAssociationProducer(const edm::ParameterSet& iConfig)
     : processSimulatedTracks_(iConfig.getParameter<bool>("processSimulatedTracks")),
       processEmulatedTracks_(iConfig.getParameter<bool>("processEmulatedTracks")),
+      l1TracksToken_(consumes<TTTrackCollectionType>(iConfig.getParameter<edm::InputTag>("l1TracksInputTag"))),
       l1VerticesToken_(processSimulatedTracks_
                            ? consumes<l1t::VertexCollection>(iConfig.getParameter<edm::InputTag>("l1VerticesInputTag"))
                            : edm::EDGetTokenT<l1t::VertexCollection>()),
@@ -189,6 +228,7 @@ L1TrackVertexAssociationProducer::L1TrackVertexAssociationProducer(const edm::Pa
       deltaZMaxEtaBounds_(cutSet_.getParameter<std::vector<double>>("deltaZMaxEtaBounds")),
       deltaZMax_(cutSet_.getParameter<std::vector<double>>("deltaZMax")),
       useDisplacedTracksDeltaZOverride_(iConfig.getParameter<double>("useDisplacedTracksDeltaZOverride")),
+      fwNTrackSetsTVA_(iConfig.getParameter<unsigned int>("fwNTrackSetsTVA")),
       debug_(iConfig.getParameter<int>("debug")) {
   // Confirm the the configuration makes sense
   if (!processSimulatedTracks_ && !processEmulatedTracks_) {
@@ -341,7 +381,7 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   auto vTTTrackAssociatedOutput = std::make_unique<TTTrackRefCollectionType>();
   auto vTTTrackAssociatedEmulationOutput = std::make_unique<TTTrackRefCollectionType>();
 
-  // TTTrackCollectionHandle l1TracksHandle;
+  TTTrackCollectionHandle l1TracksHandle;
   edm::Handle<TTTrackRefCollectionType> l1SelectedTracksHandle;
   edm::Handle<TTTrackRefCollectionType> l1SelectedTracksEmulationHandle;
   edm::Handle<l1t::VertexCollection> l1VerticesHandle;
@@ -350,43 +390,73 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   l1t::Vertex leadingVertex;
   l1t::VertexWord leadingEmulationVertex;
 
+  TTTrackWordLinkLimitSelector linkLimitSel(fwNTrackSetsTVA_);     //stateful functor for simulated tracks
+  TTTrackWordLinkLimitSelector linkLimitSelEmu(fwNTrackSetsTVA_);  //stateful functor for emulated tracks
+
   TTTrackDeltaZMaxSelector deltaZSel(deltaZMaxEtaBounds_, deltaZMax_);
   TTTrackWordDeltaZMaxSelector deltaZSelEmu(deltaZMaxEtaBounds_, deltaZMax_);
+
+  iEvent.getByToken(l1TracksToken_, l1TracksHandle);
+  size_t nOutputApproximate = l1TracksHandle->size();
 
   if (processSimulatedTracks_) {
     iEvent.getByToken(l1SelectedTracksToken_, l1SelectedTracksHandle);
     iEvent.getByToken(l1VerticesToken_, l1VerticesHandle);
-    size_t nOutputApproximate = l1SelectedTracksHandle->size();
     leadingVertex = l1VerticesHandle->at(0);
     if (debug_ >= 2) {
       edm::LogInfo("L1TrackVertexAssociationProducer") << "leading vertex z0 = " << leadingVertex.z0();
     }
     vTTTrackAssociatedOutput->reserve(nOutputApproximate);
-    for (const auto& trackword : *l1SelectedTracksHandle) {
-      auto track = l1tVertexFinder::L1Track(edm::refToPtr(trackword));
-      // Select tracks based on the floating point TTTrack
-      if (deltaZSel(*trackword, leadingVertex)) {
-        vTTTrackAssociatedOutput->push_back(trackword);
-      }
-    }
-    iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
   }
   if (processEmulatedTracks_) {
     iEvent.getByToken(l1SelectedTracksEmulationToken_, l1SelectedTracksEmulationHandle);
     iEvent.getByToken(l1VerticesEmulationToken_, l1VerticesEmulationHandle);
-    size_t nOutputApproximateEmulation = l1SelectedTracksEmulationHandle->size();
     leadingEmulationVertex = l1VerticesEmulationHandle->at(0);
     if (debug_ >= 2) {
       edm::LogInfo("L1TrackVertexAssociationProducer")
           << "leading emulation vertex z0 = " << leadingEmulationVertex.z0();
     }
-    vTTTrackAssociatedEmulationOutput->reserve(nOutputApproximateEmulation);
-    for (const auto& trackword : *l1SelectedTracksEmulationHandle) {
-      // Select tracks based on the bitwise accurate TTTrack_TrackWord
-      if (deltaZSelEmu(*trackword, leadingEmulationVertex)) {
-        vTTTrackAssociatedEmulationOutput->push_back(trackword);
+    vTTTrackAssociatedEmulationOutput->reserve(nOutputApproximate);
+  }
+  for (size_t i = 0; i < nOutputApproximate; i++) {
+    const auto& track = l1TracksHandle->at(i);
+
+    if (processSimulatedTracks_) {
+      //FIXME: make it so there's a bunch of booleans, continue statements won't work in parallel while processing this...
+      // Limit the number of processed tracks according to the firmware capability: must be run on non-selected tracks (i.e. GTTConverted tracks)
+      bool passLinkLimit = linkLimitSel(track);
+      // Only match Selected tracks, by testing that the track is in the SelectedTracks collection
+      auto itr = std::find_if(l1SelectedTracksHandle->begin(), l1SelectedTracksHandle->end(), [track](const auto& ref) {
+        return (*ref).getTrackWord() == track.getTrackWord();
+      });
+      bool passSelection = (itr != l1SelectedTracksHandle->end());
+      // Associate tracks based on the simulation delta Z
+      if (passLinkLimit && passSelection && deltaZSel(track, leadingVertex)) {
+        vTTTrackAssociatedOutput->push_back(TTTrackRef(l1TracksHandle, i));
       }
     }
+    if (processEmulatedTracks_) {
+      // Limit the number of processed tracks according to the firmware capability: must be run on non-selected tracks (i.e. GTTConverted tracks)
+      bool passLinkLimitEmu = linkLimitSelEmu(track);
+      // Only match Selected tracks, by testing that the track is in the SelectedTracks collection
+      auto itrEmu = std::find_if(l1SelectedTracksEmulationHandle->begin(),
+                                 l1SelectedTracksEmulationHandle->end(),
+                                 [track](const auto& ref) { return (*ref).getTrackWord() == track.getTrackWord(); });
+      bool passSelectionEmu = (itrEmu != l1SelectedTracksEmulationHandle->end());
+      // Associated tracks based on the bitwise accurate TTTrack_TrackWord
+      if (passLinkLimitEmu && passSelectionEmu && deltaZSelEmu(track, leadingEmulationVertex)) {
+        vTTTrackAssociatedEmulationOutput->push_back(TTTrackRef(l1TracksHandle, i));
+      }
+    }
+  }
+
+  if (processSimulatedTracks_) {
+    linkLimitSel.print(); //FIXME
+    iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
+  }
+
+  if (processEmulatedTracks_) {
+    linkLimitSelEmu.print(); //FIXME
     iEvent.put(std::move(vTTTrackAssociatedEmulationOutput), outputCollectionName_ + "Emulation");
   }
 
@@ -401,6 +471,7 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TrackVertexAssociationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1TracksInputTag", edm::InputTag("l1tGTTInputProducer", "Level1TTTracksConverted"));
   desc.add<edm::InputTag>("l1SelectedTracksInputTag",
                           edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelected"));
   desc.add<edm::InputTag>("l1SelectedTracksEmulationInputTag",
@@ -425,6 +496,7 @@ void L1TrackVertexAssociationProducer::fillDescriptions(edm::ConfigurationDescri
       ->setComment("return selected tracks after cutting on the floating point values");
   desc.add<bool>("processEmulatedTracks", true)
       ->setComment("return selected tracks after cutting on the bitwise emulated values");
+  desc.add<unsigned int>("fwNTrackSetsTVA", 94)->setComment("firmware limit on processed tracks per GTT input link");
   desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
   descriptions.addWithDefaultLabel(desc);
 }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -165,7 +165,8 @@ private:
     }
     bool operator()(const TTTrackType& t) {
       //use same method as in L1Trigger/DemonstratorTools/src/codecs_tracks.cc method getTrackWords(...)
-      unsigned int gttLinkID = (t.eta() >= 0 ? 1 : 0) + (2 * t.phiSector());
+      unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
+      unsigned int gttLinkID = etaSector + (2 * t.phiSector());
       //increment the counter of processed tracks
       processedTracksPerLink_.at(gttLinkID)++;
       //fwNTrackSetsTVA_ tracks may be processed in firmware, no more (<= used intentionally to match the off-by-one indexing versus LibHLS)
@@ -476,12 +477,12 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   } //end loop over input converted tracks
 
   if (processSimulatedTracks_) {
-    linkLimitSel.print(); //FIXME
+    // linkLimitSel.print(); //FIXME
     iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
   }
 
   if (processEmulatedTracks_) {
-    linkLimitSelEmu.print(); //FIXME
+    // linkLimitSelEmu.print(); //FIXME
     iEvent.put(std::move(vTTTrackAssociatedEmulationOutput), outputCollectionName_ + "Emulation");
     // test making the unconverted, fully-filled vertices
     for (unsigned int ive = 0; ive < nOutputVerticesEmulation; ive++) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -204,7 +204,6 @@ private:
   const edm::EDGetTokenT<l1t::VertexWordCollection> l1VerticesEmulationToken_;
   const edm::EDGetTokenT<TTTrackRefCollectionType> l1SelectedTracksEmulationToken_;
   const std::string outputCollectionName_;
-  const std::string outputVertexCollectionName_;
   const edm::ParameterSet cutSet_;
   std::vector<double> deltaZMaxEtaBounds_, deltaZMax_;
   const double useDisplacedTracksDeltaZOverride_;
@@ -236,7 +235,6 @@ L1TrackVertexAssociationProducer::L1TrackVertexAssociationProducer(const edm::Pa
                                                 "l1SelectedTracksEmulationInputTag"))
                                           : edm::EDGetTokenT<TTTrackRefCollectionType>()),
       outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
-      outputVertexCollectionName_(iConfig.getParameter<std::string>("outputVertexCollectionName")),
       cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
 
       deltaZMaxEtaBounds_(cutSet_.getParameter<std::vector<double>>("deltaZMaxEtaBounds")),
@@ -260,10 +258,8 @@ L1TrackVertexAssociationProducer::L1TrackVertexAssociationProducer(const edm::Pa
   // Get additional input tags and define the EDM output based on the previous configuration parameters
   if (processSimulatedTracks_)
     produces<TTTrackRefCollectionType>(outputCollectionName_);
-  if (processEmulatedTracks_) {
+  if (processEmulatedTracks_)
     produces<TTTrackRefCollectionType>(outputCollectionName_ + "Emulation");
-    produces<l1t::VertexWordCollection>(outputVertexCollectionName_ + "Emulation");
-  }
 }
 
 L1TrackVertexAssociationProducer::~L1TrackVertexAssociationProducer() {}
@@ -396,7 +392,6 @@ void L1TrackVertexAssociationProducer::printTrackInfo(edm::LogInfo& log,
 void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   auto vTTTrackAssociatedOutput = std::make_unique<TTTrackRefCollectionType>();
   auto vTTTrackAssociatedEmulationOutput = std::make_unique<TTTrackRefCollectionType>();
-  auto vL1UnconvertedVerticesEmulationOutput = std::make_unique<l1t::VertexWordCollection>();
 
   TTTrackCollectionHandle l1TracksHandle;
   edm::Handle<TTTrackRefCollectionType> l1SelectedTracksHandle;
@@ -406,7 +401,6 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
 
   l1t::Vertex leadingVertex;
   l1t::VertexWord leadingEmulationVertex;
-  l1t::VertexWord loopEmulationVertex;
 
   TTTrackWordLinkLimitSelector linkLimitSel(fwNTrackSetsTVA_);     //stateful functor for simulated tracks
   TTTrackWordLinkLimitSelector linkLimitSelEmu(fwNTrackSetsTVA_);  //stateful functor for emulated tracks
@@ -416,7 +410,6 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
 
   iEvent.getByToken(l1TracksToken_, l1TracksHandle);
   size_t nOutputApproximate = l1TracksHandle->size();
-  size_t nOutputVerticesEmulation = 0;
 
   // test adding the nTracksIn and nTracksOut, and updating the sumPt fields of processed vertices
   if (processSimulatedTracks_) {
@@ -431,24 +424,15 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   if (processEmulatedTracks_) {
     iEvent.getByToken(l1SelectedTracksEmulationToken_, l1SelectedTracksEmulationHandle);
     iEvent.getByToken(l1VerticesEmulationToken_, l1VerticesEmulationHandle);
-    nOutputVerticesEmulation = l1VerticesEmulationHandle->size();
     leadingEmulationVertex = l1VerticesEmulationHandle->at(0);
     if (debug_ >= 2) {
       edm::LogInfo("L1TrackVertexAssociationProducer")
           << "leading emulation vertex z0 = " << leadingEmulationVertex.z0();
     }
     vTTTrackAssociatedEmulationOutput->reserve(nOutputApproximate);
-    vL1UnconvertedVerticesEmulationOutput->reserve(nOutputVerticesEmulation);
   }
-  std::vector<l1t::VertexWord::vtxmultiplicity_t> l1VerticesEmulationNTracksIn(nOutputVerticesEmulation, 0);
-  std::vector<l1t::VertexWord::vtxsumpt_t> l1VerticesEmulationAssociatedSumPt(nOutputVerticesEmulation, 0);
-  std::vector<l1t::VertexWord::vtxinversemult_t> l1VerticesEmulationNTracksOut(nOutputVerticesEmulation, 0);
   for (size_t i = 0; i < nOutputApproximate; i++) {
     const auto& track = l1TracksHandle->at(i);
-    l1t::VertexWord::vtxsumpt_t tkpt = 0;
-    tkpt.V = track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1,
-                                  TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
-    l1t::VertexWord::vtxsumpt_t pt_tmp = tkpt;
     if (processSimulatedTracks_) {
       // Limit the number of processed tracks according to the firmware capability: must be run on non-selected tracks (i.e. GTTConverted tracks)
       bool passLinkLimit = linkLimitSel(track);
@@ -471,20 +455,11 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
                                  [track](const auto& ref) { return (*ref).getTrackWord() == track.getTrackWord(); });
       bool passSelectionEmu = (itrEmu != l1SelectedTracksEmulationHandle->end());
       // Associated tracks based on the bitwise accurate TTTrack_TrackWord
-      if (passLinkLimitEmu && passSelectionEmu) {
-        //In HLS this loop could be unrolled
-        for (unsigned int ive = 0; ive < nOutputVerticesEmulation; ive++) {
-          if (deltaZSelEmu(track, l1VerticesEmulationHandle->at(ive))) {
-            if (ive == 0)
-              vTTTrackAssociatedEmulationOutput->push_back(TTTrackRef(l1TracksHandle, i));
-            l1VerticesEmulationNTracksIn[ive]++;
-            l1VerticesEmulationAssociatedSumPt[ive] += pt_tmp;
-          } else
-            l1VerticesEmulationNTracksOut[ive]++;
-        }  //end loop over emulation vertices
-      }    //end block for satisfying LinkLimitEmu and SelectionEmu criteria
-    }      //end if (processEmulatedTracks_)
-  }        //end loop over input converted tracks
+      if (passLinkLimitEmu && passSelectionEmu && deltaZSelEmu(track, l1VerticesEmulationHandle->at(0))) {
+        vTTTrackAssociatedEmulationOutput->push_back(TTTrackRef(l1TracksHandle, i));
+      }  //end block for satisfying LinkLimitEmu and SelectionEmu criteria
+    }    //end if (processEmulatedTracks_)
+  }      //end loop over input converted tracks
 
   if (processSimulatedTracks_) {
     iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
@@ -492,21 +467,8 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
 
   if (processEmulatedTracks_) {
     iEvent.put(std::move(vTTTrackAssociatedEmulationOutput), outputCollectionName_ + "Emulation");
-    // test making the unconverted, fully-filled vertices
-    for (unsigned int ive = 0; ive < nOutputVerticesEmulation; ive++) {
-      loopEmulationVertex = l1VerticesEmulationHandle->at(ive);
-      vL1UnconvertedVerticesEmulationOutput->emplace_back(
-          l1t::VertexWord::vtxvalid_t(loopEmulationVertex.validWord()),
-          l1t::VertexWord::vtxz0_t(loopEmulationVertex.z0Word()),
-          l1t::VertexWord::vtxmultiplicity_t(l1VerticesEmulationNTracksIn[ive]),
-          l1t::VertexWord::vtxsumpt_t(l1VerticesEmulationAssociatedSumPt[ive]),
-          l1t::VertexWord::vtxquality_t(0),
-          l1t::VertexWord::vtxinversemult_t(l1VerticesEmulationNTracksOut[ive]),
-          l1t::VertexWord::vtxunassigned_t(0));
-    }  //end loop over emulation vertices
     if (debug_ >= 2)
       linkLimitSelEmu.log();
-    iEvent.put(std::move(vL1UnconvertedVerticesEmulationOutput), outputVertexCollectionName_ + "Emulation");
   }
 
   if (processSimulatedTracks_ && processEmulatedTracks_ && debug_ >= 2) {
@@ -529,7 +491,6 @@ void L1TrackVertexAssociationProducer::fillDescriptions(edm::ConfigurationDescri
   desc.add<edm::InputTag>("l1VerticesEmulationInputTag",
                           edm::InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"));
   desc.add<std::string>("outputCollectionName", "Level1TTTracksSelectedAssociated");
-  desc.add<std::string>("outputVertexCollectionName", "L1VerticesUnconverted");
   {
     edm::ParameterSetDescription descCutSet;
     descCutSet.add<std::vector<double>>("deltaZMaxEtaBounds", {0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4})

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -192,6 +192,7 @@ private:
   const edm::EDGetTokenT<l1t::VertexWordCollection> l1VerticesEmulationToken_;
   const edm::EDGetTokenT<TTTrackRefCollectionType> l1SelectedTracksEmulationToken_;
   const std::string outputCollectionName_;
+  const std::string outputVertexCollectionName_;
   const edm::ParameterSet cutSet_;
   std::vector<double> deltaZMaxEtaBounds_, deltaZMax_;
   const double useDisplacedTracksDeltaZOverride_;
@@ -223,6 +224,7 @@ L1TrackVertexAssociationProducer::L1TrackVertexAssociationProducer(const edm::Pa
                                                 "l1SelectedTracksEmulationInputTag"))
                                           : edm::EDGetTokenT<TTTrackRefCollectionType>()),
       outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      outputVertexCollectionName_(iConfig.getParameter<std::string>("outputVertexCollectionName")),
       cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
 
       deltaZMaxEtaBounds_(cutSet_.getParameter<std::vector<double>>("deltaZMaxEtaBounds")),
@@ -246,8 +248,10 @@ L1TrackVertexAssociationProducer::L1TrackVertexAssociationProducer(const edm::Pa
   // Get additional input tags and define the EDM output based on the previous configuration parameters
   if (processSimulatedTracks_)
     produces<TTTrackRefCollectionType>(outputCollectionName_);
-  if (processEmulatedTracks_)
+  if (processEmulatedTracks_) {
     produces<TTTrackRefCollectionType>(outputCollectionName_ + "Emulation");
+    produces<l1t::VertexWordCollection>(outputVertexCollectionName_ + "Emulation");
+  }
 }
 
 L1TrackVertexAssociationProducer::~L1TrackVertexAssociationProducer() {}
@@ -380,6 +384,7 @@ void L1TrackVertexAssociationProducer::printTrackInfo(edm::LogInfo& log,
 void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   auto vTTTrackAssociatedOutput = std::make_unique<TTTrackRefCollectionType>();
   auto vTTTrackAssociatedEmulationOutput = std::make_unique<TTTrackRefCollectionType>();
+  auto vL1UnconvertedVerticesEmulationOutput = std::make_unique<l1t::VertexWordCollection>();
 
   TTTrackCollectionHandle l1TracksHandle;
   edm::Handle<TTTrackRefCollectionType> l1SelectedTracksHandle;
@@ -389,6 +394,7 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
 
   l1t::Vertex leadingVertex;
   l1t::VertexWord leadingEmulationVertex;
+  l1t::VertexWord loopEmulationVertex;
 
   TTTrackWordLinkLimitSelector linkLimitSel(fwNTrackSetsTVA_);     //stateful functor for simulated tracks
   TTTrackWordLinkLimitSelector linkLimitSelEmu(fwNTrackSetsTVA_);  //stateful functor for emulated tracks
@@ -398,7 +404,9 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
 
   iEvent.getByToken(l1TracksToken_, l1TracksHandle);
   size_t nOutputApproximate = l1TracksHandle->size();
+  size_t nOutputVerticesEmulation = 0;
 
+  // test adding the nTracksIn and nTracksOut, and updating the sumPt fields of processed vertices
   if (processSimulatedTracks_) {
     iEvent.getByToken(l1SelectedTracksToken_, l1SelectedTracksHandle);
     iEvent.getByToken(l1VerticesToken_, l1VerticesHandle);
@@ -411,18 +419,25 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   if (processEmulatedTracks_) {
     iEvent.getByToken(l1SelectedTracksEmulationToken_, l1SelectedTracksEmulationHandle);
     iEvent.getByToken(l1VerticesEmulationToken_, l1VerticesEmulationHandle);
+    nOutputVerticesEmulation = l1VerticesEmulationHandle->size();
     leadingEmulationVertex = l1VerticesEmulationHandle->at(0);
     if (debug_ >= 2) {
       edm::LogInfo("L1TrackVertexAssociationProducer")
           << "leading emulation vertex z0 = " << leadingEmulationVertex.z0();
     }
     vTTTrackAssociatedEmulationOutput->reserve(nOutputApproximate);
+    vL1UnconvertedVerticesEmulationOutput->reserve(nOutputVerticesEmulation);
   }
+  std::vector<l1t::VertexWord::vtxmultiplicity_t> l1VerticesEmulationNTracksIn(nOutputVerticesEmulation, 0);
+  std::vector<l1t::VertexWord::vtxsumpt_t> l1VerticesEmulationAssociatedSumPt(nOutputVerticesEmulation, 0);
+  std::vector<l1t::VertexWord::vtxinversemult_t> l1VerticesEmulationNTracksOut(nOutputVerticesEmulation, 0);
   for (size_t i = 0; i < nOutputApproximate; i++) {
     const auto& track = l1TracksHandle->at(i);
-
+    l1t::VertexWord::vtxsumpt_t tkpt = 0;
+    tkpt.V = track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1,
+				  TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
+    l1t::VertexWord::vtxsumpt_t pt_tmp = tkpt;
     if (processSimulatedTracks_) {
-      //FIXME: make it so there's a bunch of booleans, continue statements won't work in parallel while processing this...
       // Limit the number of processed tracks according to the firmware capability: must be run on non-selected tracks (i.e. GTTConverted tracks)
       bool passLinkLimit = linkLimitSel(track);
       // Only match Selected tracks, by testing that the track is in the SelectedTracks collection
@@ -434,7 +449,7 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
       if (passLinkLimit && passSelection && deltaZSel(track, leadingVertex)) {
         vTTTrackAssociatedOutput->push_back(TTTrackRef(l1TracksHandle, i));
       }
-    }
+    } //end if (processSimulatedTracks_)
     if (processEmulatedTracks_) {
       // Limit the number of processed tracks according to the firmware capability: must be run on non-selected tracks (i.e. GTTConverted tracks)
       bool passLinkLimitEmu = linkLimitSelEmu(track);
@@ -444,11 +459,21 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
                                  [track](const auto& ref) { return (*ref).getTrackWord() == track.getTrackWord(); });
       bool passSelectionEmu = (itrEmu != l1SelectedTracksEmulationHandle->end());
       // Associated tracks based on the bitwise accurate TTTrack_TrackWord
-      if (passLinkLimitEmu && passSelectionEmu && deltaZSelEmu(track, leadingEmulationVertex)) {
-        vTTTrackAssociatedEmulationOutput->push_back(TTTrackRef(l1TracksHandle, i));
-      }
-    }
-  }
+      if (passLinkLimitEmu && passSelectionEmu) {
+	//In HLS this loop could be unrolled
+	for (unsigned int ive = 0; ive < nOutputVerticesEmulation; ive++) {
+	  if (deltaZSelEmu(track, l1VerticesEmulationHandle->at(ive))) {
+	    if (ive == 0)
+	      vTTTrackAssociatedEmulationOutput->push_back(TTTrackRef(l1TracksHandle, i));
+	    l1VerticesEmulationNTracksIn[ive]++;
+	    l1VerticesEmulationAssociatedSumPt[ive] += pt_tmp;
+	  }
+	  else
+	    l1VerticesEmulationNTracksOut[ive]++;
+	} //end loop over emulation vertices
+      } //end block for satisfying LinkLimitEmu and SelectionEmu criteria
+    } //end if (processEmulatedTracks_)
+  } //end loop over input converted tracks
 
   if (processSimulatedTracks_) {
     linkLimitSel.print(); //FIXME
@@ -458,6 +483,18 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   if (processEmulatedTracks_) {
     linkLimitSelEmu.print(); //FIXME
     iEvent.put(std::move(vTTTrackAssociatedEmulationOutput), outputCollectionName_ + "Emulation");
+    // test making the unconverted, fully-filled vertices
+    for (unsigned int ive = 0; ive < nOutputVerticesEmulation; ive++) {
+      loopEmulationVertex = l1VerticesEmulationHandle->at(ive);
+      vL1UnconvertedVerticesEmulationOutput->emplace_back(l1t::VertexWord::vtxvalid_t(loopEmulationVertex.validWord()),
+							  l1t::VertexWord::vtxz0_t(loopEmulationVertex.z0Word()),
+							  l1t::VertexWord::vtxmultiplicity_t(l1VerticesEmulationNTracksIn[ive]),
+							  l1t::VertexWord::vtxsumpt_t(l1VerticesEmulationAssociatedSumPt[ive]),
+							  l1t::VertexWord::vtxquality_t(0),
+							  l1t::VertexWord::vtxinversemult_t(l1VerticesEmulationNTracksOut[ive]),
+							  l1t::VertexWord::vtxunassigned_t(0));
+    } //end loop over emulation vertices
+    iEvent.put(std::move(vL1UnconvertedVerticesEmulationOutput), outputVertexCollectionName_ + "Emulation");
   }
 
   if (processSimulatedTracks_ && processEmulatedTracks_ && debug_ >= 2) {
@@ -480,6 +517,7 @@ void L1TrackVertexAssociationProducer::fillDescriptions(edm::ConfigurationDescri
   desc.add<edm::InputTag>("l1VerticesEmulationInputTag",
                           edm::InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"));
   desc.add<std::string>("outputCollectionName", "Level1TTTracksSelectedAssociated");
+  desc.add<std::string>("outputVertexCollectionName", "L1VerticesUnconverted");
   {
     edm::ParameterSetDescription descCutSet;
     descCutSet.add<std::vector<double>>("deltaZMaxEtaBounds", {0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4})

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -165,7 +165,7 @@ private:
     }
     bool operator()(const TTTrackType& t) {
       //use same method as in L1Trigger/DemonstratorTools/src/codecs_tracks.cc method getTrackWords(...)
-      unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
+      unsigned int etaSector = (t.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
       unsigned int gttLinkID = etaSector + (2 * t.phiSector());
       //increment the counter of processed tracks
       processedTracksPerLink_.at(gttLinkID)++;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -164,9 +164,7 @@ private:
       }
     }
     bool operator()(const TTTrackType& t) {
-      //use same method as in L1Trigger/DemonstratorTools/src/codecs_tracks.cc method getTrackWords(...)
-      unsigned int etaSector = (t.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB, TTTrack_TrackWord::TrackBitLocations::kTanlMSB) ? 0 : 1);
-      unsigned int gttLinkID = etaSector + (2 * t.phiSector());
+      unsigned int gttLinkID = l1t::demo::codecs::gttLinkID(t);
       //increment the counter of processed tracks
       processedTracksPerLink_.at(gttLinkID)++;
       //fwNTrackSetsTVA_ tracks may be processed in firmware, no more (<= used intentionally to match the off-by-one indexing versus LibHLS)

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -411,7 +411,6 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   iEvent.getByToken(l1TracksToken_, l1TracksHandle);
   size_t nOutputApproximate = l1TracksHandle->size();
 
-  // test adding the nTracksIn and nTracksOut, and updating the sumPt fields of processed vertices
   if (processSimulatedTracks_) {
     iEvent.getByToken(l1SelectedTracksToken_, l1SelectedTracksHandle);
     iEvent.getByToken(l1VerticesToken_, l1VerticesHandle);

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProducer',
+  l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Level1TTTracksConverted"),
   l1SelectedTracksInputTag = cms.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelected"),
   l1SelectedTracksEmulationInputTag = cms.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"),
   # If no vertex collection is provided, then the DeltaZ cuts will not be run
@@ -16,10 +17,12 @@ l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProd
   useDisplacedTracksDeltaZOverride = cms.double(-1.0), # override the deltaZ cut value for displaced tracks
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
+  fwNTrackSetsTVA = cms.uint32(94), # firmware limit on number of GTT converted tracks considered for primary vertex association
   debug = cms.int32(0) # Verbosity levels: 0, 1, 2, 3, 4
 )
 
 l1tTrackVertexAssociationProducerExtended = l1tTrackVertexAssociationProducer.clone(
+  l1TracksInputTag = ("l1tGTTInputProducerExtended","Level1TTTracksExtendedConverted"),
   l1SelectedTracksInputTag = cms.InputTag("l1tTrackSelectionProducerExtended", "Level1TTTracksExtendedSelected"),
   l1SelectedTracksEmulationInputTag = cms.InputTag("l1tTrackSelectionProducerExtended", "Level1TTTracksExtendedSelectedEmulation"),
   outputCollectionName = cms.string("Level1TTTracksExtendedSelectedAssociated"),

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -8,6 +8,7 @@ l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProd
   l1VerticesInputTag = cms.InputTag("l1tVertexFinder", "L1Vertices"),
   l1VerticesEmulationInputTag = cms.InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"),
   outputCollectionName = cms.string("Level1TTTracksSelectedAssociated"),
+  outputVertexCollectionName = cms.string("L1VerticesUnconverted"),
   cutSet = cms.PSet(
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -8,7 +8,6 @@ l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProd
   l1VerticesInputTag = cms.InputTag("l1tVertexFinder", "L1Vertices"),
   l1VerticesEmulationInputTag = cms.InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"),
   outputCollectionName = cms.string("Level1TTTracksSelectedAssociated"),
-  outputVertexCollectionName = cms.string("L1VerticesUnconverted"),
   cutSet = cms.PSet(
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]


### PR DESCRIPTION
#### PR description:
This PR implements matching of emulation to a firmware feature for the Global Track Trigger. For GTT, there are 18 optical links (9 phi sectors x 2 eta sectors) from the TrackFindingProcessors. Each link can send up to 104 tracks, but a limitation in the current firmware prevents all from being considered for association with the primary vertex: the limit is currently 94/104, and this limit is encoded in a configurable parameter in the l1tTrackVertexAssociation_cfi.py file. This has no impact on vertices (which are found using all (selected) tracks sent to GTT and strictly upstream of the TrackVertexAssociation), and in the cases of track-only objects, is expected to impact less than 1 in 10^6 ttbar (200PU) events (the original limit of 104 tracks per link was designed around such a figure of merit + an overhead, this PR decreases the overhead a small amount)

Bit-accurate outputs are maintained for board integration tests on 1008 events ttbar (200PU) events.

In anticipation of another PR, the code used to determine the link a track belongs to is encapsulated in a function in the codecs header, to be used commonly in the GTTFile{Reader,Writer} when updated.

#### PR validation:
This PR passes:
scram b
scram b code-checks
scram b code-format
Used to generate GTT test vectors for APx/Serenity on ~1000 events from TT (CMSSW_13_1) sample
Test vectors pass tests with corresponding update for TrackVertexAssociation in the LibHLS repo
runTheMatrix.py -l limited -i all --ibeos (master branch, prior to rebasing to integration branch)

#### Ports
This PR will need to be integrated into master as well after integration here