### PR TITLE
Update displaced track jet cuts

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -276,35 +276,65 @@ private:
   private:
     double reducedChi2RPhiMax_;
   };
-  struct TTTrackChi2MaxNstubSelector {
-    TTTrackChi2MaxNstubSelector(double reducedChi2MaxNstub4, double reducedChi2MaxNstub5)
-        : reducedChi2MaxNstub4_(reducedChi2MaxNstub4), reducedChi2MaxNstub5_(reducedChi2MaxNstub5) {}
-    TTTrackChi2MaxNstubSelector(const edm::ParameterSet& cfg)
-        : reducedChi2MaxNstub4_(cfg.template getParameter<double>("reducedChi2MaxNstub4")),
-          reducedChi2MaxNstub5_(cfg.template getParameter<double>("reducedChi2MaxNstub5")) {}
+  struct TTTrackChi2RZMaxNstubSelector {
+    TTTrackChi2RZMaxNstubSelector(double reducedChi2RZMaxNstub4, double reducedChi2RZMaxNstub5)
+        : reducedChi2RZMaxNstub4_(reducedChi2RZMaxNstub4), reducedChi2RZMaxNstub5_(reducedChi2RZMaxNstub5) {}
+    TTTrackChi2RZMaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedChi2RZMaxNstub4_(cfg.template getParameter<double>("reducedChi2RZMaxNstub4")),
+          reducedChi2RZMaxNstub5_(cfg.template getParameter<double>("reducedChi2RZMaxNstub5")) {}
     bool operator()(const L1Track& t) const {
-      return (((t.chi2Red() < reducedChi2MaxNstub4_) && (t.getStubRefs().size() == 4)) ||
-              ((t.chi2Red() < reducedChi2MaxNstub5_) && (t.getStubRefs().size() > 4)));
+      return (((t.chi2ZRed() < reducedChi2RZMaxNstub4_) && (t.getStubRefs().size() == 4)) ||
+              ((t.chi2ZRed() < reducedChi2RZMaxNstub5_) && (t.getStubRefs().size() > 4)));
     }
 
   private:
-    double reducedChi2MaxNstub4_;
-    double reducedChi2MaxNstub5_;
+    double reducedChi2RZMaxNstub4_;
+    double reducedChi2RZMaxNstub5_;
   };
-  struct TTTrackWordChi2MaxNstubSelector {  // using simulated chi2 since not implemented in track word, updates needed
-    TTTrackWordChi2MaxNstubSelector(double reducedChi2MaxNstub4, double reducedChi2MaxNstub5)
-        : reducedChi2MaxNstub4_(reducedChi2MaxNstub4), reducedChi2MaxNstub5_(reducedChi2MaxNstub5) {}
-    TTTrackWordChi2MaxNstubSelector(const edm::ParameterSet& cfg)
-        : reducedChi2MaxNstub4_(cfg.template getParameter<double>("reducedChi2MaxNstub4")),
-          reducedChi2MaxNstub5_(cfg.template getParameter<double>("reducedChi2MaxNstub5")) {}
+  struct TTTrackWordChi2RZMaxNstubSelector {
+    TTTrackWordChi2RZMaxNstubSelector(double reducedChi2RZMaxNstub4, double reducedChi2RZMaxNstub5)
+        : reducedChi2RZMaxNstub4_(reducedChi2RZMaxNstub4), reducedChi2RZMaxNstub5_(reducedChi2RZMaxNstub5) {}
+    TTTrackWordChi2RZMaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedChi2RZMaxNstub4_(cfg.template getParameter<double>("reducedChi2RZMaxNstub4")),
+          reducedChi2RZMaxNstub5_(cfg.template getParameter<double>("reducedChi2RZMaxNstub5")) {}
     bool operator()(const L1Track& t) const {
-      return (((t.chi2Red() < reducedChi2MaxNstub4_) && (t.getNStubs() == 4)) ||
-              ((t.chi2Red() < reducedChi2MaxNstub5_) && (t.getNStubs() > 4)));
+      return (((t.getChi2RZ() < reducedChi2RZMaxNstub4_) && (t.getNStubs() == 4)) ||
+              ((t.getChi2RZ() < reducedChi2RZMaxNstub5_) && (t.getNStubs() > 4)));
     }
 
   private:
-    double reducedChi2MaxNstub4_;
-    double reducedChi2MaxNstub5_;
+    double reducedChi2RZMaxNstub4_;
+    double reducedChi2RZMaxNstub5_;
+  };
+  struct TTTrackChi2RPhiMaxNstubSelector {
+    TTTrackChi2RPhiMaxNstubSelector(double reducedChi2RPhiMaxNstub4, double reducedChi2RPhiMaxNstub5)
+        : reducedChi2RPhiMaxNstub4_(reducedChi2RPhiMaxNstub4), reducedChi2RPhiMaxNstub5_(reducedChi2RPhiMaxNstub5) {}
+    TTTrackChi2RPhiMaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedChi2RPhiMaxNstub4_(cfg.template getParameter<double>("reducedChi2RPhiMaxNstub4")),
+          reducedChi2RPhiMaxNstub5_(cfg.template getParameter<double>("reducedChi2RPhiMaxNstub5")) {}
+    bool operator()(const L1Track& t) const {
+      return (((t.chi2XYRed() < reducedChi2RPhiMaxNstub4_) && (t.getStubRefs().size() == 4)) ||
+              ((t.chi2XYRed() < reducedChi2RPhiMaxNstub5_) && (t.getStubRefs().size() > 4)));
+    }
+
+  private:
+    double reducedChi2RPhiMaxNstub4_;
+    double reducedChi2RPhiMaxNstub5_;
+  };
+  struct TTTrackWordChi2RPhiMaxNstubSelector {  // using simulated chi2 since not implemented in track word, updates needed
+    TTTrackWordChi2RPhiMaxNstubSelector(double reducedChi2RPhiMaxNstub4, double reducedChi2RPhiMaxNstub5)
+        : reducedChi2RPhiMaxNstub4_(reducedChi2RPhiMaxNstub4), reducedChi2RPhiMaxNstub5_(reducedChi2RPhiMaxNstub5) {}
+    TTTrackWordChi2RPhiMaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedChi2RPhiMaxNstub4_(cfg.template getParameter<double>("reducedChi2RPhiMaxNstub4")),
+          reducedChi2RPhiMaxNstub5_(cfg.template getParameter<double>("reducedChi2RPhiMaxNstub5")) {}
+    bool operator()(const L1Track& t) const {
+      return (((t.getChi2RPhi() < reducedChi2RPhiMaxNstub4_) && (t.getNStubs() == 4)) ||
+              ((t.getChi2RPhi() < reducedChi2RPhiMaxNstub5_) && (t.getNStubs() > 4)));
+    }
+
+  private:
+    double reducedChi2RPhiMaxNstub4_;
+    double reducedChi2RPhiMaxNstub5_;
   };
   struct TTTrackBendChi2MaxNstubSelector {
     TTTrackBendChi2MaxNstubSelector(double reducedBendChi2MaxNstub4, double reducedBendChi2MaxNstub5)
@@ -348,9 +378,10 @@ private:
       TTTrackBendChi2Chi2RZChi2RPhiMaxSelector;
   typedef AndSelector<TTTrackWordBendChi2MaxSelector, TTTrackWordChi2RZMaxSelector, TTTrackWordChi2RPhiMaxSelector>
       TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector;
-  typedef AndSelector<TTTrackChi2MaxNstubSelector, TTTrackBendChi2MaxNstubSelector> TTTrackChi2BendChi2MaxNstubSelector;
-  typedef AndSelector<TTTrackWordChi2MaxNstubSelector, TTTrackWordBendChi2MaxNstubSelector>
-      TTTrackWordChi2BendChi2MaxNstubSelector;
+  typedef AndSelector<TTTrackChi2RZMaxNstubSelector, TTTrackChi2RPhiMaxNstubSelector, TTTrackBendChi2MaxNstubSelector> 
+      TTTrackChi2MaxNstubSelector;
+  typedef AndSelector<TTTrackWordChi2RZMaxNstubSelector, TTTrackWordChi2RPhiMaxNstubSelector, TTTrackWordBendChi2MaxNstubSelector>
+      TTTrackWordChi2MaxNstubSelector;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<TTTrackCollection> l1TracksToken_;
@@ -358,7 +389,7 @@ private:
   const std::string outputCollectionName_;
   const edm::ParameterSet cutSet_;
   const double ptMin_, absEtaMax_, absZ0Max_, promptMVAMin_, bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
-  const double reducedChi2MaxNstub4_, reducedChi2MaxNstub5_, reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_;
+  const double reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_, reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_, reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_;
   const int nStubsMin_, nPSStubsMin_;
   bool processSimulatedTracks_, processEmulatedTracks_;
   int debug_;
@@ -380,8 +411,10 @@ L1TrackSelectionProducer::L1TrackSelectionProducer(const edm::ParameterSet& iCon
       bendChi2Max_(cutSet_.getParameter<double>("reducedBendChi2Max")),
       reducedChi2RZMax_(cutSet_.getParameter<double>("reducedChi2RZMax")),
       reducedChi2RPhiMax_(cutSet_.getParameter<double>("reducedChi2RPhiMax")),
-      reducedChi2MaxNstub4_(cutSet_.getParameter<double>("reducedChi2MaxNstub4")),
-      reducedChi2MaxNstub5_(cutSet_.getParameter<double>("reducedChi2MaxNstub5")),
+      reducedChi2RZMaxNstub4_(cutSet_.getParameter<double>("reducedChi2RZMaxNstub4")),
+      reducedChi2RZMaxNstub5_(cutSet_.getParameter<double>("reducedChi2RZMaxNstub5")),
+      reducedChi2RPhiMaxNstub4_(cutSet_.getParameter<double>("reducedChi2RPhiMaxNstub4")),
+      reducedChi2RPhiMaxNstub5_(cutSet_.getParameter<double>("reducedChi2RPhiMaxNstub5")),
       reducedBendChi2MaxNstub4_(cutSet_.getParameter<double>("reducedBendChi2MaxNstub4")),
       reducedBendChi2MaxNstub5_(cutSet_.getParameter<double>("reducedBendChi2MaxNstub5")),
       nStubsMin_(cutSet_.getParameter<int>("nStubsMin")),
@@ -509,10 +542,12 @@ void L1TrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const 
   TTTrackNPSStubsMinSelector nPSStubsSel(nPSStubsMin_, tTopo);
   TTTrackPromptMVAMinSelector mvaSel(promptMVAMin_);
   TTTrackWordPromptMVAMinSelector mvaSelEmu(promptMVAMin_);
-  TTTrackChi2BendChi2MaxNstubSelector chi2NstubSel({reducedChi2MaxNstub4_, reducedChi2MaxNstub5_},
-                                                   {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
-  TTTrackWordChi2BendChi2MaxNstubSelector chi2NstubSelEmu({reducedChi2MaxNstub4_, reducedChi2MaxNstub5_},
-                                                          {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
+  TTTrackChi2MaxNstubSelector chi2NstubSel({reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_},
+					   {reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_},
+					   {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
+  TTTrackWordChi2MaxNstubSelector chi2NstubSelEmu({reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_},
+						  {reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_},
+						  {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
 
   for (size_t i = 0; i < nOutputApproximate; i++) {
     const auto& track = l1TracksHandle->at(i);
@@ -561,10 +596,14 @@ void L1TrackSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& 
     descCutSet.add<double>("reducedBendChi2Max", 2.25)->setComment("bend chi2 must be less than this value");
     descCutSet.add<double>("reducedChi2RZMax", 5.0)->setComment("chi2rz/dof must be less than this value");
     descCutSet.add<double>("reducedChi2RPhiMax", 20.0)->setComment("chi2rphi/dof must be less than this value");
-    descCutSet.add<double>("reducedChi2MaxNstub4", 999.9)
-        ->setComment("chi2/dof must be less than this value in nstub==4");
-    descCutSet.add<double>("reducedChi2MaxNstub5", 999.9)
-        ->setComment("chi2/dof must be less than this value in nstub>4");
+    descCutSet.add<double>("reducedChi2RZMaxNstub4", 999.9)
+        ->setComment("chi2rz/dof must be less than this value in nstub==4");
+    descCutSet.add<double>("reducedChi2RZMaxNstub5", 999.9)
+        ->setComment("chi2rz/dof must be less than this value in nstub>4");
+    descCutSet.add<double>("reducedChi2RPhiMaxNstub4", 999.9)
+      ->setComment("chi2rphi/dof must be less than this value in nstub==4");
+    descCutSet.add<double>("reducedChi2RPhiMaxNstub5", 999.9)
+      ->setComment("chi2rphi/dof must be less than this value in nstub>4");
     descCutSet.add<double>("reducedBendChi2MaxNstub4", 999.9)
         ->setComment("bend chi2 must be less than this value in nstub==4");
     descCutSet.add<double>("reducedBendChi2MaxNstub5", 999.9)

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -378,9 +378,11 @@ private:
       TTTrackBendChi2Chi2RZChi2RPhiMaxSelector;
   typedef AndSelector<TTTrackWordBendChi2MaxSelector, TTTrackWordChi2RZMaxSelector, TTTrackWordChi2RPhiMaxSelector>
       TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector;
-  typedef AndSelector<TTTrackChi2RZMaxNstubSelector, TTTrackChi2RPhiMaxNstubSelector, TTTrackBendChi2MaxNstubSelector> 
+  typedef AndSelector<TTTrackChi2RZMaxNstubSelector, TTTrackChi2RPhiMaxNstubSelector, TTTrackBendChi2MaxNstubSelector>
       TTTrackChi2MaxNstubSelector;
-  typedef AndSelector<TTTrackWordChi2RZMaxNstubSelector, TTTrackWordChi2RPhiMaxNstubSelector, TTTrackWordBendChi2MaxNstubSelector>
+  typedef AndSelector<TTTrackWordChi2RZMaxNstubSelector,
+                      TTTrackWordChi2RPhiMaxNstubSelector,
+                      TTTrackWordBendChi2MaxNstubSelector>
       TTTrackWordChi2MaxNstubSelector;
 
   // ----------member data ---------------------------
@@ -389,7 +391,8 @@ private:
   const std::string outputCollectionName_;
   const edm::ParameterSet cutSet_;
   const double ptMin_, absEtaMax_, absZ0Max_, promptMVAMin_, bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
-  const double reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_, reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_, reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_;
+  const double reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_, reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_,
+      reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_;
   const int nStubsMin_, nPSStubsMin_;
   bool processSimulatedTracks_, processEmulatedTracks_;
   int debug_;
@@ -543,11 +546,11 @@ void L1TrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const 
   TTTrackPromptMVAMinSelector mvaSel(promptMVAMin_);
   TTTrackWordPromptMVAMinSelector mvaSelEmu(promptMVAMin_);
   TTTrackChi2MaxNstubSelector chi2NstubSel({reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_},
-					   {reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_},
-					   {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
+                                           {reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_},
+                                           {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
   TTTrackWordChi2MaxNstubSelector chi2NstubSelEmu({reducedChi2RZMaxNstub4_, reducedChi2RZMaxNstub5_},
-						  {reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_},
-						  {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
+                                                  {reducedChi2RPhiMaxNstub4_, reducedChi2RPhiMaxNstub5_},
+                                                  {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
 
   for (size_t i = 0; i < nOutputApproximate; i++) {
     const auto& track = l1TracksHandle->at(i);
@@ -601,9 +604,9 @@ void L1TrackSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& 
     descCutSet.add<double>("reducedChi2RZMaxNstub5", 999.9)
         ->setComment("chi2rz/dof must be less than this value in nstub>4");
     descCutSet.add<double>("reducedChi2RPhiMaxNstub4", 999.9)
-      ->setComment("chi2rphi/dof must be less than this value in nstub==4");
+        ->setComment("chi2rphi/dof must be less than this value in nstub==4");
     descCutSet.add<double>("reducedChi2RPhiMaxNstub5", 999.9)
-      ->setComment("chi2rphi/dof must be less than this value in nstub>4");
+        ->setComment("chi2rphi/dof must be less than this value in nstub>4");
     descCutSet.add<double>("reducedBendChi2MaxNstub4", 999.9)
         ->setComment("bend chi2 must be less than this value in nstub==4");
     descCutSet.add<double>("reducedBendChi2MaxNstub5", 999.9)

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackSelectionProducer_cfi.py
@@ -14,8 +14,10 @@ l1tTrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     reducedBendChi2Max = cms.double(2.25), # bend chi2 must be less than this value
                     reducedChi2RZMax = cms.double(5.0), # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = cms.double(20.0), # chi2rphi/dof must be less than this value
-                    reducedChi2MaxNstub4 = cms.double(999.9), # chi2/dof with nstub==4 must be less than this value
-                    reducedChi2MaxNstub5 = cms.double(999.9), # chi2/dof with nstub>4 must be less than this value
+                    reducedChi2RZMaxNstub4 = cms.double(999.9), # chi2rz/dof with nstub==4 must be less than this value
+                    reducedChi2RZMaxNstub5 = cms.double(999.9), # chi2rz/dof with nstub>4 must be less than this value
+                    reducedChi2RPhiMaxNstub4 = cms.double(999.9), # chi2rphi/dof with nstub==4 must be less than this value
+                    reducedChi2RPhiMaxNstub5 = cms.double(999.9), # chi2rphi/dof with nstub>4 must be less than this value
                     reducedBendChi2MaxNstub4 = cms.double(999.9), # bend chi2 with nstub==4 must be less than this value
                     reducedBendChi2MaxNstub5 = cms.double(999.9), # bend chi2 with nstub>4 must be less than this value
                     ),
@@ -38,8 +40,10 @@ l1tTrackSelectionProducerExtended = l1tTrackSelectionProducer.clone(
                     reducedBendChi2Max = 2.4, # bend chi2 must be less than this value
                     reducedChi2RZMax = 10.0, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 40.0, # chi2rphi/dof must be less than this value
-                    reducedChi2MaxNstub4 = 999.9,# chi2/dof with nstub==4 must be less than this value 
-                    reducedChi2MaxNstub5 = 999.9,# chi2/dof with nstub>4 must be less than this value
+                    reducedChi2RZMaxNstub4 = cms.double(999.9), # chi2rz/dof with nstub==4 must be less than this value
+                    reducedChi2RZMaxNstub5 = cms.double(999.9), # chi2rz/dof with nstub>4 must be less than this value
+                    reducedChi2RPhiMaxNstub4 = cms.double(999.9), # chi2rphi/dof with nstub==4 must be less than this value
+                    reducedChi2RPhiMaxNstub5 = cms.double(999.9), # chi2rphi/dof with nstub>4 must be less than this value
                     reducedBendChi2MaxNstub4 = 999.9, # bend chi2 with nstub==4 must be less than this value
                     reducedBendChi2MaxNstub5 = 999.9, # bend chi2 with nstub>4 must be less than this value 
                     ),
@@ -59,10 +63,12 @@ l1tTrackSelectionProducerForJets = l1tTrackSelectionProducer.clone(
                     reducedBendChi2Max = 999.9, # bend chi2 must be less than this value
                     reducedChi2RZMax = 999.9, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 999.9, # chi2rphi/dof must be less than this value
-      reducedChi2MaxNstub4 = 999.9, # chi2/dof with nstub==4 must be less than this value
-      reducedChi2MaxNstub5 = 999.9, # chi2/dof with nstub>4 must be less than this value
-      reducedBendChi2MaxNstub4 = 999.9, # bend chi2 with nstub==4 must be less than this value
-      reducedBendChi2MaxNstub5 = 999.9, # bend chi2 with nstub>4 must be less than this value
+                    reducedChi2RZMaxNstub4 = cms.double(999.9), # chi2rz/dof with nstub==4 must be less than this value
+                    reducedChi2RZMaxNstub5 = cms.double(999.9), # chi2rz/dof with nstub>4 must be less than this value
+                    reducedChi2RPhiMaxNstub4 = cms.double(999.9), # chi2rphi/dof with nstub==4 must be less than this value
+                    reducedChi2RPhiMaxNstub5 = cms.double(999.9), # chi2rphi/dof with nstub>4 must be less than this value
+                    reducedBendChi2MaxNstub4 = 999.9, # bend chi2 with nstub==4 must be less than this value
+                    reducedBendChi2MaxNstub5 = 999.9, # bend chi2 with nstub>4 must be less than this value
                     ),
 )
 
@@ -78,10 +84,12 @@ l1tTrackSelectionProducerExtendedForJets = l1tTrackSelectionProducerExtended.clo
                     reducedBendChi2Max = 999.9, # bend chi2 must be less than this value
                     reducedChi2RZMax = 999.9, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 999.9, # chi2rphi/dof must be less than this value
-      reducedChi2MaxNstub4 = cms.double(3.3), # chi2/dof with nstub==4 must be less than this value
-      reducedChi2MaxNstub5 = cms.double(11.3), # chi2/dof with nstub>4 must be less than this value
-      reducedBendChi2MaxNstub4 = cms.double(2.3), # bend chi2 with nstub==4 must be less than this value
-      reducedBendChi2MaxNstub5 = cms.double(9.8), # bend chi2 with nstub>4 must be less than this value
+                    reducedChi2RZMaxNstub4 = cms.double(5.0), # chi2rz/dof with nstub==4 must be less than this value
+                    reducedChi2RZMaxNstub5 = cms.double(5.0), # chi2rz/dof with nstub>4 must be less than this value
+                    reducedChi2RPhiMaxNstub4 = cms.double(6.0), # chi2rphi/dof with nstub==4 must be less than this value
+                    reducedChi2RPhiMaxNstub5 = cms.double(35.0), # chi2rphi/dof with nstub>4 must be less than this value
+                    reducedBendChi2MaxNstub4 = cms.double(2.25), # bend chi2 with nstub==4 must be less than this value
+                    reducedBendChi2MaxNstub5 = cms.double(3.5), # bend chi2 with nstub>4 must be less than this value
                     ),
 )
 


### PR DESCRIPTION
#### PR description:

This PR updates the displaced track cuts to only use variables available in the track word. The main swap is to use chi2rz/dof and chi2rphi/dof instead of chi2/dof. More on the swapping of the cuts can be seen in the GTT presentation [here](https://indico.cern.ch/event/1356822/contributions/5718823/attachments/2772928/4831803/GTT_disptrkjet_15_12_23.pdf)

#### PR validation:

Checks were made to test the jet efficiency before and after swapping the displaced jet cuts and see no significant change, as can be seen below:
<img width="377" alt="image" src="https://github.com/cms-l1t-offline/cmssw/assets/15660721/25da4225-efa2-438f-bd62-aa13c70536c1">

All code checks were performed.
