### PR TITLE
Modify Btag Jet Types [13_3_0_pre3]

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -43,7 +43,7 @@ namespace l1ct {
   typedef ap_ufixed<10, 5, AP_TRN, AP_SAT> hoe_t;
   typedef ap_uint<4> redChi2Bin_t;
   typedef ap_fixed<10, 1, AP_RND_CONV, AP_SAT> id_score_t;  // ID score to be between -1 (background) and 1 (signal)
-  typedef ap_ufixed<10, 0, AP_RND, AP_SAT> b_tag_score_t; // result_t from the NN is still apx_fixed<16,6>
+  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t; // result_t from the NN is still apx_fixed<16,6>
 
   // FIXME: adjust range 10-11bits -> 1/4 - 1/2TeV is probably more than enough for all reasonable use cases
   typedef ap_ufixed<11, 9, AP_TRN, AP_SAT> iso_t;

--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -43,6 +43,7 @@ namespace l1ct {
   typedef ap_ufixed<10, 5, AP_TRN, AP_SAT> hoe_t;
   typedef ap_uint<4> redChi2Bin_t;
   typedef ap_fixed<10, 1, AP_RND_CONV, AP_SAT> id_score_t;  // ID score to be between -1 (background) and 1 (signal)
+  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t; // result_t from the NN is still apx_fixed<16,6>
 
   // FIXME: adjust range 10-11bits -> 1/4 - 1/2TeV is probably more than enough for all reasonable use cases
   typedef ap_ufixed<11, 9, AP_TRN, AP_SAT> iso_t;
@@ -178,6 +179,7 @@ namespace l1ct {
     inline float floatMeanZ(meanz_t meanz) { return meanz + MEANZ_OFFSET; };
     inline float floatHoe(hoe_t hoe) { return hoe.to_float(); };
     inline float floatIDScore(id_score_t score) { return score.to_float(); };
+    inline float floatBtagScore(b_tag_score_t b_tag_score) {return b_tag_score.to_float();}
 
     inline pt_t makePt(int pt) { return ap_ufixed<16, 14>(pt) >> 2; }
     inline dpt_t makeDPt(int dpt) { return ap_fixed<18, 16>(dpt) >> 2; }

--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -43,7 +43,7 @@ namespace l1ct {
   typedef ap_ufixed<10, 5, AP_TRN, AP_SAT> hoe_t;
   typedef ap_uint<4> redChi2Bin_t;
   typedef ap_fixed<10, 1, AP_RND_CONV, AP_SAT> id_score_t;  // ID score to be between -1 (background) and 1 (signal)
-  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t; // result_t from the NN is still apx_fixed<16,6>
+  typedef ap_ufixed<10, 0, AP_RND, AP_SAT> b_tag_score_t; // result_t from the NN is still apx_fixed<16,6>
 
   // FIXME: adjust range 10-11bits -> 1/4 - 1/2TeV is probably more than enough for all reasonable use cases
   typedef ap_ufixed<11, 9, AP_TRN, AP_SAT> iso_t;

--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -43,7 +43,7 @@ namespace l1ct {
   typedef ap_ufixed<10, 5, AP_TRN, AP_SAT> hoe_t;
   typedef ap_uint<4> redChi2Bin_t;
   typedef ap_fixed<10, 1, AP_RND_CONV, AP_SAT> id_score_t;  // ID score to be between -1 (background) and 1 (signal)
-  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t; // result_t from the NN is still apx_fixed<16,6>
+  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t;   // result_t from the NN is still apx_fixed<16,6>
 
   // FIXME: adjust range 10-11bits -> 1/4 - 1/2TeV is probably more than enough for all reasonable use cases
   typedef ap_ufixed<11, 9, AP_TRN, AP_SAT> iso_t;
@@ -179,7 +179,7 @@ namespace l1ct {
     inline float floatMeanZ(meanz_t meanz) { return meanz + MEANZ_OFFSET; };
     inline float floatHoe(hoe_t hoe) { return hoe.to_float(); };
     inline float floatIDScore(id_score_t score) { return score.to_float(); };
-    inline float floatBtagScore(b_tag_score_t b_tag_score) {return b_tag_score.to_float();}
+    inline float floatBtagScore(b_tag_score_t b_tag_score) { return b_tag_score.to_float(); }
 
     inline pt_t makePt(int pt) { return ap_ufixed<16, 14>(pt) >> 2; }
     inline dpt_t makeDPt(int dpt) { return ap_fixed<18, 16>(dpt) >> 2; }

--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -26,7 +26,7 @@ namespace l1gt {
   typedef ap_fixed<14, 14, AP_RND_CONV, AP_SAT> eta_t;
   // While bitwise identical to the l1ct::z0_t value, we store z0 in mm to profit of ap_fixed goodies
   typedef ap_fixed<10, 9, AP_RND_CONV, AP_SAT> z0_t;  // NOTE: mm instead of cm!!!
-  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t;
+  typedef ap_ufixed<10, 0, AP_RND, AP_SAT> b_tag_score_t;
   typedef ap_uint<1> valid_t;
 
   // E/gamma fields

--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -26,7 +26,7 @@ namespace l1gt {
   typedef ap_fixed<14, 14, AP_RND_CONV, AP_SAT> eta_t;
   // While bitwise identical to the l1ct::z0_t value, we store z0 in mm to profit of ap_fixed goodies
   typedef ap_fixed<10, 9, AP_RND_CONV, AP_SAT> z0_t;  // NOTE: mm instead of cm!!!
-  typedef ap_ufixed<10, 0, AP_RND, AP_SAT> b_tag_score_t;
+  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t;
   typedef ap_uint<1> valid_t;
 
   // E/gamma fields

--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -26,6 +26,7 @@ namespace l1gt {
   typedef ap_fixed<14, 14, AP_RND_CONV, AP_SAT> eta_t;
   // While bitwise identical to the l1ct::z0_t value, we store z0 in mm to profit of ap_fixed goodies
   typedef ap_fixed<10, 9, AP_RND_CONV, AP_SAT> z0_t;  // NOTE: mm instead of cm!!!
+  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t;
   typedef ap_uint<1> valid_t;
 
   // E/gamma fields
@@ -86,6 +87,7 @@ namespace l1gt {
     valid_t valid;
     ThreeVector v3;
     z0_t z0;
+    b_tag_score_t hwBtagScore;
 
     inline bool operator==(const Jet &other) const { return valid == other.valid && z0 == other.z0 && v3 == other.v3; }
 
@@ -96,6 +98,7 @@ namespace l1gt {
       pack_into_bits(ret, start, valid);
       pack_into_bits(ret, start, v3.pack());
       pack_into_bits(ret, start, z0);
+      pack_into_bits(ret, start, hwBtagScore);
       return ret;
     }
 
@@ -120,6 +123,7 @@ namespace l1gt {
       unpack_from_bits(src, start, v3.phi);
       unpack_from_bits(src, start, v3.eta);
       unpack_from_bits(src, start, z0);
+      unpack_from_bits(src, start, hwBtagScore);
     }
 
     inline static Jet unpack(const std::array<uint64_t, 2> &src) {

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -13,6 +13,8 @@ namespace l1ct {
     pt_t hwPt;
     glbeta_t hwEta;
     glbphi_t hwPhi;
+    z0_t z0;
+    b_tag_score_t hwBtagScore;
 
     inline bool operator==(const Jet &other) const {
       return hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi;
@@ -25,6 +27,8 @@ namespace l1ct {
       hwPt = 0;
       hwEta = 0;
       hwPhi = 0;
+      z0 = 0;
+      hwBtagScore = 0;
     }
 
     int intPt() const { return Scales::intPt(hwPt); }
@@ -33,14 +37,17 @@ namespace l1ct {
     float floatPt() const { return Scales::floatPt(hwPt); }
     float floatEta() const { return Scales::floatEta(hwEta); }
     float floatPhi() const { return Scales::floatPhi(hwPhi); }
+    float floatBtagScore() const {return Scales::floatBtagScore(hwBtagScore);}
 
-    static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width;
+    static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width + z0_t::width + b_tag_score_t::width;
     inline ap_uint<BITWIDTH> pack_ap() const {
       ap_uint<BITWIDTH> ret;
       unsigned int start = 0;
       pack_into_bits(ret, start, hwPt);
       pack_into_bits(ret, start, hwEta);
       pack_into_bits(ret, start, hwPhi);
+      pack_into_bits(ret, start, z0);
+      pack_into_bits(ret, start, hwBtagScore);
       return ret;
     }
 
@@ -63,6 +70,8 @@ namespace l1ct {
       unpack_from_bits(src, start, hwPt);
       unpack_from_bits(src, start, hwEta);
       unpack_from_bits(src, start, hwPhi);
+      unpack_from_bits(src, start, z0);
+      unpack_from_bits(src, start, hwBtagScore);
     }
 
     inline static Jet unpack(const std::array<uint64_t, 2> &src) {
@@ -83,7 +92,8 @@ namespace l1ct {
       j.v3.pt = CTtoGT_pt(hwPt);
       j.v3.phi = CTtoGT_phi(hwPhi);
       j.v3.eta = CTtoGT_eta(hwEta);
-      j.z0 = 0;
+      j.z0 = z0;
+      j.hwBtagScore = hwBtagScore;
       return j;
     }
   };

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -13,7 +13,7 @@ namespace l1ct {
     pt_t hwPt;
     glbeta_t hwEta;
     glbphi_t hwPhi;
-    z0_t z0;
+    z0_t hwZ0;
     b_tag_score_t hwBtagScore;
 
     inline bool operator==(const Jet &other) const {

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -70,7 +70,7 @@ namespace l1ct {
       unpack_from_bits(src, start, hwPt);
       unpack_from_bits(src, start, hwEta);
       unpack_from_bits(src, start, hwPhi);
-      unpack_from_bits(src, start, z0);
+      unpack_from_bits(src, start, hwZ0);
       unpack_from_bits(src, start, hwBtagScore);
     }
 

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -92,7 +92,7 @@ namespace l1ct {
       j.v3.pt = CTtoGT_pt(hwPt);
       j.v3.phi = CTtoGT_phi(hwPhi);
       j.v3.eta = CTtoGT_eta(hwEta);
-      j.z0 = z0;
+      j.z0(l1ct::z0_t::width - 1, 0) = hwZ0(l1ct::z0_t::width - 1, 0);
       j.hwBtagScore = hwBtagScore;
       return j;
     }

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -37,8 +37,8 @@ namespace l1ct {
     float floatPt() const { return Scales::floatPt(hwPt); }
     float floatEta() const { return Scales::floatEta(hwEta); }
     float floatPhi() const { return Scales::floatPhi(hwPhi); }
-    float floatBtagScore() const {return Scales::floatBtagScore(hwBtagScore);}
-    float floatZ0() const {return Scales::floatZ0(hwZ0); }
+    float floatBtagScore() const { return Scales::floatBtagScore(hwBtagScore); }
+    float floatZ0() const { return Scales::floatZ0(hwZ0); }
 
     static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width + z0_t::width + b_tag_score_t::width;
     inline ap_uint<BITWIDTH> pack_ap() const {

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -46,7 +46,7 @@ namespace l1ct {
       pack_into_bits(ret, start, hwPt);
       pack_into_bits(ret, start, hwEta);
       pack_into_bits(ret, start, hwPhi);
-      pack_into_bits(ret, start, z0);
+      pack_into_bits(ret, start, hwZ0);
       pack_into_bits(ret, start, hwBtagScore);
       return ret;
     }

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -27,7 +27,7 @@ namespace l1ct {
       hwPt = 0;
       hwEta = 0;
       hwPhi = 0;
-      z0 = 0;
+      hwZ0 = 0;
       hwBtagScore = 0;
     }
 

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -38,6 +38,7 @@ namespace l1ct {
     float floatEta() const { return Scales::floatEta(hwEta); }
     float floatPhi() const { return Scales::floatPhi(hwPhi); }
     float floatBtagScore() const {return Scales::floatBtagScore(hwBtagScore);}
+    float floatZ0() const {return Scales::floatZ0(hwZ0); }
 
     static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width + z0_t::width + b_tag_score_t::width;
     inline ap_uint<BITWIDTH> pack_ap() const {


### PR DESCRIPTION
#### PR description:

Modifications of jet types in order to package the btagging scores. 

#### PR validation:

Everything should compiles, I tested this in conjunction with this PR in the hardware development branch: https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/156#note_7488170