### PR TITLE
Add Phase-2 Level-1 trigger ML MET emulator [14_0_0_pre3]

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -218,6 +218,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tLayer1EG_*_*',
         'keep *_l1tLayer2EG_*_*',
         'keep *_l1tMETPFProducer_*_*',
+        'keep *_l1tMETMLProducer_*_*',
         'keep *_l1tNNTauProducer_*_*',
         'keep *_l1tNNTauProducerPuppi_*_*',
         'keep *_l1tHPSPFTauProducerPF_*_*',

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -223,6 +223,7 @@ _phase2_siml1emulator.add(L1TPFJetsEmulationTask)
 
 from L1Trigger.Phase2L1ParticleFlow.l1tMETPFProducer_cfi import *
 _phase2_siml1emulator.add(l1tMETPFProducer)
+_phase2_siml1emulator.add(l1tMETMLProducer)
 
 
 # NNTaus

--- a/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
@@ -13,6 +13,8 @@
 <use name="tensorflow"/>
 <use name="roottmva"/>
 <use name="hls"/>
+<use name="hls4mlEmulatorExtras"/>
+<use name="L1METML"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1MetPfProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1MetPfProducer.cc
@@ -136,15 +136,15 @@ void L1MetPfProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
 
 int L1MetPfProducer::EncodePdgId(int pdgId) const {
   switch (abs(pdgId)) {
-    case 211:
+    case 211:  // charged hadron (pion)
       return 1;
-    case 130:
+    case 130:  // neutral hadron (kaon)
       return 2;
-    case 22:
+    case 22:  // photon
       return 3;
-    case 13:
+    case 13:  // muon
       return 4;
-    case 11:
+    case 11:  // electron
       return 5;
     default:
       return 0;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1MetPfProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1MetPfProducer.cc
@@ -55,12 +55,12 @@ private:
   bool useMlModel_;
   std::shared_ptr<hls4mlEmulator::Model> model;
   std::string modelVersion_;
-  typedef ap_fixed<32,16> input_t;
-  typedef ap_fixed<32,16> result_t;
+  typedef ap_fixed<32, 16> input_t;
+  typedef ap_fixed<32, 16> result_t;
   int numContInputs_ = 4;
   int numPxPyInputs_ = 2;
   int numCatInputs_ = 2;
-  int numInputs_ = numContInputs_+numPxPyInputs_+numCatInputs_;
+  int numInputs_ = numContInputs_ + numPxPyInputs_ + numCatInputs_;
 
   void Project(pt_t pt, phi_t phi, pxy_t& pxy, bool isX, bool debug = false) const;
   void PhiFromXY(pxy_t px, pxy_t py, phi_t& phi, bool debug = false) const;
@@ -68,7 +68,13 @@ private:
   int EncodePdgId(int pdgId) const;
 
   void CalcMetHLS(std::vector<float> pt, std::vector<float> phi, reco::Candidate::PolarLorentzVector& metVector) const;
-  void CalcMlMet(std::vector<float> pt, std::vector<float> eta, std::vector<float> phi, std::vector<float> puppiWeight, std::vector<int> pdgId, std::vector<int> charge, reco::Candidate::PolarLorentzVector& metVector) const;
+  void CalcMlMet(std::vector<float> pt,
+                 std::vector<float> eta,
+                 std::vector<float> phi,
+                 std::vector<float> puppiWeight,
+                 std::vector<int> pdgId,
+                 std::vector<int> charge,
+                 reco::Candidate::PolarLorentzVector& metVector) const;
 };
 
 L1MetPfProducer::L1MetPfProducer(const edm::ParameterSet& cfg)
@@ -108,8 +114,7 @@ void L1MetPfProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
 
   if (useMlModel_) {
     CalcMlMet(pt, eta, phi, puppiWeight, pdgId, charge, metVector);
-  }
-  else {
+  } else {
     CalcMetHLS(pt, phi, metVector);
   }
 
@@ -121,7 +126,7 @@ void L1MetPfProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
 }
 
 int L1MetPfProducer::EncodePdgId(int pdgId) const {
-  switch(abs(pdgId)) {
+  switch (abs(pdgId)) {
     case 211:
       return 1;
     case 130:
@@ -156,17 +161,17 @@ void L1MetPfProducer::CalcMlMet(std::vector<float> pt,
 
   for (uint i = 0; i < pt.size(); i++) {
     // input_cont
-    input[i*numContInputs_] = pt[i];
-    input[i*numContInputs_+1] = eta[i];
-    input[i*numContInputs_+2] = phi[i];
-    input[i*numContInputs_+3] = puppiWeight[i];
+    input[i * numContInputs_] = pt[i];
+    input[i * numContInputs_ + 1] = eta[i];
+    input[i * numContInputs_ + 2] = phi[i];
+    input[i * numContInputs_ + 3] = puppiWeight[i];
     // input_pxpy
-    input[maxCands_*numContInputs_+i*numPxPyInputs_] = pt[i] * cos(phi[i]);
-    input[maxCands_*numContInputs_+i*numPxPyInputs_+1] = pt[i] * sin(phi[i]);
+    input[maxCands_ * numContInputs_ + i * numPxPyInputs_] = pt[i] * cos(phi[i]);
+    input[maxCands_ * numContInputs_ + i * numPxPyInputs_ + 1] = pt[i] * sin(phi[i]);
     // input_cat0
-    input[maxCands_*(numContInputs_+numPxPyInputs_)+i] = EncodePdgId(pdgId[i]);
+    input[maxCands_ * (numContInputs_ + numPxPyInputs_) + i] = EncodePdgId(pdgId[i]);
     // input_cat1
-    input[maxCands_*(numContInputs_+numPxPyInputs_+1)+i] = (abs(charge[i]) <= 1) ? (charge[i] + 2) : 0;
+    input[maxCands_ * (numContInputs_ + numPxPyInputs_ + 1) + i] = (abs(charge[i]) <= 1) ? (charge[i] + 2) : 0;
   }
 
   model->prepare_input(input);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1MetPfProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1MetPfProducer.cc
@@ -1,4 +1,5 @@
 #include <vector>
+#include <string>
 #include <ap_int.h>
 #include <ap_fixed.h>
 #include <TVector2.h>
@@ -12,6 +13,8 @@
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "hls4ml/emulator.h"
 
 using namespace l1t;
 
@@ -48,16 +51,36 @@ private:
   const int invTableBits_ = 10;
   const int invTableSize_ = (1 << invTableBits_);
 
+  // hls4ml emulator objects
+  bool useMlModel_;
+  std::shared_ptr<hls4mlEmulator::Model> model;
+  std::string modelVersion_;
+  typedef ap_fixed<32,16> input_t;
+  typedef ap_fixed<32,16> result_t;
+  int numContInputs_ = 4;
+  int numPxPyInputs_ = 2;
+  int numCatInputs_ = 2;
+  int numInputs_ = numContInputs_+numPxPyInputs_+numCatInputs_;
+
   void Project(pt_t pt, phi_t phi, pxy_t& pxy, bool isX, bool debug = false) const;
   void PhiFromXY(pxy_t px, pxy_t py, phi_t& phi, bool debug = false) const;
 
+  int EncodePdgId(int pdgId) const;
+
   void CalcMetHLS(std::vector<float> pt, std::vector<float> phi, reco::Candidate::PolarLorentzVector& metVector) const;
+  void CalcMlMet(std::vector<float> pt, std::vector<float> eta, std::vector<float> phi, std::vector<float> puppiWeight, std::vector<int> pdgId, std::vector<int> charge, reco::Candidate::PolarLorentzVector& metVector) const;
 };
 
 L1MetPfProducer::L1MetPfProducer(const edm::ParameterSet& cfg)
     : _l1PFToken(consumes<std::vector<l1t::PFCandidate>>(cfg.getParameter<edm::InputTag>("L1PFObjects"))),
-      maxCands_(cfg.getParameter<int>("maxCands")) {
+      maxCands_(cfg.getParameter<int>("maxCands")),
+      modelVersion_(cfg.getParameter<std::string>("modelVersion")) {
   produces<std::vector<l1t::EtSum>>();
+  useMlModel_ = (modelVersion_.length() > 0);
+  if (useMlModel_) {
+    hls4mlEmulator::ModelLoader loader(modelVersion_);
+    model = loader.load_model();
+  }
 }
 
 void L1MetPfProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
@@ -65,23 +88,94 @@ void L1MetPfProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
   iEvent.getByToken(_l1PFToken, l1PFCandidates);
 
   std::vector<float> pt;
+  std::vector<float> eta;
   std::vector<float> phi;
+  std::vector<float> puppiWeight;
+  std::vector<int> pdgId;
+  std::vector<int> charge;
 
   for (int i = 0; i < int(l1PFCandidates->size()) && (i < maxCands_ || maxCands_ < 0); i++) {
     const auto& l1PFCand = l1PFCandidates->at(i);
     pt.push_back(l1PFCand.pt());
+    eta.push_back(l1PFCand.eta());
     phi.push_back(l1PFCand.phi());
+    puppiWeight.push_back(l1PFCand.puppiWeight());
+    pdgId.push_back(l1PFCand.pdgId());
+    charge.push_back(l1PFCand.charge());
   }
 
   reco::Candidate::PolarLorentzVector metVector;
 
-  CalcMetHLS(pt, phi, metVector);
+  if (useMlModel_) {
+    CalcMlMet(pt, eta, phi, puppiWeight, pdgId, charge, metVector);
+  }
+  else {
+    CalcMetHLS(pt, phi, metVector);
+  }
 
   l1t::EtSum theMET(metVector, l1t::EtSum::EtSumType::kTotalHt, 0, 0, 0, 0);
 
   std::unique_ptr<std::vector<l1t::EtSum>> metCollection(new std::vector<l1t::EtSum>(0));
   metCollection->push_back(theMET);
   iEvent.put(std::move(metCollection));
+}
+
+int L1MetPfProducer::EncodePdgId(int pdgId) const {
+  switch(abs(pdgId)) {
+    case 211:
+      return 1;
+    case 130:
+      return 2;
+    case 22:
+      return 3;
+    case 13:
+      return 4;
+    case 11:
+      return 5;
+    default:
+      return 0;
+  }
+}
+
+void L1MetPfProducer::CalcMlMet(std::vector<float> pt,
+                                std::vector<float> eta,
+                                std::vector<float> phi,
+                                std::vector<float> puppiWeight,
+                                std::vector<int> pdgId,
+                                std::vector<int> charge,
+                                reco::Candidate::PolarLorentzVector& metVector) const {
+  const int inputSize = maxCands_ * numInputs_;
+
+  input_t input[800];
+  result_t result[2];
+
+  // initialize with zeros (for padding)
+  for (int i = 0; i < inputSize; i++) {
+    input[i] = 0;
+  }
+
+  for (uint i = 0; i < pt.size(); i++) {
+    // input_cont
+    input[i*numContInputs_] = pt[i];
+    input[i*numContInputs_+1] = eta[i];
+    input[i*numContInputs_+2] = phi[i];
+    input[i*numContInputs_+3] = puppiWeight[i];
+    // input_pxpy
+    input[maxCands_*numContInputs_+i*numPxPyInputs_] = pt[i] * cos(phi[i]);
+    input[maxCands_*numContInputs_+i*numPxPyInputs_+1] = pt[i] * sin(phi[i]);
+    // input_cat0
+    input[maxCands_*(numContInputs_+numPxPyInputs_)+i] = EncodePdgId(pdgId[i]);
+    // input_cat1
+    input[maxCands_*(numContInputs_+numPxPyInputs_+1)+i] = (abs(charge[i]) <= 1) ? (charge[i] + 2) : 0;
+  }
+
+  model->prepare_input(input);
+  model->predict();
+  model->read_result(result);
+
+  metVector.SetPt(hypot(result[0].to_double(), result[1].to_double()));
+  metVector.SetPhi(atan2(result[1].to_double(), result[0].to_double()));
+  metVector.SetEta(0);
 }
 
 void L1MetPfProducer::CalcMetHLS(std::vector<float> pt,

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1tMETPFProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1tMETPFProducer_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 l1tMETPFProducer = cms.EDProducer("L1MetPfProducer",
                                  L1PFObjects = cms.InputTag("l1tLayer1","Puppi"),
-                                 maxCands = cms.int32(128),
+                                 maxCands = cms.int32(100),
+                                 modelVersion = cms.string("L1METML_v1"),
 )

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1tMETPFProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1tMETPFProducer_cfi.py
@@ -2,6 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 l1tMETPFProducer = cms.EDProducer("L1MetPfProducer",
                                  L1PFObjects = cms.InputTag("l1tLayer1","Puppi"),
+                                 maxCands = cms.int32(128),
+                                 modelVersion = cms.string(""),
+)
+
+l1tMETMLProducer = cms.EDProducer("L1MetPfProducer",
+                                 L1PFObjects = cms.InputTag("l1tLayer1","Puppi"),
                                  maxCands = cms.int32(100),
                                  modelVersion = cms.string("L1METML_v1"),
 )


### PR DESCRIPTION
#### PR description:

  - Add ML-based MET to Phase-2 Level-1 trigger emulator
  - Requires L1METML external integrated here: https://github.com/cms-sw/cmsdist/pull/8901
  - Presented at L1 Tau-Jets-MET meetings, e.g. https://indico.cern.ch/event/1081765/contributions/4549653
  - This model represents a v1 baseline with post-training quantization. We expect to update it with a more realistic firmware implementation.
  - Model and expected performance plots shown here: https://github.com/cms-hls4ml/L1METML/blob/main/README.md
  - Currently enabled for testing; but plan to switch it off to run standard MET by default
  - Central CMSSW PR: https://github.com/cms-sw/cmssw/pull/43633
  - Model external repo: https://github.com/cms-hls4ml/L1METML

#### PR validation:

 - Run on 40 ([/RelValTTbar_14TeV/CMSSW_14_0_0_pre1-PU_133X_mcRun4_realistic_v1_2026D98PU200-v1/GEN-SIM-DIGI-RAW](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FRelValTTbar_14TeV%2FCMSSW_14_0_0_pre1-PU_133X_mcRun4_realistic_v1_2026D98PU200-v1%2FGEN-SIM-DIGI-RAW&instance=prod/global)) events, and results are consistent with PUPPI MET (and ML algo)
<img src="https://github.com/cms-sw/cmssw/assets/4932543/2b1c797e-72fe-4059-8a7e-8f0dd3fc5767" width=300/>
