### PR TITLE
GE0 Fixes for L1T for CMSSW_13_3_0_pre3

### DIFF
--- a/DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h
@@ -8,9 +8,11 @@
  */
 
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/GEMDigi/interface/ME0TriggerDigi.h"
 #include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<ME0DetId, ME0TriggerDigi> ME0TriggerDigiCollection;
+typedef MuonDigiCollection<GEMDetId, ME0TriggerDigi> GE0TriggerDigiCollection;
 
 #endif

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -132,4 +132,9 @@
 <class name="MuonDigiCollection<ME0DetId,ME0TriggerDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0TriggerDigi> >" splitLevel="0"/>
 
+<class name="std::map<GEMDetId,std::vector<ME0TriggerDigi> >"/>
+<class name="std::pair<GEMDetId,std::vector<ME0TriggerDigi> >"/>
+<class name="MuonDigiCollection<GEMDetId,ME0TriggerDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,ME0TriggerDigi> >" splitLevel="0"/>
+
 </lcgdict>

--- a/L1Trigger/L1TGEM/interface/GE0TriggerPseudoBuilder.h
+++ b/L1Trigger/L1TGEM/interface/GE0TriggerPseudoBuilder.h
@@ -1,0 +1,63 @@
+#ifndef L1Trigger_L1TGEM_GE0TriggerPseudoBuilder_h
+#define L1Trigger_L1TGEM_GE0TriggerPseudoBuilder_h
+
+/** \class GE0TriggerPseudoBuilder
+ *
+ * Builds GE0 trigger objects from GE0 segment
+ *
+ * \author Original ME0 code by Tao Huang (TAMU). Converted and updated to GE0 by Ian J. Watson (USeoul)
+ *
+ */
+
+#include "DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h"
+#include "DataFormats/GEMRecHit/interface/GEMSegmentCollection.h"
+#include "DataFormats/GEMRecHit/interface/GEMSegment.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class GEMGeometry;
+
+class GE0TriggerPseudoBuilder {
+public:
+  /** Configure the algorithm via constructor.
+   *  Receives ParameterSet percolated down from
+   *  EDProducer which owns this Builder.
+   */
+  explicit GE0TriggerPseudoBuilder(const edm::ParameterSet&);
+
+  ~GE0TriggerPseudoBuilder();
+
+  /** Build Triggers from ME0 segment in each chamber and fill them into output collections. */
+  void build(const GEMSegmentCollection* me0segments, ME0TriggerDigiCollection& oc_trig);
+
+  /** set geometry for the matching needs */
+  void setME0Geometry(const GEMGeometry* g) { me0_g = g; }
+
+  /* print all ME0 segments in the event */
+  void dumpAllME0Segments(const GEMSegmentCollection& segments) const;
+
+  /** Max values of trigger labels for all ME0s;
+   *  used to construct TMB processors.
+   */
+  enum class trig_me0s { MAX_ENDCAPS = 2, MAX_CHAMBERS = 18 };
+
+private:
+  static const int min_endcap;
+  static const int max_endcap;
+  static const int min_chamber;
+  static const int max_chamber;
+  static const unsigned int ME0KeyLayer;
+  static const int ME0TriggerCentralBX;
+
+  const GEMGeometry* me0_g;
+
+  int info_;
+
+  double dphiresolution_;  //unit: trigger pad
+
+  ME0TriggerDigi segmentConversion(const GEMSegment segment);
+
+  edm::ParameterSet config_;
+};
+
+#endif

--- a/L1Trigger/L1TGEM/interface/GE0TriggerPseudoBuilder.h
+++ b/L1Trigger/L1TGEM/interface/GE0TriggerPseudoBuilder.h
@@ -28,7 +28,7 @@ public:
   ~GE0TriggerPseudoBuilder();
 
   /** Build Triggers from ME0 segment in each chamber and fill them into output collections. */
-  void build(const GEMSegmentCollection* me0segments, ME0TriggerDigiCollection& oc_trig);
+  void build(const GEMSegmentCollection* me0segments, GE0TriggerDigiCollection& oc_trig);
 
   /** set geometry for the matching needs */
   void setME0Geometry(const GEMGeometry* g) { me0_g = g; }

