### PR TITLE
Add additional int accessors for P2GTCandidate hw values

### DIFF
--- a/DataFormats/L1Trigger/interface/P2GTCandidate.h
+++ b/DataFormats/L1Trigger/interface/P2GTCandidate.h
@@ -278,6 +278,139 @@ namespace l1t {
              objectType_ == CL2Jets;
     }
 
+  int hwPT_toInt() const {
+      if (!hwPT_) {
+        throw std::invalid_argument("Object doesn't have pT");
+      }
+      return static_cast<int>(hwPT_);
+    }
+  
+    int hwPhi_toInt() const {
+      if (!hwPhi_) {
+        throw std::invalid_argument("Object doesn't have phi");
+      }
+      return static_cast<int>(hwPhi_);
+    }
+  
+    int hwEta_toInt() const {
+      if (!hwEta_) {
+        throw std::invalid_argument("Object doesn't have eta");
+      }
+      return static_cast<int>(hwEta_);
+    }
+  
+    int hwZ0_toInt() const {
+      if (!hwZ0_) {
+        throw std::invalid_argument("Object doesn't have z0");
+      }
+      return static_cast<int>(hwZ0_);
+    }
+  
+    int hwIso_toInt() const {
+      if (!hwIso_) {
+        throw std::invalid_argument("Object doesn't have iso");
+      }
+      return static_cast<int>(hwIso_);
+    }
+  
+    int hwQual_toInt() const {
+      if (!hwQual_) {
+        throw std::invalid_argument("Object doesn't have qual");
+      }
+      return static_cast<int>(hwQual_);
+    }
+  
+    int hwCharge_toInt() const {
+      if (!hwCharge_) {
+        throw std::invalid_argument("Object doesn't have charge");
+      }
+      return static_cast<int>(hwCharge_);
+    }
+  
+    int hwD0_toInt() const {
+      if (!hwD0_) {
+        throw std::invalid_argument("Object doesn't have d0");
+      }
+      return static_cast<int>(hwD0_);
+    }
+  
+    int hwBeta_toInt() const {
+      if (!hwBeta_) {
+        throw std::invalid_argument("Object doesn't have beta");
+      }
+      return static_cast<int>(hwBeta_);
+    }
+  
+    int hwMass_toInt() const {
+      if (!hwMass_) {
+        throw std::invalid_argument("Object doesn't have mass");
+      }
+      return static_cast<int>(hwMass_);
+    }
+  
+    int hwIndex_toInt() const {
+      if (!hwIndex_) {
+        throw std::invalid_argument("Object doesn't have index");
+      }
+      return static_cast<int>(hwIndex_);
+    }
+  
+    int hwSeed_pT_toInt() const {
+      if (!hwSeed_pT_) {
+        throw std::invalid_argument("Object doesn't have seed_pT");
+      }
+      return static_cast<int>(hwSeed_pT_);
+    }
+  
+    int hwSeed_z0_toInt() const {
+      if (!hwSeed_z0_) {
+        throw std::invalid_argument("Object doesn't have seed_z0");
+      }
+      return static_cast<int>(hwSeed_z0_);
+    }
+  
+    int hwSca_sum_toInt() const {
+      if (!hwSca_sum_) {
+        throw std::invalid_argument("Object doesn't have sca_sum");
+      }
+      return static_cast<int>(hwSca_sum_);
+    }
+  
+    int hwNumber_of_tracks_toInt() const {
+      if (!hwNumber_of_tracks_) {
+        throw std::invalid_argument("Object doesn't have number_of_tracks");
+      }
+      return static_cast<int>(hwNumber_of_tracks_);
+    }
+  
+    int hwSum_pT_pv_toInt() const {
+      if (!hwSum_pT_pv_) {
+        throw std::invalid_argument("Object doesn't have sum_pT_pv");
+      }
+      return static_cast<int>(hwSum_pT_pv_);
+    }
+  
+    int hwType_toInt() const {
+      if (!hwType_) {
+        throw std::invalid_argument("Object doesn't have type");
+      }
+      return static_cast<int>(hwType_);
+    }
+  
+    int hwNumber_of_tracks_in_pv_toInt() const {
+      if (!hwNumber_of_tracks_in_pv_) {
+        throw std::invalid_argument("Object doesn't have number_of_tracks_in_pv");
+      }
+      return static_cast<int>(hwNumber_of_tracks_in_pv_);
+    }
+  
+    int hwNumber_of_tracks_not_in_pv_toInt() const {
+      if (!hwNumber_of_tracks_not_in_pv_) {
+        throw std::invalid_argument("Object doesn't have hwNumber_of_tracks_not_in_pv");
+      }
+      return static_cast<int>(hwNumber_of_tracks_not_in_pv_);
+    }
+
   private:
     Optional<int> hwPT_;
     Optional<int> hwPhi_;

--- a/DataFormats/L1Trigger/interface/P2GTCandidate.h
+++ b/DataFormats/L1Trigger/interface/P2GTCandidate.h
@@ -278,132 +278,132 @@ namespace l1t {
              objectType_ == CL2Jets;
     }
 
