### PR TITLE
Correlator: support for running barrel TM18

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -1,15 +1,6 @@
 #ifndef DataFormats_L1TParticleFlow_datatypes_h
 #define DataFormats_L1TParticleFlow_datatypes_h
 
-#if (!defined(__CLANG__)) && defined(__GNUC__) && defined(CMSSW_GIT_HASH)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#endif
-#include <ap_int.h>
-#if (!defined(__CLANG__)) && defined(__GNUC__) && defined(CMSSW_GIT_HASH)
-#pragma GCC diagnostic pop
-#endif
-
 #include <ap_int.h>
 #include <cassert>
 #include <cmath>
@@ -162,8 +153,14 @@ namespace l1ct {
     inline float floatPt(pt_t pt) { return pt.to_float(); }
     inline float floatPt(dpt_t pt) { return pt.to_float(); }
     inline float floatPt(pt2_t pt2) { return pt2.to_float(); }
-    inline int intPt(pt_t pt) { return (ap_ufixed<16, 14>(pt) << 2).to_int(); }
-    inline int intPt(dpt_t pt) { return (ap_fixed<18, 16>(pt) << 2).to_int(); }
+    inline int intPt(pt_t pt) {
+      ap_uint<pt_t::width> rawPt = pt.range();
+      return rawPt.to_int();
+    }
+    inline int intPt(dpt_t pt) {
+      ap_int<dpt_t::width> rawPt = pt.range();
+      return rawPt.to_int();
+    }
     inline float floatEta(eta_t eta) { return eta.to_float() * ETAPHI_LSB; }
     inline float floatPhi(phi_t phi) { return phi.to_float() * ETAPHI_LSB; }
     inline float floatEta(tkdeta_t eta) { return eta.to_float() * ETAPHI_LSB; }
@@ -181,9 +178,9 @@ namespace l1ct {
 
     inline pt_t makePt(int pt) { return ap_ufixed<16, 14>(pt) >> 2; }
     inline dpt_t makeDPt(int dpt) { return ap_fixed<18, 16>(dpt) >> 2; }
-    inline pt_t makePtFromFloat(float pt) { return pt_t(0.25 * round(pt * 4)); }
+    inline pt_t makePtFromFloat(float pt) { return pt_t(0.25 * std::round(pt * 4)); }
     inline dpt_t makeDPtFromFloat(float dpt) { return dpt_t(dpt); }
-    inline z0_t makeZ0(float z0) { return z0_t(round(z0 / Z0_LSB)); }
+    inline z0_t makeZ0(float z0) { return z0_t(std::round(z0 / Z0_LSB)); }
 
     inline ap_uint<pt_t::width> ptToInt(pt_t pt) {
       // note: this can be synthethized, e.g. when pT is used as intex in a LUT
@@ -216,7 +213,7 @@ namespace l1ct {
     inline float maxAbsPhi() { return ((1 << (phi_t::width - 1)) - 1) * ETAPHI_LSB; }
     inline float maxAbsGlbEta() { return ((1 << (glbeta_t::width - 1)) - 1) * ETAPHI_LSB; }
     inline float maxAbsGlbPhi() { return ((1 << (glbphi_t::width - 1)) - 1) * ETAPHI_LSB; }
-  };  // namespace Scales
+  }  // namespace Scales
 
   inline int dr2_int(eta_t eta1, phi_t phi1, eta_t eta2, phi_t phi2) {
     ap_int<eta_t::width + 1> deta = (eta1 - eta2);

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
@@ -1,0 +1,112 @@
+#ifndef middle_buffer_multififo_regionizer_ref_h
+#define middle_buffer_multififo_regionizer_ref_h
+
+#include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/dbgPrintf.h"
+#include <memory>
+#include <deque>
+
+namespace l1ct {
+  class MiddleBufferMultififoRegionizerEmulator : public RegionizerEmulator {
+  public:
+    MiddleBufferMultififoRegionizerEmulator(unsigned int nclocks,
+                                            unsigned int etabufferDepth,
+                                            unsigned int ntklinks,
+                                            unsigned int nHCalLinks,
+                                            unsigned int nECalLinks,
+                                            unsigned int ntk,
+                                            unsigned int ncalo,
+                                            unsigned int nem,
+                                            unsigned int nmu,
+                                            bool streaming,
+                                            unsigned int outii,
+                                            unsigned int pauseii,
+                                            bool useAlsoVtxCoords);
+    // note: this one will work only in CMSSW
+    MiddleBufferMultififoRegionizerEmulator(const edm::ParameterSet& iConfig);
+
+    ~MiddleBufferMultififoRegionizerEmulator() override;
+
+    static edm::ParameterSetDescription getParameterSetDescription();
+
+    void initSectorsAndRegions(const RegionizerDecodedInputs& in, const std::vector<PFInputRegion>& out) override;
+
+    void run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) override;
+
+    // link emulation from decoded inputs (for simulation)
+    void fillLinks(unsigned int iclock,
+                   const RegionizerDecodedInputs& in,
+                   std::vector<l1ct::TkObjEmu>& links,
+                   std::vector<bool>& valid);
+    void fillLinks(unsigned int iclock,
+                   const RegionizerDecodedInputs& in,
+                   std::vector<l1ct::HadCaloObjEmu>& links,
+                   std::vector<bool>& valid);
+    void fillLinks(unsigned int iclock,
+                   const RegionizerDecodedInputs& in,
+                   std::vector<l1ct::EmCaloObjEmu>& links,
+                   std::vector<bool>& valid);
+    void fillLinks(unsigned int iclock,
+                   const RegionizerDecodedInputs& in,
+                   std::vector<l1ct::MuObjEmu>& links,
+                   std::vector<bool>& valid);
+    template <typename T>
+    void fillLinks(unsigned int iclock, const RegionizerDecodedInputs& in, std::vector<T>& links) {
+      std::vector<bool> unused;
+      fillLinks(iclock, in, links, unused);
+    }
+    void destream(int iclock,
+                  const std::vector<l1ct::TkObjEmu>& tk_out,
+                  const std::vector<l1ct::EmCaloObjEmu>& em_out,
+                  const std::vector<l1ct::HadCaloObjEmu>& calo_out,
+                  const std::vector<l1ct::MuObjEmu>& mu_out,
+                  PFInputRegion& out);
+
+    // clock-cycle emulation
+    bool step(bool newEvent,
+              const std::vector<l1ct::TkObjEmu>& links_tk,
+              const std::vector<l1ct::HadCaloObjEmu>& links_hadCalo,
+              const std::vector<l1ct::EmCaloObjEmu>& links_emCalo,
+              const std::vector<l1ct::MuObjEmu>& links_mu,
+              std::vector<l1ct::TkObjEmu>& out_tk,
+              std::vector<l1ct::HadCaloObjEmu>& out_hadCalo,
+              std::vector<l1ct::EmCaloObjEmu>& out_emCalo,
+              std::vector<l1ct::MuObjEmu>& out_mu,
+              bool /*unused*/);
+
+    template <typename TEmu, typename TFw>
+    void toFirmware(const std::vector<TEmu>& emu, TFw fw[]) {
+      for (unsigned int i = 0, n = emu.size(); i < n; ++i) {
+        fw[i] = emu[i];
+      }
+    }
+
+    void reset();
+
+  protected:
+    const unsigned int NTK_SECTORS, NCALO_SECTORS;
+    const unsigned int NTK_LINKS, HCAL_LINKS, ECAL_LINKS, NMU_LINKS;
+    unsigned int nclocks_, etabuffer_depth_, ntk_, ncalo_, nem_, nmu_, outii_, pauseii_, nregions_pre_, nregions_post_;
+    bool streaming_;
+    bool init_;
+    unsigned int iclock_;
+
+    multififo_regionizer::Regionizer<l1ct::TkObjEmu> tkRegionizerPre_, tkRegionizerPost_;
+    multififo_regionizer::Regionizer<l1ct::HadCaloObjEmu> hadCaloRegionizerPre_, hadCaloRegionizerPost_;
+    multififo_regionizer::Regionizer<l1ct::EmCaloObjEmu> emCaloRegionizerPre_, emCaloRegionizerPost_;
+    multififo_regionizer::Regionizer<l1ct::MuObjEmu> muRegionizerPre_, muRegionizerPost_;
+    std::vector<l1ct::multififo_regionizer::Route> tkRoutes_, caloRoutes_, emCaloRoutes_, muRoutes_;
+    std::vector<l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::TkObjEmu>> tkBuffers_;
+    std::vector<l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::HadCaloObjEmu>> hadCaloBuffers_;
+    std::vector<l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::EmCaloObjEmu>> emCaloBuffers_;
+    std::vector<l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::MuObjEmu>> muBuffers_;
+
+    template <typename T>
+    void fillCaloLinks_(unsigned int iclock,
+                        const std::vector<DetectorSector<T>>& in,
+                        std::vector<T>& links,
+                        std::vector<bool>& valid);
+  };
+}  // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
@@ -10,6 +10,7 @@ namespace l1ct {
   class MiddleBufferMultififoRegionizerEmulator : public RegionizerEmulator {
   public:
     MiddleBufferMultififoRegionizerEmulator(unsigned int nclocks,
+                                            unsigned int nbuffers,
                                             unsigned int etabufferDepth,
                                             unsigned int ntklinks,
                                             unsigned int nHCalLinks,
@@ -86,11 +87,12 @@ namespace l1ct {
   protected:
     const unsigned int NTK_SECTORS, NCALO_SECTORS;
     const unsigned int NTK_LINKS, HCAL_LINKS, ECAL_LINKS, NMU_LINKS;
-    unsigned int nclocks_, etabuffer_depth_, ntk_, ncalo_, nem_, nmu_, outii_, pauseii_, nregions_pre_, nregions_post_;
+    unsigned int nclocks_, nbuffers_, etabuffer_depth_, ntk_, ncalo_, nem_, nmu_, outii_, pauseii_, nregions_pre_,
+        nregions_post_;
     bool streaming_;
     bool init_;
     unsigned int iclock_;
-
+    std::vector<l1ct::PFRegionEmu> mergedRegions_, outputRegions_;
     multififo_regionizer::Regionizer<l1ct::TkObjEmu> tkRegionizerPre_, tkRegionizerPost_;
     multififo_regionizer::Regionizer<l1ct::HadCaloObjEmu> hadCaloRegionizerPre_, hadCaloRegionizerPost_;
     multififo_regionizer::Regionizer<l1ct::EmCaloObjEmu> emCaloRegionizerPre_, emCaloRegionizerPost_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
@@ -56,6 +56,7 @@ namespace l1ct {
       std::vector<bool> unused;
       fillLinks(iclock, in, links, unused);
     }
+
     void destream(int iclock,
                   const std::vector<l1ct::TkObjEmu>& tk_out,
                   const std::vector<l1ct::EmCaloObjEmu>& em_out,
@@ -108,6 +109,16 @@ namespace l1ct {
                         const std::vector<DetectorSector<T>>& in,
                         std::vector<T>& links,
                         std::vector<bool>& valid);
+
+    void fillSharedCaloLinks(unsigned int iclock,
+                             const std::vector<DetectorSector<l1ct::EmCaloObjEmu>>& em_in,
+                             const std::vector<DetectorSector<l1ct::HadCaloObjEmu>>& had_in,
+                             std::vector<l1ct::HadCaloObjEmu>& links,
+                             std::vector<bool>& valid);
+
+    void encode(const l1ct::EmCaloObjEmu& from, l1ct::HadCaloObjEmu& to);
+    void encode(const l1ct::HadCaloObjEmu& from, l1ct::HadCaloObjEmu& to);
+    void decode(l1ct::HadCaloObjEmu& had, l1ct::EmCaloObjEmu& em);
   };
 }  // namespace l1ct
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.h
@@ -5,6 +5,7 @@
 
 #include <list>
 #include <vector>
+#include <deque>
 #include <cassert>
 
 namespace l1ct {
@@ -74,6 +75,64 @@ namespace l1ct {
       void queue_to_stage_(std::vector<T>& queue, std::vector<T>& staging_area);
       void stage_to_queue_(std::vector<T>& staging_area, std::vector<T>& queue);
       T pop_queue_(std::vector<T>& queue);
+    };
+
+    template <typename T>
+    inline bool local_eta_phi_window(const T& t,
+                                     const l1ct::glbeta_t& etaMin,
+                                     const l1ct::glbeta_t& etaMax,
+                                     const l1ct::glbphi_t& phiMin,
+                                     const l1ct::glbphi_t& phiMax);
+    template <>
+    inline bool local_eta_phi_window<l1ct::TkObjEmu>(const l1ct::TkObjEmu& t,
+                                                     const l1ct::glbeta_t& etaMin,
+                                                     const l1ct::glbeta_t& etaMax,
+                                                     const l1ct::glbphi_t& phiMin,
+                                                     const l1ct::glbphi_t& phiMax);
+
+    template <typename T>
+    class EtaPhiBuffer {
+    public:
+      EtaPhiBuffer() {}
+      EtaPhiBuffer(unsigned int maxitems,
+                   const l1ct::glbeta_t& etaMin = 0,
+                   const l1ct::glbeta_t& etaMax = 0,
+                   const l1ct::glbeta_t& etaShift = 0,
+                   const l1ct::glbphi_t& phiMin = 0,
+                   const l1ct::glbphi_t& phiMax = 0,
+                   const l1ct::glbphi_t& phiShift = 0)
+          : size_(maxitems),
+            iwrite_(0),
+            iread_(0),
+            etaMin_(etaMin),
+            etaMax_(etaMax),
+            etaShift_(etaShift),
+            phiMin_(phiMin),
+            phiMax_(phiMax),
+            phiShift_(phiShift) {}
+      void maybe_push(const T& t);
+      void writeNewEvent() {
+        iwrite_ = 1 - iwrite_;
+        items_[iwrite_].clear();
+        //std::cout << "Starting to write on " << iwrite_ << " (size " << items_[iwrite_].size() << ", other size " << items_[1-iwrite_].size() << ", reading " << iread_ << ")" << std::endl;
+      }
+      void readNewEvent() {
+        iread_ = 1 - iread_;
+        //std::cout << "Starting to read on " << iread_ << " (size " << items_[iread_].size() << ", other size " << items_[1-iread_].size() << ", writing " << iwrite_ << ")" << std::endl;
+      }
+      T pop();
+      unsigned int writeSize() const { return items_[iwrite_].size(); }
+      unsigned int readSize() const { return items_[iread_].size(); }
+      unsigned int maxSize() const { return size_; }
+      void reset();
+
+    private:
+      unsigned int size_, iwrite_, iread_;
+      l1ct::glbeta_t etaMin_, etaMax_;
+      l1ct::glbeta_t etaShift_;
+      l1ct::glbphi_t phiMin_, phiMax_;
+      l1ct::glbphi_t phiShift_;
+      std::deque<T> items_[2];
     };
 
     // forward decl for later
@@ -182,5 +241,58 @@ namespace l1ct {
 
   }  // namespace  multififo_regionizer
 }  // namespace l1ct
+
+template <typename T>
+inline bool l1ct::multififo_regionizer::local_eta_phi_window(const T& t,
+                                                             const l1ct::glbeta_t& etaMin,
+                                                             const l1ct::glbeta_t& etaMax,
+                                                             const l1ct::glbphi_t& phiMin,
+                                                             const l1ct::glbphi_t& phiMax) {
+  return (etaMin == etaMax) ||
+         (etaMin <= t.hwEta && t.hwEta <= etaMax && ((phiMin == phiMax) || (phiMin <= t.hwPhi && t.hwPhi <= phiMax)));
+}
+template <>
+inline bool l1ct::multififo_regionizer::local_eta_phi_window<l1ct::TkObjEmu>(const l1ct::TkObjEmu& t,
+                                                                             const l1ct::glbeta_t& etaMin,
+                                                                             const l1ct::glbeta_t& etaMax,
+                                                                             const l1ct::glbphi_t& phiMin,
+                                                                             const l1ct::glbphi_t& phiMax) {
+  return (etaMin == etaMax) ||
+         (etaMin <= t.hwEta && t.hwEta <= etaMax && ((phiMin == phiMax) || (phiMin <= t.hwPhi && t.hwPhi <= phiMax))) ||
+         (etaMin <= t.hwVtxEta() && t.hwVtxEta() <= etaMax &&
+          ((phiMin == phiMax) || (phiMin <= t.hwVtxPhi() && t.hwVtxPhi() <= phiMax)));
+}
+template <typename T>
+void l1ct::multififo_regionizer::EtaPhiBuffer<T>::maybe_push(const T& t) {
+  if ((t.hwPt != 0) && local_eta_phi_window(t, etaMin_, etaMax_, phiMin_, phiMax_)) {
+    if (items_[iwrite_].size() < size_) {
+      items_[iwrite_].push_back(t);
+      items_[iwrite_].back().hwEta += etaShift_;
+      items_[iwrite_].back().hwPhi += phiShift_;
+    } else {
+      // uncommenting the message below may be useful for debugging
+      //dbgCout() << "WARNING: sector buffer is full for " << typeid(T).name() << ", pt = " << t.intPt()
+      //          << ", eta = " << t.intEta() << ", phi = " << t.intPhi() << "\n";
+    }
+  }
+}
+
+template <typename T>
+T l1ct::multififo_regionizer::EtaPhiBuffer<T>::pop() {
+  T ret;
+  ret.clear();
+  if (!items_[iread_].empty()) {
+    ret = items_[iread_].front();
+    items_[iread_].pop_front();
+  }
+  return ret;
+}
+template <typename T>
+void l1ct::multififo_regionizer::EtaPhiBuffer<T>::reset() {
+  iread_ = 0;
+  iwrite_ = 0;
+  items_[0].clear();
+  items_[1].clear();
+}
 
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.h
@@ -114,12 +114,8 @@ namespace l1ct {
       void writeNewEvent() {
         iwrite_ = 1 - iwrite_;
         items_[iwrite_].clear();
-        //std::cout << "Starting to write on " << iwrite_ << " (size " << items_[iwrite_].size() << ", other size " << items_[1-iwrite_].size() << ", reading " << iread_ << ")" << std::endl;
       }
-      void readNewEvent() {
-        iread_ = 1 - iread_;
-        //std::cout << "Starting to read on " << iread_ << " (size " << items_[iread_].size() << ", other size " << items_[1-iread_].size() << ", writing " << iwrite_ << ")" << std::endl;
-      }
+      void readNewEvent() { iread_ = 1 - iread_; }
       T pop();
       unsigned int writeSize() const { return items_[iwrite_].size(); }
       unsigned int readSize() const { return items_[iread_].size(); }

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.icc
@@ -41,6 +41,11 @@ void l1ct::multififo_regionizer::maybe_push<l1ct::TkObjEmu>(const l1ct::TkObjEmu
 template <typename T>
 void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos) {
   assert(nfifos_ == 0);
+  bool isGood =
+      (nfifos == 1 || nfifos == 2 || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12);
+  if (!isGood) {
+    dbgCerr() << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
+  }
   nfifos_ = nfifos;
   fifos_.resize(nfifos);
   unsigned int nmerged = nfifos;
@@ -52,11 +57,6 @@ void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos)
       t.clear();
     for (auto& t : queues_.back().second)
       t.clear();
-  }
-  bool isGood =
-      (nfifos == 1 || nfifos == 2 || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12);
-  if (!isGood) {
-    dbgCerr() << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
   }
   assert(isGood);
 }

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_ref.h
@@ -34,6 +34,7 @@ namespace l1ct {
 
     enum class BarrelSetup { Full54, Full27, Central18, Central9, Phi18, Phi9 };
     MultififoRegionizerEmulator(BarrelSetup barrelSetup,
+                                unsigned int ntklinks,
                                 unsigned int nHCalLinks,
                                 unsigned int nECalLinks,
                                 unsigned int nclocks,

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -28,6 +28,7 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/regionizer_base_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/buffered_folded_multififo_regionizer_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/pf/pfalgo2hgc_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/pf/pfalgo3_ref.h"
@@ -265,6 +266,9 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
     const auto &pset = iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters");
     regionizer_ =
         std::make_unique<l1ct::MultififoRegionizerEmulator>(pset.getParameter<std::string>("barrelSetup"), pset);
+  } else if (regalgo == "MiddleBufferMultififo") {
+    regionizer_ = std::make_unique<l1ct::MiddleBufferMultififoRegionizerEmulator>(
+        iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
   } else if (regalgo == "TDR") {
     regionizer_ = std::make_unique<l1ct::TDRRegionizerEmulator>(
         iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
@@ -367,9 +371,11 @@ void L1TCorrelatorLayer1Producer::fillDescriptions(edm::ConfigurationDescription
   auto bfMultififoRegPD = getParDesc<l1ct::BufferedFoldedMultififoRegionizerEmulator>("regionizerAlgo");
   auto multififoBarrelRegPD = edm::ParameterDescription<edm::ParameterSetDescription>(
       "regionizerAlgoParameters", l1ct::MultififoRegionizerEmulator::getParameterSetDescriptionBarrel(), true);
+  auto mbMultififoRegPD = getParDesc<l1ct::MiddleBufferMultififoRegionizerEmulator>("regionizerAlgo");
   desc.ifValue(edm::ParameterDescription<std::string>("regionizerAlgo", "Ideal", true),
                "Ideal" >> idealRegPD or "TDR" >> tdrRegPD or "Multififo" >> multififoRegPD or
-                   "BufferedFoldedMultififo" >> bfMultififoRegPD or "MultififoBarrel" >> multififoBarrelRegPD);
+                   "BufferedFoldedMultififo" >> bfMultififoRegPD or "MultififoBarrel" >> multififoBarrelRegPD or
+                   "MiddleBufferMultififo" >> mbMultififoRegPD);
   // PF
   desc.ifValue(edm::ParameterDescription<std::string>("pfAlgo", "PFAlgo3", true),
                "PFAlgo3" >> getParDesc<l1ct::PFAlgo3Emulator>("pfAlgo") or

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/buffered_folded_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/buffered_folded_multififo_regionizer_ref.cpp
@@ -88,16 +88,17 @@ void l1ct::BufferedFoldedMultififoRegionizerEmulator::initSectorsAndRegions(cons
     l1ct::glbeta_t etaMin, etaMax;
     findEtaBounds_(fold_[ie].sectors.track[0].region, fold_[ie].regions, etaMin, etaMax);
     for (unsigned int isec = 0; ntk_ > 0 && isec < NTK_SECTORS; ++isec) {
-      tkBuffers_[2 * isec + ie] = l1ct::multififo_regionizer::EtaBuffer<l1ct::TkObjEmu>(nclocks_ / 2, etaMin, etaMax);
+      tkBuffers_[2 * isec + ie] =
+          l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::TkObjEmu>(nclocks_ / 2, etaMin, etaMax);
     }
     findEtaBounds_(fold_[ie].sectors.hadcalo[0].region, fold_[ie].regions, etaMin, etaMax);
     for (unsigned int isec = 0; ncalo_ > 0 && isec < NCALO_SECTORS; ++isec) {
       caloBuffers_[2 * isec + ie] =
-          l1ct::multififo_regionizer::EtaBuffer<l1ct::HadCaloObjEmu>(nclocks_ / 2, etaMin, etaMax);
+          l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::HadCaloObjEmu>(nclocks_ / 2, etaMin, etaMax);
     }
     findEtaBounds_(fold_[ie].sectors.muon.region, fold_[ie].regions, etaMin, etaMax);
     if (nmu_ > 0) {
-      muBuffers_[ie] = l1ct::multififo_regionizer::EtaBuffer<l1ct::MuObjEmu>(nclocks_ / 2, etaMin, etaMax);
+      muBuffers_[ie] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::MuObjEmu>(nclocks_ / 2, etaMin, etaMax);
     }
   }
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
@@ -32,11 +32,11 @@ l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEm
 edm::ParameterSetDescription l1ct::MiddleBufferMultififoRegionizerEmulator::getParameterSetDescription() {
   edm::ParameterSetDescription description;
   description.add<uint32_t>("nClocks", 162);
-  description.add<uint32_t>("nBuffers", 54);
+  description.add<uint32_t>("nBuffers", 27);
   description.add<uint32_t>("etaBufferDepth", 54);
   description.add<uint32_t>("nTkLinks", 1);
   description.add<uint32_t>("nHCalLinks", 1);
-  description.add<uint32_t>("nECalLinks", 1);
+  description.add<uint32_t>("nECalLinks", 0);
   description.add<uint32_t>("nTrack", 22);
   description.add<uint32_t>("nCalo", 15);
   description.add<uint32_t>("nEmCalo", 12);

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
@@ -226,7 +226,8 @@ void l1ct::MiddleBufferMultififoRegionizerEmulator::initSectorsAndRegions(const 
     assert(in.emcalo.size() == NCALO_SECTORS);
     emCaloRegionizerPre_.initSectors(in.emcalo);
     emCaloRegionizerPre_.initRegions(mergedRegions);
-    emCaloRegionizerPre_.initRouting(emCaloRoutes_);
+    if (ECAL_LINKS)
+      emCaloRegionizerPre_.initRouting(emCaloRoutes_);
     emCaloRegionizerPost_.initRegions(out);
   }
   if (nmu_) {
@@ -261,8 +262,16 @@ bool l1ct::MiddleBufferMultififoRegionizerEmulator::step(bool newEvent,
     ret = muRegionizerPre_.step(newEvent, links_mu, pre_out_mu, false);
   if (ncalo_)
     ret = hadCaloRegionizerPre_.step(newEvent, links_hadCalo, pre_out_hadCalo, false);
-  if (nem_)
-    ret = emCaloRegionizerPre_.step(newEvent, links_emCalo, pre_out_emCalo, false);
+  if (nem_) {
+    if (ECAL_LINKS) {
+      ret = emCaloRegionizerPre_.step(newEvent, links_emCalo, pre_out_emCalo, false);
+    } else if (ncalo_) {
+      pre_out_emCalo.resize(pre_out_hadCalo.size());
+      for (unsigned int i = 0, n = pre_out_hadCalo.size(); i < n; ++i) {
+        decode(pre_out_hadCalo[i], pre_out_emCalo[i]);
+      }
+    }
+  }
 
   // in the no-streaming case, we just output the pre-regionizer
   if (!streaming_) {
@@ -428,6 +437,34 @@ void l1ct::MiddleBufferMultififoRegionizerEmulator::fillCaloLinks_(unsigned int 
     }
   }
 }
+void l1ct::MiddleBufferMultififoRegionizerEmulator::fillSharedCaloLinks(
+    unsigned int iclock,
+    const std::vector<l1ct::DetectorSector<l1ct::EmCaloObjEmu>>& em_in,
+    const std::vector<l1ct::DetectorSector<l1ct::HadCaloObjEmu>>& had_in,
+    std::vector<l1ct::HadCaloObjEmu>& links,
+    std::vector<bool>& valid) {
+  assert(ECAL_LINKS == 0 && HCAL_LINKS == 1 && ncalo_ != 0 && nem_ != 0);
+  links.resize(NCALO_SECTORS);
+  valid.resize(links.size());
+  // for the moment we assume the first 54 clocks are for EM, the rest for HAD
+  const unsigned int NCLK_EM = 54;
+  for (unsigned int is = 0; is < NCALO_SECTORS; ++is) {
+    links[is].clear();
+    if (iclock < NCLK_EM) {
+      valid[is] = true;
+      if (iclock < em_in[is].size()) {
+        encode(em_in[is][iclock], links[is]);
+      }
+    } else {
+      if (iclock - NCLK_EM < had_in[is].size()) {
+        encode(had_in[is][iclock - NCLK_EM], links[is]);
+        valid[is] = true;
+      } else {
+        valid[is] = false;
+      }
+    }
+  }  // sectors
+}
 
 void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int iclock,
                                                               const l1ct::RegionizerDecodedInputs& in,
@@ -435,7 +472,10 @@ void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int icloc
                                                               std::vector<bool>& valid) {
   if (ncalo_ == 0)
     return;
-  fillCaloLinks_(iclock, in.hadcalo, links, valid);
+  if (nem_ != 0 && ECAL_LINKS == 0 && HCAL_LINKS == 1)
+    fillSharedCaloLinks(iclock, in.emcalo, in.hadcalo, links, valid);
+  else
+    fillCaloLinks_(iclock, in.hadcalo, links, valid);
 }
 
 void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int iclock,
@@ -557,4 +597,36 @@ void l1ct::MiddleBufferMultififoRegionizerEmulator::run(const RegionizerDecodedI
   }
 
   reset();
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::encode(const l1ct::EmCaloObjEmu& from, l1ct::HadCaloObjEmu& to) {
+  assert(!from.hwEmID[5]);
+  to.hwPt = from.hwPt;
+  to.hwEmPt = from.hwPtErr;
+  to.hwEta = from.hwEta;
+  to.hwPhi = from.hwPhi;
+  to.hwEmID[5] = true;
+  to.hwEmID(4, 0) = from.hwEmID(4, 0);
+  to.src = from.src;
+}
+void l1ct::MiddleBufferMultififoRegionizerEmulator::encode(const l1ct::HadCaloObjEmu& from, l1ct::HadCaloObjEmu& to) {
+  assert(!from.hwEmID[5]);
+  to = from;
+}
+void l1ct::MiddleBufferMultififoRegionizerEmulator::decode(l1ct::HadCaloObjEmu& had, l1ct::EmCaloObjEmu& em) {
+  if (had.hwPt && had.hwEmID[5]) {
+    em.hwPt = had.hwPt;
+    em.hwPtErr = had.hwEmPt;
+    em.hwEta = had.hwEta;
+    em.hwPhi = had.hwPhi;
+    em.hwEmID[5] = 0;
+    em.hwEmID(4, 0) = had.hwEmID(4, 0);
+    em.hwSrrTot = 0;
+    em.hwMeanZ = 0;
+    em.hwHoe = 0;
+    em.src = had.src;
+    had.clear();
+  } else {
+    em.clear();
+  }
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
@@ -1,0 +1,498 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/dbgPrintf.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_elements_ref.icc"
+
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/allowedValues.h"
+
+l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEmulator(const edm::ParameterSet& iConfig)
+    : MiddleBufferMultififoRegionizerEmulator(iConfig.getParameter<uint32_t>("nClocks"),
+                                              iConfig.getParameter<uint32_t>("etaBufferDepth"),
+                                              iConfig.getParameter<uint32_t>("nTkLinks"),
+                                              iConfig.getParameter<uint32_t>("nHCalLinks"),
+                                              iConfig.getParameter<uint32_t>("nECalLinks"),
+                                              iConfig.getParameter<uint32_t>("nTrack"),
+                                              iConfig.getParameter<uint32_t>("nCalo"),
+                                              iConfig.getParameter<uint32_t>("nEmCalo"),
+                                              iConfig.getParameter<uint32_t>("nMu"),
+                                              /*streaming=*/true,
+                                              /*outii=*/2,
+                                              /*pauseii=*/1,
+                                              iConfig.getParameter<bool>("useAlsoVtxCoords")) {
+  debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+}
+
+edm::ParameterSetDescription l1ct::MiddleBufferMultififoRegionizerEmulator::getParameterSetDescription() {
+  edm::ParameterSetDescription description;
+  description.add<uint32_t>("nClocks", 162);
+  description.add<uint32_t>("etaBufferDepth", 54);
+  description.add<uint32_t>("nTkLinks", 1);
+  description.add<uint32_t>("nHCalLinks", 1);
+  description.add<uint32_t>("nECalLinks", 1);
+  description.add<uint32_t>("nTrack", 22);
+  description.add<uint32_t>("nCalo", 15);
+  description.add<uint32_t>("nEmCalo", 12);
+  description.add<uint32_t>("nMu", 2);
+  description.add<bool>("useAlsoVtxCoords", true);
+  description.addUntracked<bool>("debug", false);
+  return description;
+}
+
+#endif
+
+l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEmulator(unsigned int nclocks,
+                                                                                       unsigned int etabufferDepth,
+                                                                                       unsigned int ntklinks,
+                                                                                       unsigned int nHCalLinks,
+                                                                                       unsigned int nECalLinks,
+                                                                                       unsigned int ntk,
+                                                                                       unsigned int ncalo,
+                                                                                       unsigned int nem,
+                                                                                       unsigned int nmu,
+                                                                                       bool streaming,
+                                                                                       unsigned int outii,
+                                                                                       unsigned int pauseii,
+                                                                                       bool useAlsoVtxCoords)
+    : RegionizerEmulator(useAlsoVtxCoords),
+      NTK_SECTORS(9),
+      NCALO_SECTORS(3),
+      NTK_LINKS(ntklinks),
+      HCAL_LINKS(nHCalLinks),
+      ECAL_LINKS(nECalLinks),
+      NMU_LINKS(1),
+      nclocks_(nclocks),
+      etabuffer_depth_(etabufferDepth),
+      ntk_(ntk),
+      ncalo_(ncalo),
+      nem_(nem),
+      nmu_(nmu),
+      outii_(outii),
+      pauseii_(pauseii),
+      nregions_pre_(27),
+      nregions_post_(54),
+      streaming_(streaming),
+      init_(false),
+      iclock_(0),
+      tkRegionizerPre_(ntk, ntk, false, outii, pauseii, useAlsoVtxCoords),
+      tkRegionizerPost_(ntk, (ntk + outii - 1) / outii, true, outii, pauseii, useAlsoVtxCoords),
+      hadCaloRegionizerPre_(ncalo, ncalo, false, outii, pauseii),
+      hadCaloRegionizerPost_(ncalo, (ncalo + outii - 1) / outii, true, outii, pauseii),
+      emCaloRegionizerPre_(nem, nem, false, outii, pauseii),
+      emCaloRegionizerPost_(nem, (nem + outii - 1) / outii, true, outii, pauseii),
+      muRegionizerPre_(nmu, nmu, false, outii, pauseii),
+      muRegionizerPost_(nmu, std::max(1u, (nmu + outii - 1) / outii), true, outii, pauseii),
+      tkBuffers_(ntk ? nregions_post_ : 0),
+      hadCaloBuffers_(ncalo ? nregions_post_ : 0),
+      emCaloBuffers_(nem ? nregions_post_ : 0),
+      muBuffers_(nmu ? nregions_post_ : 0) {
+  unsigned int phisectors = 9, etaslices = 3;
+  for (unsigned int ietaslice = 0; ietaslice < etaslices && ntk > 0; ++ietaslice) {
+    for (unsigned int ie = 0; ie < 2; ++ie) {  // 0 = negative, 1 = positive
+      unsigned int nTFEtaSlices = ietaslice == 1 ? 2 : 1;
+      if ((ietaslice == 0 && ie == 1) || (ietaslice == 2 && ie == 0))
+        continue;
+      unsigned int ireg0 = phisectors * ietaslice, il0 = 3 * NTK_LINKS * (nTFEtaSlices - 1) * ie;
+      for (unsigned int is = 0; is < NTK_SECTORS; ++is) {  // 9 tf sectors
+        for (unsigned int il = 0; il < NTK_LINKS; ++il) {  // max tracks per sector per clock
+          unsigned int isp = (is + 1) % NTK_SECTORS, ism = (is + NTK_SECTORS - 1) % NTK_SECTORS;
+          tkRoutes_.emplace_back(is + NTK_SECTORS * ie, il, is + ireg0, il0 + il);
+          tkRoutes_.emplace_back(is + NTK_SECTORS * ie, il, isp + ireg0, il0 + il + NTK_LINKS);
+          tkRoutes_.emplace_back(is + NTK_SECTORS * ie, il, ism + ireg0, il0 + il + 2 * NTK_LINKS);
+        }
+      }
+    }
+  }
+  // calo
+  for (unsigned int ie = 0; ie < etaslices; ++ie) {
+    for (unsigned int is = 0; is < NCALO_SECTORS; ++is) {  // NCALO_SECTORS sectors
+      for (unsigned int j = 0; j < 3; ++j) {               // 3 regions x sector
+        for (unsigned int il = 0; il < HCAL_LINKS; ++il) {
+          caloRoutes_.emplace_back(is, il, 3 * is + j + phisectors * ie, il);
+          if (j) {
+            caloRoutes_.emplace_back((is + 1) % 3, il, 3 * is + j + phisectors * ie, il + HCAL_LINKS);
+          }
+        }
+        for (unsigned int il = 0; il < ECAL_LINKS; ++il) {
+          emCaloRoutes_.emplace_back(is, il, 3 * is + j + phisectors * ie, il);
+          if (j) {
+            emCaloRoutes_.emplace_back((is + 1) % 3, il, 3 * is + j + phisectors * ie, il + ECAL_LINKS);
+          }
+        }
+      }
+    }
+  }
+  // mu
+  for (unsigned int il = 0; il < NMU_LINKS && nmu > 0; ++il) {
+    for (unsigned int j = 0; j < nregions_pre_; ++j) {
+      muRoutes_.emplace_back(0, il, j, il);
+    }
+  }
+}
+
+l1ct::MiddleBufferMultififoRegionizerEmulator::~MiddleBufferMultififoRegionizerEmulator() {}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedInputs& in,
+                                                                          const std::vector<PFInputRegion>& out) {
+  assert(!init_);
+  init_ = true;
+  assert(out.size() == nregions_post_);
+
+  std::vector<PFInputRegion> mergedRegions;
+  unsigned int neta = 3, nphi = 9;
+  for (unsigned int ieta = 0; ieta < neta; ++ieta) {
+    for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
+      const PFRegionEmu& reg0 = out[(2 * ieta + 0) * nphi + iphi].region;
+      const PFRegionEmu& reg1 = out[(2 * ieta + 1) * nphi + iphi].region;
+      assert(reg0.hwPhiCenter == reg1.hwPhiCenter);
+      mergedRegions.emplace_back(reg0.floatEtaMin(),
+                                 reg1.floatEtaMax(),
+                                 reg0.floatPhiCenter(),
+                                 reg0.floatPhiHalfWidth() * 2,
+                                 reg0.floatEtaExtra(),
+                                 reg0.floatPhiExtra());
+      if (debug_) {
+        dbgCout() << "Created region with etaCenter " << mergedRegions.back().region.hwEtaCenter.to_int()
+                  << ", halfWidth " << mergedRegions.back().region.hwEtaHalfWidth.to_int() << "\n";
+      }
+      for (int i = 0; i < 2; ++i) {
+        unsigned int iout = (2 * ieta + i) * nphi + iphi;
+        const l1ct::PFRegionEmu& from = mergedRegions.back().region;
+        const l1ct::PFRegionEmu& to = out[iout].region;
+        l1ct::glbeta_t etaMin = to.hwEtaCenter - to.hwEtaHalfWidth - to.hwEtaExtra - from.hwEtaCenter;
+        l1ct::glbeta_t etaMax = to.hwEtaCenter + to.hwEtaHalfWidth + to.hwEtaExtra - from.hwEtaCenter;
+        l1ct::glbeta_t etaShift = from.hwEtaCenter - to.hwEtaCenter;
+        l1ct::glbphi_t phiMin = -to.hwPhiHalfWidth - to.hwPhiExtra;
+        l1ct::glbphi_t phiMax = +to.hwPhiHalfWidth + to.hwPhiExtra;
+        l1ct::glbphi_t phiShift = 0;
+        if (ntk_ > 0)
+          tkBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::TkObjEmu>(
+              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+        if (ncalo_ > 0)
+          hadCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::HadCaloObjEmu>(
+              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+        if (nem_ > 0)
+          emCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::EmCaloObjEmu>(
+              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+        if (nmu_ > 0)
+          muBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::MuObjEmu>(
+              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+      }
+    }
+  }
+  if (ntk_) {
+    assert(in.track.size() == 2 * NTK_SECTORS);
+    tkRegionizerPre_.initSectors(in.track);
+    tkRegionizerPre_.initRegions(mergedRegions);
+    tkRegionizerPre_.initRouting(tkRoutes_);
+    tkRegionizerPost_.initRegions(out);
+  }
+  if (ncalo_) {
+    assert(in.hadcalo.size() == NCALO_SECTORS);
+    hadCaloRegionizerPre_.initSectors(in.hadcalo);
+    hadCaloRegionizerPre_.initRegions(mergedRegions);
+    hadCaloRegionizerPre_.initRouting(caloRoutes_);
+    hadCaloRegionizerPost_.initRegions(out);
+  }
+  if (nem_) {
+    assert(in.emcalo.size() == NCALO_SECTORS);
+    emCaloRegionizerPre_.initSectors(in.emcalo);
+    emCaloRegionizerPre_.initRegions(mergedRegions);
+    emCaloRegionizerPre_.initRouting(emCaloRoutes_);
+    emCaloRegionizerPost_.initRegions(out);
+  }
+  if (nmu_) {
+    muRegionizerPre_.initSectors(in.muon);
+    muRegionizerPre_.initRegions(mergedRegions);
+    muRegionizerPre_.initRouting(muRoutes_);
+    muRegionizerPost_.initRegions(out);
+  }
+}
+
+bool l1ct::MiddleBufferMultififoRegionizerEmulator::step(bool newEvent,
+                                                         const std::vector<l1ct::TkObjEmu>& links_tk,
+                                                         const std::vector<l1ct::HadCaloObjEmu>& links_hadCalo,
+                                                         const std::vector<l1ct::EmCaloObjEmu>& links_emCalo,
+                                                         const std::vector<l1ct::MuObjEmu>& links_mu,
+                                                         std::vector<l1ct::TkObjEmu>& out_tk,
+                                                         std::vector<l1ct::HadCaloObjEmu>& out_hadCalo,
+                                                         std::vector<l1ct::EmCaloObjEmu>& out_emCalo,
+                                                         std::vector<l1ct::MuObjEmu>& out_mu,
+                                                         bool /*unused*/) {
+  iclock_ = (newEvent ? 0 : iclock_ + 1);
+  bool newRead = iclock_ == 2 * etabuffer_depth_;
+
+  std::vector<l1ct::TkObjEmu> pre_out_tk;
+  std::vector<l1ct::HadCaloObjEmu> pre_out_hadCalo;
+  std::vector<l1ct::EmCaloObjEmu> pre_out_emCalo;
+  std::vector<l1ct::MuObjEmu> pre_out_mu;
+  bool ret = false;
+  if (ntk_)
+    ret = tkRegionizerPre_.step(newEvent, links_tk, pre_out_tk, false);
+  if (nmu_)
+    ret = muRegionizerPre_.step(newEvent, links_mu, pre_out_mu, false);
+  if (ncalo_)
+    ret = hadCaloRegionizerPre_.step(newEvent, links_hadCalo, pre_out_hadCalo, false);
+  if (nem_)
+    ret = emCaloRegionizerPre_.step(newEvent, links_emCalo, pre_out_emCalo, false);
+
+  // in the no-streaming case, we just output the pre-regionizer
+  if (!streaming_) {
+    out_tk.swap(pre_out_tk);
+    out_mu.swap(pre_out_mu);
+    out_hadCalo.swap(pre_out_hadCalo);
+    out_emCalo.swap(pre_out_emCalo);
+    return ret;
+  }
+
+  // otherwise, we push into the eta buffers
+  if (newEvent) {
+    for (auto& b : tkBuffers_)
+      b.writeNewEvent();
+    for (auto& b : hadCaloBuffers_)
+      b.writeNewEvent();
+    for (auto& b : emCaloBuffers_)
+      b.writeNewEvent();
+    for (auto& b : muBuffers_)
+      b.writeNewEvent();
+  }
+  unsigned int neta = 3, nphi = 9;
+  for (unsigned int ieta = 0; ieta < neta; ++ieta) {
+    for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
+      unsigned int iin = ieta * nphi + iphi;
+      //if (ieta == 0 && iphi == 0 && pre_out_tk[iin].hwPt != 0) std::cout << "iclock " << iclock_ << ",  pre_out_tk[" << iin << "] = " << pre_out_tk[iin].pack().to_string(16) << std::endl;
+      for (int i = 0; i < 2; ++i) {
+        unsigned int iout = (2 * ieta + i) * nphi + iphi;
+        if (ntk_)
+          tkBuffers_[iout].maybe_push(pre_out_tk[iin]);
+        if (ncalo_)
+          hadCaloBuffers_[iout].maybe_push(pre_out_hadCalo[iin]);
+        if (nem_)
+          emCaloBuffers_[iout].maybe_push(pre_out_emCalo[iin]);
+        if (nmu_)
+          muBuffers_[iout].maybe_push(pre_out_mu[iin]);
+      }
+    }
+  }
+
+  // and we read from eta buffers into muxes
+  if (newRead) {
+    for (auto& b : tkBuffers_)
+      b.readNewEvent();
+    for (auto& b : hadCaloBuffers_)
+      b.readNewEvent();
+    for (auto& b : emCaloBuffers_)
+      b.readNewEvent();
+    for (auto& b : muBuffers_)
+      b.readNewEvent();
+  }
+  std::vector<l1ct::TkObjEmu> bufferOut_tk(ntk_ ? nregions_post_ : 0);
+  std::vector<l1ct::HadCaloObjEmu> bufferOut_hadCalo(ncalo_ ? nregions_post_ : 0);
+  std::vector<l1ct::EmCaloObjEmu> bufferOut_emCalo(nem_ ? nregions_post_ : 0);
+  std::vector<l1ct::MuObjEmu> bufferOut_mu(nmu_ ? nregions_post_ : 0);
+  for (unsigned int i = 0; i < nregions_post_; ++i) {
+    if (ntk_)
+      bufferOut_tk[i] = tkBuffers_[i].pop();
+    if (ncalo_)
+      bufferOut_hadCalo[i] = hadCaloBuffers_[i].pop();
+    if (nem_)
+      bufferOut_emCalo[i] = emCaloBuffers_[i].pop();
+    if (nmu_)
+      bufferOut_mu[i] = muBuffers_[i].pop();
+  }
+  if (ntk_)
+    tkRegionizerPost_.muxonly_step(newEvent, /*flush=*/true, bufferOut_tk, out_tk);
+  if (ncalo_)
+    hadCaloRegionizerPost_.muxonly_step(newEvent, /*flush=*/true, bufferOut_hadCalo, out_hadCalo);
+  if (nem_)
+    emCaloRegionizerPost_.muxonly_step(newEvent, /*flush=*/true, bufferOut_emCalo, out_emCalo);
+  if (nmu_)
+    muRegionizerPost_.muxonly_step(newEvent, /*flush=*/true, bufferOut_mu, out_mu);
+
+  return newRead;
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                              const l1ct::RegionizerDecodedInputs& in,
+                                                              std::vector<l1ct::TkObjEmu>& links,
+                                                              std::vector<bool>& valid) {
+  if (ntk_ == 0)
+    return;
+  assert(NTK_LINKS == 1);
+  links.resize(NTK_SECTORS * NTK_LINKS * 2);
+  valid.resize(links.size());
+  // emulate reduced rate from 96b tracks on 64b links
+  unsigned int itkclock = 2 * (iclock / 3) + (iclock % 3) - 1;  // will underflow for iclock == 0 but it doesn't matter
+  for (unsigned int is = 0, idx = 0; is < 2 * NTK_SECTORS; ++is, ++idx) {  // tf sectors
+    const l1ct::DetectorSector<l1ct::TkObjEmu>& sec = in.track[is];
+    unsigned int ntracks = sec.size();
+    unsigned int nw64 = (ntracks * 3 + 1) / 2;
+    if (iclock % 3 == 0) {
+      links[idx].clear();
+      valid[idx] = (iclock == 0) || (iclock < nw64);
+    } else if (itkclock < ntracks && itkclock < nclocks_ - 1) {
+      links[idx] = sec[itkclock];
+      valid[idx] = true;
+    } else {
+      links[idx].clear();
+      valid[idx] = false;
+    }
+  }
+}
+
+template <typename T>
+void l1ct::MiddleBufferMultififoRegionizerEmulator::fillCaloLinks_(unsigned int iclock,
+                                                                   const std::vector<DetectorSector<T>>& in,
+                                                                   std::vector<T>& links,
+                                                                   std::vector<bool>& valid) {
+  unsigned int NLINKS = (typeid(T) == typeid(l1ct::HadCaloObjEmu) ? HCAL_LINKS : ECAL_LINKS);
+  links.resize(NCALO_SECTORS * NLINKS);
+  valid.resize(links.size());
+  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS; ++is) {
+    for (unsigned int il = 0; il < NLINKS; ++il, ++idx) {
+      unsigned int ioffs = iclock * NLINKS + il;
+      if (ioffs < in[is].size() && iclock < nclocks_ - 1) {
+        links[idx] = in[is][ioffs];
+        valid[idx] = true;
+      } else {
+        links[idx].clear();
+        valid[idx] = false;
+      }
+    }
+  }
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                              const l1ct::RegionizerDecodedInputs& in,
+                                                              std::vector<l1ct::HadCaloObjEmu>& links,
+                                                              std::vector<bool>& valid) {
+  if (ncalo_ == 0)
+    return;
+  fillCaloLinks_(iclock, in.hadcalo, links, valid);
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                              const l1ct::RegionizerDecodedInputs& in,
+                                                              std::vector<l1ct::EmCaloObjEmu>& links,
+                                                              std::vector<bool>& valid) {
+  if (nem_ == 0)
+    return;
+  fillCaloLinks_(iclock, in.emcalo, links, valid);
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                              const l1ct::RegionizerDecodedInputs& in,
+                                                              std::vector<l1ct::MuObjEmu>& links,
+                                                              std::vector<bool>& valid) {
+  if (nmu_ == 0)
+    return;
+  assert(NMU_LINKS == 1);
+  links.resize(NMU_LINKS);
+  valid.resize(links.size());
+  if (iclock < in.muon.size() && iclock < nclocks_ - 1) {
+    links[0] = in.muon[iclock];
+    valid[0] = true;
+  } else {
+    links[0].clear();
+    valid[0] = false;
+  }
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::destream(int iclock,
+                                                             const std::vector<l1ct::TkObjEmu>& tk_out,
+                                                             const std::vector<l1ct::EmCaloObjEmu>& em_out,
+                                                             const std::vector<l1ct::HadCaloObjEmu>& calo_out,
+                                                             const std::vector<l1ct::MuObjEmu>& mu_out,
+                                                             PFInputRegion& out) {
+  if (ntk_)
+    tkRegionizerPost_.destream(iclock, tk_out, out.track);
+  if (ncalo_)
+    hadCaloRegionizerPost_.destream(iclock, calo_out, out.hadcalo);
+  if (nem_)
+    emCaloRegionizerPost_.destream(iclock, em_out, out.emcalo);
+  if (nmu_)
+    muRegionizerPost_.destream(iclock, mu_out, out.muon);
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::reset() {
+  tkRegionizerPre_.reset();
+  emCaloRegionizerPre_.reset();
+  hadCaloRegionizerPre_.reset();
+  muRegionizerPre_.reset();
+  tkRegionizerPost_.reset();
+  emCaloRegionizerPost_.reset();
+  hadCaloRegionizerPost_.reset();
+  muRegionizerPost_.reset();
+  for (auto& b : tkBuffers_)
+    b.reset();
+  for (auto& b : hadCaloBuffers_)
+    b.reset();
+  for (auto& b : emCaloBuffers_)
+    b.reset();
+  for (auto& b : muBuffers_)
+    b.reset();
+}
+
+void l1ct::MiddleBufferMultififoRegionizerEmulator::run(const RegionizerDecodedInputs& in,
+                                                        std::vector<PFInputRegion>& out) {
+  assert(streaming_);  // doesn't make sense otherwise
+  if (!init_)
+    initSectorsAndRegions(in, out);
+  reset();
+  std::vector<l1ct::TkObjEmu> tk_links_in, tk_out;
+  std::vector<l1ct::EmCaloObjEmu> em_links_in, em_out;
+  std::vector<l1ct::HadCaloObjEmu> calo_links_in, calo_out;
+  std::vector<l1ct::MuObjEmu> mu_links_in, mu_out;
+
+  // read and sort the inputs
+  for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
+    fillLinks(iclock, in, tk_links_in);
+    fillLinks(iclock, in, em_links_in);
+    fillLinks(iclock, in, calo_links_in);
+    fillLinks(iclock, in, mu_links_in);
+
+    bool newevt = (iclock == 0);
+    step(newevt, tk_links_in, calo_links_in, em_links_in, mu_links_in, tk_out, calo_out, em_out, mu_out, true);
+  }
+
+  // set up an empty event
+  for (auto& l : tk_links_in)
+    l.clear();
+  for (auto& l : em_links_in)
+    l.clear();
+  for (auto& l : calo_links_in)
+    l.clear();
+  for (auto& l : mu_links_in)
+    l.clear();
+
+  // read and put the inputs in the regions
+  assert(out.size() == nregions_post_);
+  for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
+    bool newevt = (iclock == 0);
+    step(newevt, tk_links_in, calo_links_in, em_links_in, mu_links_in, tk_out, calo_out, em_out, mu_out, true);
+
+    unsigned int ireg = (iclock / (outii_ + pauseii_));
+    if ((iclock % (outii_ + pauseii_)) >= outii_)
+      continue;
+    if (ireg >= nregions_post_)
+      break;
+
+    if (streaming_) {
+      destream(iclock, tk_out, em_out, calo_out, mu_out, out[ireg]);
+    } else {
+      if (iclock % outii_ == 0) {
+        out[ireg].track = tk_out;
+        out[ireg].emcalo = em_out;
+        out[ireg].hadcalo = calo_out;
+        out[ireg].muon = mu_out;
+      }
+    }
+  }
+
+  reset();
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
@@ -13,6 +13,7 @@
 
 l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEmulator(const edm::ParameterSet& iConfig)
     : MiddleBufferMultififoRegionizerEmulator(iConfig.getParameter<uint32_t>("nClocks"),
+                                              iConfig.getParameter<uint32_t>("nBuffers"),
                                               iConfig.getParameter<uint32_t>("etaBufferDepth"),
                                               iConfig.getParameter<uint32_t>("nTkLinks"),
                                               iConfig.getParameter<uint32_t>("nHCalLinks"),
@@ -31,6 +32,7 @@ l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEm
 edm::ParameterSetDescription l1ct::MiddleBufferMultififoRegionizerEmulator::getParameterSetDescription() {
   edm::ParameterSetDescription description;
   description.add<uint32_t>("nClocks", 162);
+  description.add<uint32_t>("nBuffers", 54);
   description.add<uint32_t>("etaBufferDepth", 54);
   description.add<uint32_t>("nTkLinks", 1);
   description.add<uint32_t>("nHCalLinks", 1);
@@ -47,6 +49,7 @@ edm::ParameterSetDescription l1ct::MiddleBufferMultififoRegionizerEmulator::getP
 #endif
 
 l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEmulator(unsigned int nclocks,
+                                                                                       unsigned int nbuffers,
                                                                                        unsigned int etabufferDepth,
                                                                                        unsigned int ntklinks,
                                                                                        unsigned int nHCalLinks,
@@ -67,6 +70,7 @@ l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEm
       ECAL_LINKS(nECalLinks),
       NMU_LINKS(1),
       nclocks_(nclocks),
+      nbuffers_(nbuffers),
       etabuffer_depth_(etabufferDepth),
       ntk_(ntk),
       ncalo_(ncalo),
@@ -87,10 +91,11 @@ l1ct::MiddleBufferMultififoRegionizerEmulator::MiddleBufferMultififoRegionizerEm
       emCaloRegionizerPost_(nem, (nem + outii - 1) / outii, true, outii, pauseii),
       muRegionizerPre_(nmu, nmu, false, outii, pauseii),
       muRegionizerPost_(nmu, std::max(1u, (nmu + outii - 1) / outii), true, outii, pauseii),
-      tkBuffers_(ntk ? nregions_post_ : 0),
-      hadCaloBuffers_(ncalo ? nregions_post_ : 0),
-      emCaloBuffers_(nem ? nregions_post_ : 0),
-      muBuffers_(nmu ? nregions_post_ : 0) {
+      tkBuffers_(ntk ? nbuffers_ : 0),
+      hadCaloBuffers_(ncalo ? nbuffers_ : 0),
+      emCaloBuffers_(nem ? nbuffers_ : 0),
+      muBuffers_(nmu ? nbuffers_ : 0) {
+  assert(nbuffers_ == nregions_post_ || nbuffers_ == nregions_pre_);
   unsigned int phisectors = 9, etaslices = 3;
   for (unsigned int ietaslice = 0; ietaslice < etaslices && ntk > 0; ++ietaslice) {
     for (unsigned int ie = 0; ie < 2; ++ie) {  // 0 = negative, 1 = positive
@@ -145,6 +150,9 @@ void l1ct::MiddleBufferMultififoRegionizerEmulator::initSectorsAndRegions(const 
 
   std::vector<PFInputRegion> mergedRegions;
   unsigned int neta = 3, nphi = 9;
+  mergedRegions.reserve(nregions_pre_);
+  mergedRegions_.reserve(nregions_pre_);
+  outputRegions_.reserve(nregions_post_);
   for (unsigned int ieta = 0; ieta < neta; ++ieta) {
     for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
       const PFRegionEmu& reg0 = out[(2 * ieta + 0) * nphi + iphi].region;
@@ -156,32 +164,47 @@ void l1ct::MiddleBufferMultififoRegionizerEmulator::initSectorsAndRegions(const 
                                  reg0.floatPhiHalfWidth() * 2,
                                  reg0.floatEtaExtra(),
                                  reg0.floatPhiExtra());
+      mergedRegions_.push_back(mergedRegions.back().region);
+      outputRegions_.push_back(reg0);
+      outputRegions_.push_back(reg1);
       if (debug_) {
         dbgCout() << "Created region with etaCenter " << mergedRegions.back().region.hwEtaCenter.to_int()
                   << ", halfWidth " << mergedRegions.back().region.hwEtaHalfWidth.to_int() << "\n";
       }
-      for (int i = 0; i < 2; ++i) {
-        unsigned int iout = (2 * ieta + i) * nphi + iphi;
-        const l1ct::PFRegionEmu& from = mergedRegions.back().region;
-        const l1ct::PFRegionEmu& to = out[iout].region;
-        l1ct::glbeta_t etaMin = to.hwEtaCenter - to.hwEtaHalfWidth - to.hwEtaExtra - from.hwEtaCenter;
-        l1ct::glbeta_t etaMax = to.hwEtaCenter + to.hwEtaHalfWidth + to.hwEtaExtra - from.hwEtaCenter;
-        l1ct::glbeta_t etaShift = from.hwEtaCenter - to.hwEtaCenter;
-        l1ct::glbphi_t phiMin = -to.hwPhiHalfWidth - to.hwPhiExtra;
-        l1ct::glbphi_t phiMax = +to.hwPhiHalfWidth + to.hwPhiExtra;
-        l1ct::glbphi_t phiShift = 0;
+      if (nbuffers_ == nregions_post_) {
+        for (int i = 0; i < 2; ++i) {
+          unsigned int iout = (2 * ieta + i) * nphi + iphi;
+          const l1ct::PFRegionEmu& from = mergedRegions.back().region;
+          const l1ct::PFRegionEmu& to = out[iout].region;
+          l1ct::glbeta_t etaMin = to.hwEtaCenter - to.hwEtaHalfWidth - to.hwEtaExtra - from.hwEtaCenter;
+          l1ct::glbeta_t etaMax = to.hwEtaCenter + to.hwEtaHalfWidth + to.hwEtaExtra - from.hwEtaCenter;
+          l1ct::glbeta_t etaShift = from.hwEtaCenter - to.hwEtaCenter;
+          l1ct::glbphi_t phiMin = -to.hwPhiHalfWidth - to.hwPhiExtra;
+          l1ct::glbphi_t phiMax = +to.hwPhiHalfWidth + to.hwPhiExtra;
+          l1ct::glbphi_t phiShift = 0;
+          if (ntk_ > 0)
+            tkBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::TkObjEmu>(
+                etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          if (ncalo_ > 0)
+            hadCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::HadCaloObjEmu>(
+                etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          if (nem_ > 0)
+            emCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::EmCaloObjEmu>(
+                etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          if (nmu_ > 0)
+            muBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::MuObjEmu>(
+                etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+        }
+      } else if (nbuffers_ == nregions_pre_) {
+        unsigned int iout = ieta * nphi + iphi;
         if (ntk_ > 0)
-          tkBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::TkObjEmu>(
-              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          tkBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::TkObjEmu>(etabuffer_depth_);
         if (ncalo_ > 0)
-          hadCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::HadCaloObjEmu>(
-              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          hadCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::HadCaloObjEmu>(etabuffer_depth_);
         if (nem_ > 0)
-          emCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::EmCaloObjEmu>(
-              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          emCaloBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::EmCaloObjEmu>(etabuffer_depth_);
         if (nmu_ > 0)
-          muBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::MuObjEmu>(
-              etabuffer_depth_, etaMin, etaMax, etaShift, phiMin, phiMax, phiShift);
+          muBuffers_[iout] = l1ct::multififo_regionizer::EtaPhiBuffer<l1ct::MuObjEmu>(etabuffer_depth_);
       }
     }
   }
@@ -266,8 +289,8 @@ bool l1ct::MiddleBufferMultififoRegionizerEmulator::step(bool newEvent,
     for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
       unsigned int iin = ieta * nphi + iphi;
       //if (ieta == 0 && iphi == 0 && pre_out_tk[iin].hwPt != 0) std::cout << "iclock " << iclock_ << ",  pre_out_tk[" << iin << "] = " << pre_out_tk[iin].pack().to_string(16) << std::endl;
-      for (int i = 0; i < 2; ++i) {
-        unsigned int iout = (2 * ieta + i) * nphi + iphi;
+      for (int i = 0, n = nbuffers_ == nregions_pre_ ? 1 : 2; i < n; ++i) {
+        unsigned int iout = (n * ieta + i) * nphi + iphi;
         if (ntk_)
           tkBuffers_[iout].maybe_push(pre_out_tk[iin]);
         if (ncalo_)
@@ -295,15 +318,54 @@ bool l1ct::MiddleBufferMultififoRegionizerEmulator::step(bool newEvent,
   std::vector<l1ct::HadCaloObjEmu> bufferOut_hadCalo(ncalo_ ? nregions_post_ : 0);
   std::vector<l1ct::EmCaloObjEmu> bufferOut_emCalo(nem_ ? nregions_post_ : 0);
   std::vector<l1ct::MuObjEmu> bufferOut_mu(nmu_ ? nregions_post_ : 0);
-  for (unsigned int i = 0; i < nregions_post_; ++i) {
-    if (ntk_)
-      bufferOut_tk[i] = tkBuffers_[i].pop();
-    if (ncalo_)
-      bufferOut_hadCalo[i] = hadCaloBuffers_[i].pop();
-    if (nem_)
-      bufferOut_emCalo[i] = emCaloBuffers_[i].pop();
-    if (nmu_)
-      bufferOut_mu[i] = muBuffers_[i].pop();
+  if (nbuffers_ == nregions_post_) {  // just copy directly
+    for (unsigned int i = 0; i < nregions_post_; ++i) {
+      if (ntk_)
+        bufferOut_tk[i] = tkBuffers_[i].pop();
+      if (ncalo_)
+        bufferOut_hadCalo[i] = hadCaloBuffers_[i].pop();
+      if (nem_)
+        bufferOut_emCalo[i] = emCaloBuffers_[i].pop();
+      if (nmu_)
+        bufferOut_mu[i] = muBuffers_[i].pop();
+    }
+  } else if (nbuffers_ == nregions_pre_) {  // propagate and copy
+    unsigned int neta = 3, nphi = 9;
+    for (unsigned int ieta = 0; ieta < neta; ++ieta) {
+      for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
+        unsigned int iin = ieta * nphi + iphi;
+        const l1ct::PFRegionEmu& from = mergedRegions_[iin];
+        l1ct::TkObjEmu tk = ntk_ ? tkBuffers_[iin].pop() : l1ct::TkObjEmu();
+        l1ct::HadCaloObjEmu calo = ncalo_ ? hadCaloBuffers_[iin].pop() : l1ct::HadCaloObjEmu();
+        l1ct::EmCaloObjEmu em = nem_ ? emCaloBuffers_[iin].pop() : l1ct::EmCaloObjEmu();
+        l1ct::MuObjEmu mu = nmu_ ? muBuffers_[iin].pop() : l1ct::MuObjEmu();
+        for (int i = 0; i < 2; ++i) {
+          const l1ct::PFRegionEmu& to = outputRegions_[2 * iin + i];
+          unsigned int iout = (2 * ieta + i) * nphi + iphi;
+          l1ct::glbeta_t etaMin = to.hwEtaCenter - to.hwEtaHalfWidth - to.hwEtaExtra - from.hwEtaCenter;
+          l1ct::glbeta_t etaMax = to.hwEtaCenter + to.hwEtaHalfWidth + to.hwEtaExtra - from.hwEtaCenter;
+          l1ct::glbeta_t etaShift = from.hwEtaCenter - to.hwEtaCenter;
+          l1ct::glbphi_t phiMin = -to.hwPhiHalfWidth - to.hwPhiExtra;
+          l1ct::glbphi_t phiMax = +to.hwPhiHalfWidth + to.hwPhiExtra;
+          if (tk.hwPt > 0 && l1ct::multififo_regionizer::local_eta_phi_window(tk, etaMin, etaMax, phiMin, phiMax)) {
+            bufferOut_tk[iout] = tk;
+            bufferOut_tk[iout].hwEta += etaShift;
+          }
+          if (calo.hwPt > 0 && l1ct::multififo_regionizer::local_eta_phi_window(calo, etaMin, etaMax, phiMin, phiMax)) {
+            bufferOut_hadCalo[iout] = calo;
+            bufferOut_hadCalo[iout].hwEta += etaShift;
+          }
+          if (em.hwPt > 0 && l1ct::multififo_regionizer::local_eta_phi_window(em, etaMin, etaMax, phiMin, phiMax)) {
+            bufferOut_emCalo[iout] = em;
+            bufferOut_emCalo[iout].hwEta += etaShift;
+          }
+          if (mu.hwPt > 0 && l1ct::multififo_regionizer::local_eta_phi_window(mu, etaMin, etaMax, phiMin, phiMax)) {
+            bufferOut_mu[iout] = mu;
+            bufferOut_mu[iout].hwEta += etaShift;
+          }
+        }
+      }
+    }
   }
   if (ntk_)
     tkRegionizerPost_.muxonly_step(newEvent, /*flush=*/true, bufferOut_tk, out_tk);

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/middle_buffer_multififo_regionizer_ref.cpp
@@ -297,7 +297,6 @@ bool l1ct::MiddleBufferMultififoRegionizerEmulator::step(bool newEvent,
   for (unsigned int ieta = 0; ieta < neta; ++ieta) {
     for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
       unsigned int iin = ieta * nphi + iphi;
-      //if (ieta == 0 && iphi == 0 && pre_out_tk[iin].hwPt != 0) std::cout << "iclock " << iclock_ << ",  pre_out_tk[" << iin << "] = " << pre_out_tk[iin].pack().to_string(16) << std::endl;
       for (int i = 0, n = nbuffers_ == nregions_pre_ ? 1 : 2; i < n; ++i) {
         unsigned int iout = (n * ieta + i) * nphi + iphi;
         if (ntk_)

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/tdr_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/tdr_regionizer_ref.cpp
@@ -75,9 +75,11 @@ void l1ct::TDRRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedI
         netaInBR_, nphiInBR_, nmu_, bigRegionEdges_[i], bigRegionEdges_[i + 1], nclocks_, 1, false);
   }
 
-  dbgCout() << "in.track.size() = " << in.track.size() << std::endl;
-  dbgCout() << "in.hadcalo.size() = " << in.hadcalo.size() << std::endl;
-  dbgCout() << "in.emcalo.size() = " << in.emcalo.size() << std::endl;
+  if (debug_) {
+    dbgCout() << "in.track.size() = " << in.track.size() << std::endl;
+    dbgCout() << "in.hadcalo.size() = " << in.hadcalo.size() << std::endl;
+    dbgCout() << "in.emcalo.size() = " << in.emcalo.size() << std::endl;
+  }
 
   if (ntk_) {
     for (unsigned int i = 0; i < nBigRegions_; i++) {

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -174,13 +174,24 @@ if args.tm18:
     del process.l1tLayer1HGCalNoTKTM18.regionizerAlgoParameters.nEndcaps 
     del process.l1tLayer1HGCalNoTKTM18.regionizerAlgoParameters.nTkLinks
     del process.l1tLayer1HGCalNoTKTM18.regionizerAlgoParameters.nCaloLinks
+    process.l1tLayer1BarrelSerenityTM18 = process.l1tLayer1BarrelSerenity.clone()
+    process.l1tLayer1BarrelSerenityTM18.regionizerAlgo = "MiddleBufferMultififo"
+    process.l1tLayer1BarrelSerenityTM18.regionizerAlgoParameters = cms.PSet(
+        nTrack = process.l1tLayer1BarrelSerenity.regionizerAlgoParameters.nTrack,
+        nCalo = process.l1tLayer1BarrelSerenity.regionizerAlgoParameters.nCalo,
+        nEmCalo = process.l1tLayer1BarrelSerenity.regionizerAlgoParameters.nEmCalo,
+        nMu = process.l1tLayer1BarrelSerenity.regionizerAlgoParameters.nMu,
+    )
+    process.l1tLayer1BarrelSerenityTM18.boards = cms.VPSet(*[cms.PSet(regions = cms.vuint32(*range(18*i,18*i+18))) for i in range(3)])
     process.runPF.insert(process.runPF.index(process.l1tLayer1HGCal)+1, process.l1tLayer1HGCalTM18)
     process.runPF.insert(process.runPF.index(process.l1tLayer1HGCalNoTK)+1, process.l1tLayer1HGCalNoTKTM18)
+    process.runPF.insert(process.runPF.index(process.l1tLayer1BarrelSerenity)+1, process.l1tLayer1BarrelSerenityTM18)
     if not args.patternFilesOFF:
         process.l1tLayer1HGCalTM18.patternWriters = cms.untracked.VPSet(*hgcalTM18WriterConfigs)
         process.l1tLayer1HGCalNoTKTM18.patternWriters = cms.untracked.VPSet(hgcalNoTKOutputTM18WriterConfig)
+        process.l1tLayer1BarrelSerenityTM18.patternWriters = cms.untracked.VPSet()
     if not args.dumpFilesOFF:
-        for det in "HGCalTM18", "HGCalNoTKTM18":
+        for det in "HGCalTM18", "HGCalNoTKTM18", "BarrelSerenityTM18":
                 getattr(process, 'l1tLayer1'+det).dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
 
 process.source.fileNames  = [ '/store/cmst3/group/l1tr/gpetrucc/12_5_X/NewInputs125X/150223/TTbar_PU200/inputs125X_1.root' ]


### PR DESCRIPTION
This PR extends the emulators of the correlator layer 1 to support running the barrel at tmux 18 (albeit for now only on serenity boards)

There are no changes in the default correlator layer 1 configuration that is used in the L1 menu, which runs an idealized version of the barrel at tmux6.

Having the tmux18 version in CMSSW is however useful to do studies of this possible architecture and prepare pattern files for single and multi board tests at b904.

If this looks ok to you, I'll make the corresponding PR to CMSSW master this week

@cerminar