--- a/L1Trigger/L1TGEM/plugins/GE0TriggerPseudoProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GE0TriggerPseudoProducer.cc
@@ -47,7 +47,7 @@ GE0TriggerPseudoProducer::GE0TriggerPseudoProducer(const edm::ParameterSet& conf
   config_ = conf;
 
   // register what this produces
-  produces<ME0TriggerDigiCollection>();
+  produces<GE0TriggerDigiCollection>();
 }
 
 GE0TriggerPseudoProducer::~GE0TriggerPseudoProducer() {}
@@ -60,7 +60,7 @@ void GE0TriggerPseudoProducer::produce(edm::StreamID, edm::Event& ev, const edm:
   const GEMSegmentCollection* me0segments = me0Segmentcoll.product();
 
   // Create empty collection
-  auto oc_trig = std::make_unique<ME0TriggerDigiCollection>();
+  auto oc_trig = std::make_unique<GE0TriggerDigiCollection>();
 
   auto trigBuilder = std::make_unique<GE0TriggerPseudoBuilder>(config_);
   trigBuilder->setME0Geometry(&*h_me0);

--- a/L1Trigger/L1TGEM/plugins/GE0TriggerPseudoProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GE0TriggerPseudoProducer.cc
@@ -1,0 +1,77 @@
+/** \class GE0TriggerPseudoProducer
+ *
+ * Takes offline GE0 segment as input
+ * Produces GE0 trigger objects
+ *
+ * \author Original ME0 code by Tao Huang (TAMU). Converted and updated to GE0 by Ian J. Watson (USeoul)
+ *
+ */
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "L1Trigger/L1TGEM/interface/GE0TriggerPseudoBuilder.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h"
+#include "DataFormats/GEMRecHit/interface/GEMSegmentCollection.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+
+class GE0TriggerPseudoBuilder;
+
+class GE0TriggerPseudoProducer : public edm::global::EDProducer<> {
+public:
+  explicit GE0TriggerPseudoProducer(const edm::ParameterSet&);
+  ~GE0TriggerPseudoProducer() override;
+
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  edm::InputTag me0segmentProducer_;
+  edm::EDGetTokenT<GEMSegmentCollection> me0segment_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> me0_geom_token_;
+  edm::ParameterSet config_;
+};
+
+GE0TriggerPseudoProducer::GE0TriggerPseudoProducer(const edm::ParameterSet& conf) {
+  me0segmentProducer_ = conf.getParameter<edm::InputTag>("ME0SegmentProducer");
+  me0segment_token_ = consumes<GEMSegmentCollection>(me0segmentProducer_);
+  me0_geom_token_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  config_ = conf;
+
+  // register what this produces
+  produces<ME0TriggerDigiCollection>();
+}
+
+GE0TriggerPseudoProducer::~GE0TriggerPseudoProducer() {}
+
+void GE0TriggerPseudoProducer::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& setup) const {
+  edm::ESHandle<GEMGeometry> h_me0 = setup.getHandle(me0_geom_token_);
+
+  edm::Handle<GEMSegmentCollection> me0Segmentcoll;
+  ev.getByToken(me0segment_token_, me0Segmentcoll);
+  const GEMSegmentCollection* me0segments = me0Segmentcoll.product();
+
+  // Create empty collection
+  auto oc_trig = std::make_unique<ME0TriggerDigiCollection>();
+
+  auto trigBuilder = std::make_unique<GE0TriggerPseudoBuilder>(config_);
+  trigBuilder->setME0Geometry(&*h_me0);
+
+  // Fill output collections if valid input collection is available.
+  if (me0Segmentcoll.isValid()) {
+    trigBuilder->build(me0segments, *oc_trig);
+  }
+
+  // Put collections in event.
+  ev.put(std::move(oc_trig));
+}
+
+DEFINE_FWK_MODULE(GE0TriggerPseudoProducer);