-  int hwPT_toInt() const {
+    int hwPT_toInt() const {
       if (!hwPT_) {
         throw std::invalid_argument("Object doesn't have pT");
       }
       return static_cast<int>(hwPT_);
     }
-  
+
     int hwPhi_toInt() const {
       if (!hwPhi_) {
         throw std::invalid_argument("Object doesn't have phi");
       }
       return static_cast<int>(hwPhi_);
     }
-  
+
     int hwEta_toInt() const {
       if (!hwEta_) {
         throw std::invalid_argument("Object doesn't have eta");
       }
       return static_cast<int>(hwEta_);
     }
-  
+
     int hwZ0_toInt() const {
       if (!hwZ0_) {
         throw std::invalid_argument("Object doesn't have z0");
       }
       return static_cast<int>(hwZ0_);
     }
-  
+
     int hwIso_toInt() const {
       if (!hwIso_) {
         throw std::invalid_argument("Object doesn't have iso");
       }
       return static_cast<int>(hwIso_);
     }
-  
+
     int hwQual_toInt() const {
       if (!hwQual_) {
         throw std::invalid_argument("Object doesn't have qual");
       }
       return static_cast<int>(hwQual_);
     }
-  
+
     int hwCharge_toInt() const {
       if (!hwCharge_) {
         throw std::invalid_argument("Object doesn't have charge");
       }
       return static_cast<int>(hwCharge_);
     }
-  
+
     int hwD0_toInt() const {
       if (!hwD0_) {
         throw std::invalid_argument("Object doesn't have d0");
       }
       return static_cast<int>(hwD0_);
     }
-  
+
     int hwBeta_toInt() const {
       if (!hwBeta_) {
         throw std::invalid_argument("Object doesn't have beta");
       }
       return static_cast<int>(hwBeta_);
     }
-  
+
     int hwMass_toInt() const {
       if (!hwMass_) {
         throw std::invalid_argument("Object doesn't have mass");
       }
       return static_cast<int>(hwMass_);
     }
-  
+
     int hwIndex_toInt() const {
       if (!hwIndex_) {
         throw std::invalid_argument("Object doesn't have index");
       }
       return static_cast<int>(hwIndex_);
     }
-  
+
     int hwSeed_pT_toInt() const {
       if (!hwSeed_pT_) {
         throw std::invalid_argument("Object doesn't have seed_pT");
       }
       return static_cast<int>(hwSeed_pT_);
     }
-  
+
     int hwSeed_z0_toInt() const {
       if (!hwSeed_z0_) {
         throw std::invalid_argument("Object doesn't have seed_z0");
       }
       return static_cast<int>(hwSeed_z0_);
     }
-  
+
     int hwSca_sum_toInt() const {
       if (!hwSca_sum_) {
         throw std::invalid_argument("Object doesn't have sca_sum");
       }
       return static_cast<int>(hwSca_sum_);
     }
-  
+
     int hwNumber_of_tracks_toInt() const {
       if (!hwNumber_of_tracks_) {
         throw std::invalid_argument("Object doesn't have number_of_tracks");
       }
       return static_cast<int>(hwNumber_of_tracks_);
     }
-  
+
     int hwSum_pT_pv_toInt() const {
       if (!hwSum_pT_pv_) {
         throw std::invalid_argument("Object doesn't have sum_pT_pv");
       }
       return static_cast<int>(hwSum_pT_pv_);
     }
-  
+
     int hwType_toInt() const {
       if (!hwType_) {
         throw std::invalid_argument("Object doesn't have type");
       }
       return static_cast<int>(hwType_);
     }
-  
+
     int hwNumber_of_tracks_in_pv_toInt() const {
       if (!hwNumber_of_tracks_in_pv_) {
         throw std::invalid_argument("Object doesn't have number_of_tracks_in_pv");
       }
       return static_cast<int>(hwNumber_of_tracks_in_pv_);
     }
-  
+
     int hwNumber_of_tracks_not_in_pv_toInt() const {
       if (!hwNumber_of_tracks_not_in_pv_) {
         throw std::invalid_argument("Object doesn't have hwNumber_of_tracks_not_in_pv");


### PR DESCRIPTION
#### PR description:
This is a useful/necessary addition for using the P2GTCandidates with the the Nano [`SimpleCandidateFlatTableProducer`](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc#L4C50-L4C82). 
See example usage in the P2L1Nano repo: 
https://github.com/cms-l1-dpg/Phase2-L1Nano/blob/main/python/l1Ph2Nano_cff.py#L57

The problem with the `hw` values of the `P2GTCandidate` is that these are based on `ap_type` and the standard accessors cannot cast to `int` in a way compatible with the Table Producer. Elias (@qvyz) discussed this with Giovanni @gpetruc. 
Hence this solution was proposed by Elias and Benjamin from the P2GT team,.

The downside is the necessity to have two different access methods for the `hw` members of the P2GT Candidate, e.g.:
* `hwQual_t hwQual()`
* `int hwQual_toInt()`

Note, that for the phase-1 GT Candidates there is no necessity for this, as the `hw` value accessors return `int` and not `ap` types: https://github.com/cms-sw/cmssw/blob/CMSSW_13_3_X/DataFormats/L1Trigger/interface/L1Candidate.h#L34

#### PR validation:
This works with the Phase2 L1Nano recipe as linked above. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for

Backport only needed if we are planning to use the Nano for earlier releases than `133X`.
(For now the L1Nano recipe checks out this change from my private branch)