### PR TITLE
[Phase 2] Add calo jet and tau to L1 sequence and event content

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -193,6 +193,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tCaloJetHTT_*_*',
         'keep *_l1tNNCaloTauProducer_*_*',
         'keep *_l1tNNCaloTauEmulator_*_*',
+        'keep *_l1tPhase2CaloJetEmulator_*_*',
         'keep *_l1tPFClustersFromL1EGClusters_*_*',
         'keep *_l1tPFClustersFromCombinedCaloHCal_*_*',
         'keep *_l1tPFClustersFromCombinedCaloHF_*_*',

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -102,13 +102,13 @@ l1tTowerCalibration = l1tTowerCalibrationProducer.clone(
   L1HgcalTowersInputTag = ("l1tHGCalTowerProducer","HGCalTowerProcessor",""),
   l1CaloTowers = ("l1tEGammaClusterEmuProducer","L1CaloTowerCollection","")
 )
-# ----    Produce the L1CaloJets
+# ----    Produce the simulated L1CaloJets
 from L1Trigger.L1CaloTrigger.l1tCaloJetProducer_cfi import *
 l1tCaloJet = l1tCaloJetProducer.clone (
     l1CaloTowers = ("l1tTowerCalibration","L1CaloTowerCalibratedCollection",""),
     L1CrystalClustersInputTag = ("l1tEGammaClusterEmuProducer", "","")
 )
-# ----    Produce the CaloJet HTT Sums
+# ----    Produce the simulated CaloJet HTT Sums
 from L1Trigger.L1CaloTrigger.l1tCaloJetHTTProducer_cfi import *
 l1tCaloJetHTT = l1tCaloJetHTTProducer.clone(
     BXVCaloJetsInputTag = ("L1CaloJet", "CaloJets") 
@@ -120,10 +120,14 @@ _phase2_siml1emulator.add(l1tNNCaloTauProducer)
 from L1Trigger.L1CaloTrigger.l1tNNCaloTauEmulator_cfi import *
 _phase2_siml1emulator.add(l1tNNCaloTauEmulator)
 
+# ---- Produce the emulated CaloJets and Taus
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
 
 _phase2_siml1emulator.add(l1tTowerCalibration)
 _phase2_siml1emulator.add(l1tCaloJet)
 _phase2_siml1emulator.add(l1tCaloJetHTT)
+_phase2_siml1emulator.add(l1tPhase2CaloJetEmulator)
+
 
 # ########################################################################
 # Phase-2 L1T - TrackTrigger dependent modules


### PR DESCRIPTION
#### PR description:

Following the PRs introducing the latest GCT calo jet and tau emulators, this PR adds those emulators to the L1 sequence and event content.  I have kept the existing simulated calo jet and tau objects as they are still used for the calo sums, and I am not aware if there is an emulator for those.

#### PR validation:

Checked the collections appear in the output root file

