### PR TITLE
Fix module names in HGCal tower customisation function

### DIFF
--- a/L1Trigger/L1THGCal/python/customTowers.py
+++ b/L1Trigger/L1THGCal/python/customTowers.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
+from L1Trigger.L1THGCal.l1tHGCalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
 import math
 
 def custom_towers_unclustered_tc(process):
@@ -38,7 +38,7 @@ def custom_towers_etaphi(process,
 
 def custom_towers_energySplit(process):
     parameters_towers_2d = L1TTriggerTowerConfig_energySplit.clone()
-    process.hgcalTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
+    process.l1tHGCalTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
     return process
 
 def custom_towers_map(process,


### PR DESCRIPTION
#### PR description:

The module names in the HGCal tower customisation function required by the GCT calo jets/taus #1174  is assuming the old naming convention of the l1t modules.  I assume this customisation isn't used in any test workflow, which is why it's not been noticed before.

#### PR validation:

Successfully run standard L1 cmsDriver command with this customisation function.