--- a/L1Trigger/L1TGEM/python/me0TriggerConvertedPseudoDigis_cfi.py
+++ b/L1Trigger/L1TGEM/python/me0TriggerConvertedPseudoDigis_cfi.py
@@ -5,3 +5,9 @@ me0TriggerConvertedPseudoDigis = cms.EDProducer("ME0TriggerPseudoProducer",
     info = cms.untracked.int32(0),
     DeltaPhiResolution = cms.untracked.double(0.25)# in term of trigger pad
 )
+
+ge0TriggerConvertedPseudoDigis = cms.EDProducer("GE0TriggerPseudoProducer",
+    ME0SegmentProducer = cms.InputTag("gemSegments"),
+    info = cms.untracked.int32(0),
+    DeltaPhiResolution = cms.untracked.double(0.25)# in term of trigger pad
+)

--- a/L1Trigger/L1TGEM/python/me0TriggerDigis_cff.py
+++ b/L1Trigger/L1TGEM/python/me0TriggerDigis_cff.py
@@ -7,6 +7,8 @@ from L1Trigger.L1TGEM.me0TriggerPseudoDigis_cff import *
 
 me0TriggerRealDigiTask = cms.Task(simMuonME0PadDigis, me0TriggerDigis)
 me0TriggerAllDigiTask = cms.Task(me0TriggerRealDigiTask, me0TriggerPseudoDigiTask)
+ge0TriggerAllDigiTask = cms.Task(me0TriggerRealDigiTask, ge0TriggerPseudoDigiTask)
 
 ## in scenarios with GE0, remove the pseudo digis
-phase2_GE0.toReplaceWith(me0TriggerAllDigiTask, me0TriggerAllDigiTask.copyAndExclude([me0TriggerPseudoDigiTask]))
+# phase2_GE0.toReplaceWith(me0TriggerAllDigiTask, me0TriggerAllDigiTask.copyAndExclude([me0TriggerPseudoDigiTask]))
+phase2_GE0.toReplaceWith(me0TriggerAllDigiTask, ge0TriggerAllDigiTask)

--- a/L1Trigger/L1TGEM/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/L1TGEM/python/me0TriggerPseudoDigis_cff.py
@@ -37,3 +37,16 @@ me0TriggerPseudoDigiTask = cms.Task(
     me0Segments,
     me0TriggerConvertedPseudoDigis
 )
+
+from RecoLocalMuon.GEMRecHit.gemRecHits_cfi import *
+from RecoLocalMuon.GEMSegment.gemSegments_cfi import *
+
+ge0TriggerPseudoDigiTask = cms.Task(
+    simMuonME0PseudoReDigisCoarse,
+    me0RecHitsCoarse,
+    me0TriggerPseudoDigis,
+    ## need to run the standard ME0 RECO sequence for converted triggers
+    gemRecHits,
+    gemSegments,
+    ge0TriggerConvertedPseudoDigis
+)

--- a/L1Trigger/L1TGEM/src/GE0TriggerPseudoBuilder.cc
+++ b/L1Trigger/L1TGEM/src/GE0TriggerPseudoBuilder.cc
@@ -1,0 +1,164 @@
+#include "L1Trigger/L1TGEM/interface/GE0TriggerPseudoBuilder.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+
+#include <iostream>
+#include <cassert>
+
+const unsigned int GE0TriggerPseudoBuilder::ME0KeyLayer = 3;
+const int GE0TriggerPseudoBuilder::ME0TriggerCentralBX = 8;
+
+GE0TriggerPseudoBuilder::GE0TriggerPseudoBuilder(const edm::ParameterSet& conf) {
+  config_ = conf;
+  info_ = config_.getUntrackedParameter<int>("info", 0);
+  dphiresolution_ = config_.getUntrackedParameter<double>("DeltaPhiResolution", 0.25);
+}
+
+GE0TriggerPseudoBuilder::~GE0TriggerPseudoBuilder() {}
+
+void GE0TriggerPseudoBuilder::build(const GEMSegmentCollection* me0Segments, ME0TriggerDigiCollection& oc_trig) {
+  if (info_ > 2)
+    dumpAllME0Segments(*me0Segments);
+
+  for (int endc = 0; endc < static_cast<int>(trig_me0s::MAX_ENDCAPS); endc++) {
+    for (int cham = 0; cham < static_cast<int>(trig_me0s::MAX_CHAMBERS); cham++) {
+      // 0th layer means whole chamber.
+      // chamber counts from 1 to 18 in ME0ID
+      const int region(endc == 0 ? -1 : 1);
+      //  constexpr GEMDetId(int region, int ring, int station, int layer, int chamber, int ieta)
+      GEMDetId detid(region, 0, 0, 0, cham + 1, 0);
+
+      const auto& drange = me0Segments->get(detid);
+      std::vector<ME0TriggerDigi> trigV;
+      for (auto digiIt = drange.first; digiIt != drange.second; digiIt++) {
+        if (info_ > 1)
+          LogTrace("L1ME0Trigger") << "GE0TriggerPseudoBuilder id " << detid << " ME0 segment " << *digiIt
+                                   << " to be converted into trigger digi\n";
+        ME0TriggerDigi trig = segmentConversion(*digiIt);
+        if (trig.isValid())
+          trigV.push_back(trig);
+        if (info_ > 1 and trig.isValid())
+          LogTrace("L1ME0Trigger") << " ME0trigger " << trig << "\n";
+        else if (info_ > 1)
+          LogTrace("L1ME0Trigger") << " ME0trigger is not valid. Conversion failed \n";
+      }
+
+      if (!trigV.empty()) {
+        LogTrace("L1ME0Trigger") << "GE0TriggerPseudoBuilder got results in " << detid << std::endl
+                                 << "Put " << trigV.size() << " Trigger digi" << ((trigV.size() > 1) ? "s " : " ")
+                                 << "in collection\n";
+        oc_trig.put(std::make_pair(trigV.begin(), trigV.end()), detid);
+      }
+    }
+  }
+}
+
+ME0TriggerDigi GE0TriggerPseudoBuilder::segmentConversion(const GEMSegment segment) {
+  auto detid = segment.gemDetId();
+  const GEMSuperChamber* chamber = me0_g->superChamber(detid);
+  const GEMChamber* keylayer = chamber->chamber(GE0TriggerPseudoBuilder::ME0KeyLayer);
+  int chamberid = detid.superChamberId() % 2;
+  int totRolls = keylayer->nEtaPartitions();
+  float dphi = chamber->computeDeltaPhi(segment.localPosition(), segment.localDirection());
+  // !!!!TODO!!!! float time = segment.time();
+  // !!!!TODO!!!! int sign_time = (time > 0) ? 1 : -1;
+  int nrechits = segment.nRecHits();
+  std::vector<int> rolls;
+  for (const auto& rechit : segment.specificRecHits()) {
+    if (std::find(rolls.begin(), rolls.end(), rechit.gemId().roll()) == rolls.end())
+      rolls.push_back(rechit.gemId().roll());
+  }
+  if (rolls.size() > 2 or rolls.empty())
+    LogTrace("L1ME0Trigger") << " ME0 segment is crossing " << rolls.size() << " roll !!! \n";
+  //assert(rolls.size() <= 2);   // we did found very few ME0 segments crossing 3 rolls!!! this cut is applied offline
+  if (rolls.empty())
+    return ME0TriggerDigi();
+  if (rolls[0] < 1)
+    LogTrace("L1ME0Trigger") << " ME0 segment has wrong roll number " << rolls[0] << " which should be >= 1 \n !!!";
+  assert(rolls[0] >= 1);
+  int partition = (rolls[0] - 1) << 1;  //roll from detid counts from 1
+  if (rolls.size() == 2 and rolls[0] > rolls[1])
+    partition = partition - 1;
+  else if (rolls.size() == 2 and rolls[0] < rolls[1])
+    partition = partition + 1;
+
+  if (partition < 0 or partition >= 2 * totRolls) {
+    LogTrace("L1ME0Trigger") << " ME0 segment rolls size of all hits " << rolls.size() << " rolls[0] " << rolls[0]
+                             << " rolls.back() " << rolls.back() << " and ME0 trigger roll is " << partition
+                             << " max expected " << 2 * totRolls - 1 << "\n";
+    return ME0TriggerDigi();
+  }
+
+  //globalpoint from ME0 segment
+  GlobalPoint gp = me0_g->idToDet(segment.gemDetId())->surface().toGlobal(segment.localPosition());
+  const GEMEtaPartition* etapart = keylayer->etaPartition(rolls[0]);
+  LocalPoint segment_lp = etapart->surface().toLocal(gp);  // convert segment gp into lp in etapartition coordinate
+  float strippitch = etapart->localPitch(segment_lp);
+  float strip = etapart->strip(segment_lp);
+  int totstrip = etapart->nstrips();
+  int istrip = static_cast<int>(strip);
+  int phiposition = istrip;
+  if (phiposition > totstrip)
+    LogTrace("L1ME0Trigger") << " ME0 segment strip number is " << phiposition << " larger than nstrip " << totstrip
+                             << " !!! \n";
+  float phi_resolution = 0.5;                                                         //halfstrip
+  int phiposition2 = (static_cast<int>((strip - phiposition) / phi_resolution) & 1);  // half-strip resolution
+  phiposition = (phiposition << 1) | phiposition2;
+
+  //gloablpoint from ME0 trigger digi
+  float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
+  GlobalPoint gp_digi = etapart->toGlobal(etapart->centreOfStrip(centreOfStrip));
+
+  float strippitch_rad = strippitch / gp.perp();  //unit in rad
+
+  int idphi = static_cast<int>(fabs(dphi) / (strippitch_rad * dphiresolution_));
+  const int max_idphi = 512;
+  if (idphi >= max_idphi) {
+    LogTrace("L1ME0Trigger") << " ME0 segment dphi " << dphi << " and int type: " << idphi
+                             << " larger than max allowed: " << max_idphi << " !!! \n";
+    idphi = max_idphi - 1;
+  }
+  int quality = nrechits;  // attention: not the same as discussed in meeting
+  // !!!!TODO!!!! int BX = (static_cast<int>(fabs(time) / 25.0)) * sign_time + GE0TriggerPseudoBuilder::ME0TriggerCentralBX;
+  int BX = GE0TriggerPseudoBuilder::ME0TriggerCentralBX;
+  int bend = (dphi > 0.0) ? 0 : 1;
+  if (info_ > 2)
+    LogTrace("L1ME0Trigger") << " ME0trigger in conversion function:\n"
+                             << "\t chamber(1-18) " << detid.chamber() << " chamber id " << chamberid << " \n"
+                             << "\t rolls size of all hits " << rolls.size() << " rolls[0] " << rolls[0]
+                             << " rolls.back() " << rolls.back() << " roll " << partition << " \n"
+                             << "\t nRechits " << nrechits << " quality " << quality << " \n"
+                             << "\t strip(float) " << strip << " (int) " << istrip << " phiposition " << phiposition
+                             << " resolution (in term of strip) " << phi_resolution << " \n"
+                             << "\t deltaphi(float) " << dphi << " (int) " << idphi << " resolution "
+                             << strippitch_rad * dphiresolution_ << " bend " << bend << " \n"
+                             << "\t global point eta " << gp.eta() << " phi " << gp.phi() << " trigger digi eta "
+                             << gp_digi.eta() << " phi " << gp_digi.phi() << " \n"
+                             // << "\t time (ns, float) " << time << " BX " << BX << " \n"
+      ;
+
+  ME0TriggerDigi result = ME0TriggerDigi(chamberid, quality, phiposition, partition, idphi, bend, BX);
+  result.setStrip(istrip);
+  return result;
+
+  return ME0TriggerDigi();
+}
+
+void GE0TriggerPseudoBuilder::dumpAllME0Segments(const GEMSegmentCollection& segments) const {
+  LogTrace("L1ME0Trigger") << "dumpt all ME0 Segments" << std::endl;
+  // for (auto iC = segments.id_begin(); iC != segments.id_end(); ++iC) {
+  //   auto ch_segs = segments.get(*iC);
+  //   for (auto iS = ch_segs.first; iS != ch_segs.second; ++iS) {
+  //     GlobalPoint gp = me0_g->idToDet(iS->me0DetId())->surface().toGlobal(iS->localPosition());
+  //     LogTrace("L1ME0Trigger") << "ME0Detid " << iS->me0DetId() << " segment " << *iS << " eta " << gp.eta() << " phi "
+  //                              << gp.phi() << std::endl;
+  //     auto recHits(iS->recHits());
+  //     LogTrace("L1ME0Trigger") << "\t has " << recHits.size() << " me0 rechits" << std::endl;
+  //     for (auto& rh : recHits) {
+  //       const ME0RecHit* me0rh(dynamic_cast<const ME0RecHit*>(rh));
+  //       LogTrace("L1ME0Trigger") << "\t  detid " << me0rh->me0Id() << " rechit " << *me0rh << std::endl;
+  //     }
+  //   }
+  // }
+}

--- a/L1Trigger/L1TGEM/src/GE0TriggerPseudoBuilder.cc
+++ b/L1Trigger/L1TGEM/src/GE0TriggerPseudoBuilder.cc
@@ -17,7 +17,7 @@ GE0TriggerPseudoBuilder::GE0TriggerPseudoBuilder(const edm::ParameterSet& conf) 
 
 GE0TriggerPseudoBuilder::~GE0TriggerPseudoBuilder() {}
 
-void GE0TriggerPseudoBuilder::build(const GEMSegmentCollection* me0Segments, ME0TriggerDigiCollection& oc_trig) {
+void GE0TriggerPseudoBuilder::build(const GEMSegmentCollection* me0Segments, GE0TriggerDigiCollection& oc_trig) {
   if (info_ > 2)
     dumpAllME0Segments(*me0Segments);
 
@@ -27,7 +27,7 @@ void GE0TriggerPseudoBuilder::build(const GEMSegmentCollection* me0Segments, ME0
       // chamber counts from 1 to 18 in ME0ID
       const int region(endc == 0 ? -1 : 1);
       //  constexpr GEMDetId(int region, int ring, int station, int layer, int chamber, int ieta)
-      GEMDetId detid(region, 0, 0, 0, cham + 1, 0);
+      GEMDetId detid(region, 1, 0, 0, cham + 1, 0);
 
       const auto& drange = me0Segments->get(detid);
       std::vector<ME0TriggerDigi> trigV;

--- a/L1Trigger/L1TGEM/src/GE0TriggerPseudoBuilder.cc
+++ b/L1Trigger/L1TGEM/src/GE0TriggerPseudoBuilder.cc
@@ -135,8 +135,8 @@ ME0TriggerDigi GE0TriggerPseudoBuilder::segmentConversion(const GEMSegment segme
                              << strippitch_rad * dphiresolution_ << " bend " << bend << " \n"
                              << "\t global point eta " << gp.eta() << " phi " << gp.phi() << " trigger digi eta "
                              << gp_digi.eta() << " phi " << gp_digi.phi() << " \n"
-                             // << "\t time (ns, float) " << time << " BX " << BX << " \n"
-      ;
+        // << "\t time (ns, float) " << time << " BX " << BX << " \n"
+        ;
 
   ME0TriggerDigi result = ME0TriggerDigi(chamberid, quality, phiposition, partition, idphi, bend, BX);
   result.setStrip(istrip);

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -222,6 +222,8 @@ namespace L1TMuon {
 
     // Constructor from ME0 data
     TriggerPrimitive(const ME0DetId& detid, const ME0TriggerDigi& digi);
+    // Constructor from GE0 data
+    TriggerPrimitive(const GEMDetId& detid, const ME0TriggerDigi& digi);
 
     // Copy constructor
     TriggerPrimitive(const TriggerPrimitive& tp);

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -123,10 +123,10 @@ from L1Trigger.L1TGEM.me0TriggerDigis_cff import *
 _phase2_SimL1TMuonTask = SimL1TMuonTask.copy()
 _phase2_SimL1TMuonTask.add(me0TriggerAllDigiTask)
 _phase2_SimL1TMuonTask.add(simCscTriggerPrimitiveDigisPhase2)
-_phase2_GE0_SimL1TMuonTask = SimL1TMuonTask.copyAndExclude([me0TriggerAllDigiTask])
+# _phase2_GE0_SimL1TMuonTask = SimL1TMuonTask.copyAndExclude([me0TriggerAllDigiTask])
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 (stage2L1Trigger & phase2_muon).toReplaceWith( SimL1TMuonTask, _phase2_SimL1TMuonTask )
 
-from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
-(stage2L1Trigger & phase2_GE0).toReplaceWith( SimL1TMuonTask, _phase2_GE0_SimL1TMuonTask )
+# from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+# (stage2L1Trigger & phase2_GE0).toReplaceWith( SimL1TMuonTask, _phase2_GE0_SimL1TMuonTask )

--- a/L1Trigger/L1TMuon/src/GeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/GeometryTranslator.cc
@@ -151,21 +151,39 @@ void GeometryTranslator::checkAndUpdateGeometry(const edm::EventSetup& es) {
 // _____________________________________________________________________________
 // ME0
 GlobalPoint GeometryTranslator::getME0SpecificPoint(const TriggerPrimitive& tp) const {
-  const ME0DetId id(tp.detId<ME0DetId>());
-  const ME0Chamber* chamber = _geome0->chamber(id);
-  const ME0Layer* keylayer = chamber->layer(3);  // ME0 key layer is layer 3
-  int partition = tp.getME0Data().partition;     // 'partition' is in half-roll unit
-  int iroll = (partition >> 1) + 1;
-  const ME0EtaPartition* roll = keylayer->etaPartition(iroll);
-  assert(roll != nullptr);  // failed to get ME0 roll
-  // See L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
-  int phiposition = tp.getME0Data().phiposition;  // 'phiposition' is in half-strip unit
-  int istrip = (phiposition >> 1);
-  int phiposition2 = (phiposition & 0x1);
-  float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
-  const LocalPoint& lp = roll->centreOfStrip(centreOfStrip);
-  const GlobalPoint& gp = roll->surface().toGlobal(lp);
-  return gp;
+  if (tp.detId<DetId>().subdetId() == MuonSubdetId::GEM) { // GE0
+    const GEMDetId id(tp.detId<GEMDetId>());
+    const GEMSuperChamber* chamber = _geogem->superChamber(id);
+    const GEMChamber* keylayer = chamber->chamber(3);  // GEM key layer is layer 3
+    int partition = tp.getME0Data().partition;     // 'partition' is in half-roll unit
+    int iroll = (partition >> 1) + 1;
+    const GEMEtaPartition* roll = keylayer->etaPartition(iroll);
+    assert(roll != nullptr);  // failed to get GEM roll
+    // See L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+    int phiposition = tp.getME0Data().phiposition;  // 'phiposition' is in half-strip unit
+    int istrip = (phiposition >> 1);
+    int phiposition2 = (phiposition & 0x1);
+    float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
+    const LocalPoint& lp = roll->centreOfStrip(centreOfStrip);
+    const GlobalPoint& gp = roll->surface().toGlobal(lp);
+    return gp;
+  } else { // ME0
+    const ME0DetId id(tp.detId<ME0DetId>());
+    const ME0Chamber* chamber = _geome0->chamber(id);
+    const ME0Layer* keylayer = chamber->layer(3);  // ME0 key layer is layer 3
+    int partition = tp.getME0Data().partition;     // 'partition' is in half-roll unit
+    int iroll = (partition >> 1) + 1;
+    const ME0EtaPartition* roll = keylayer->etaPartition(iroll);
+    assert(roll != nullptr);  // failed to get ME0 roll
+    // See L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+    int phiposition = tp.getME0Data().phiposition;  // 'phiposition' is in half-strip unit
+    int istrip = (phiposition >> 1);
+    int phiposition2 = (phiposition & 0x1);
+    float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
+    const LocalPoint& lp = roll->centreOfStrip(centreOfStrip);
+    const GlobalPoint& gp = roll->surface().toGlobal(lp);
+    return gp;
+  }
 }
 
 double GeometryTranslator::calcME0SpecificEta(const TriggerPrimitive& tp) const {

--- a/L1Trigger/L1TMuon/src/GeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/GeometryTranslator.cc
@@ -151,11 +151,11 @@ void GeometryTranslator::checkAndUpdateGeometry(const edm::EventSetup& es) {
 // _____________________________________________________________________________
 // ME0
 GlobalPoint GeometryTranslator::getME0SpecificPoint(const TriggerPrimitive& tp) const {
-  if (tp.detId<DetId>().subdetId() == MuonSubdetId::GEM) { // GE0
+  if (tp.detId<DetId>().subdetId() == MuonSubdetId::GEM) {  // GE0
     const GEMDetId id(tp.detId<GEMDetId>());
     const GEMSuperChamber* chamber = _geogem->superChamber(id);
     const GEMChamber* keylayer = chamber->chamber(3);  // GEM key layer is layer 3
-    int partition = tp.getME0Data().partition;     // 'partition' is in half-roll unit
+    int partition = tp.getME0Data().partition;         // 'partition' is in half-roll unit
     int iroll = (partition >> 1) + 1;
     const GEMEtaPartition* roll = keylayer->etaPartition(iroll);
     assert(roll != nullptr);  // failed to get GEM roll
@@ -167,7 +167,7 @@ GlobalPoint GeometryTranslator::getME0SpecificPoint(const TriggerPrimitive& tp) 
     const LocalPoint& lp = roll->centreOfStrip(centreOfStrip);
     const GlobalPoint& gp = roll->surface().toGlobal(lp);
     return gp;
-  } else { // ME0
+  } else {  // ME0
     const ME0DetId id(tp.detId<ME0DetId>());
     const ME0Chamber* chamber = _geome0->chamber(id);
     const ME0Layer* keylayer = chamber->layer(3);  // ME0 key layer is layer 3

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -495,7 +495,11 @@ void TriggerPrimitive::print(std::ostream& out) const {
       out << "Pad high      : " << _gem.pad_hi << std::endl;
       break;
     case kME0:
-      out << detId<ME0DetId>() << std::endl;
+      try {
+        out << detId<ME0DetId>() << std::endl;
+      } catch (...) {
+        out << detId<GEMDetId>() << std::endl;
+      }
       out << "Local BX      : " << _me0.bx << std::endl;
       out << "Chamber id    : " << _me0.chamberid << std::endl;
       out << "Quality       : " << _me0.quality << std::endl;

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -251,6 +251,23 @@ TriggerPrimitive::TriggerPrimitive(const ME0DetId& detid, const ME0TriggerDigi& 
   _me0.bx = digi.getBX();
 }
 
+// Constructor from ME0 data
+TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid, const ME0TriggerDigi& digi)
+    : _id(detid), _subsystem(L1TMuon::kME0) {
+  calculateGlobalSector(detid, _globalsector, _subsector);
+  _eta = 0.;
+  _phi = 0.;
+  _rho = 0.;
+  _theta = 0.;
+  _me0.chamberid = digi.getChamberid();
+  _me0.quality = digi.getQuality();
+  _me0.phiposition = digi.getPhiposition();
+  _me0.partition = digi.getPartition();
+  _me0.deltaphi = digi.getDeltaphi();
+  _me0.bend = digi.getBend();
+  _me0.bx = digi.getBX();
+}
+
 // _____________________________________________________________________________
 // Copy constructor
 TriggerPrimitive::TriggerPrimitive(const TriggerPrimitive& tp)


### PR DESCRIPTION
In response to @epalencia. This is the first of 3 PR that makeup the [PR1184](https://github.com/cms-l1t-offline/cmssw/pull/1184). This PR includes the code necessary for the L1T to support GE0. This PR is a dependancy of EMTF++ emulator that will be merged in the 3rd PR.
