### PR TITLE
Phase 2 GTT Fix ptbits z0bits of GTT ObjectWords

### DIFF
--- a/DataFormats/L1Trigger/interface/TkJetWord.h
+++ b/DataFormats/L1Trigger/interface/TkJetWord.h
@@ -134,10 +134,10 @@ namespace l1t {
 
     // These functions return the packed bits in integer format for each quantity
     // Signed quantities have the sign enconded in the left-most bit.
-    unsigned int ptBits() const { return ptWord().to_uint(); }
+    unsigned int ptBits() const { return ptWord().range().to_uint(); }
     unsigned int glbEtaBits() const { return glbEtaWord().to_uint(); }
     unsigned int glbPhiBits() const { return glbPhiWord().to_uint(); }
-    unsigned int z0Bits() const { return z0Word().to_uint(); }
+    unsigned int z0Bits() const { return z0Word().range().to_uint(); }
     unsigned int ntBits() const { return ntWord().to_uint(); }
     unsigned int xtBits() const { return xtWord().to_uint(); }
     unsigned int dispFlagBits() const { return dispFlagWord().to_uint(); }

--- a/DataFormats/L1Trigger/interface/VertexWord.h
+++ b/DataFormats/L1Trigger/interface/VertexWord.h
@@ -145,9 +145,9 @@ namespace l1t {
     // These functions return the packed bits in integer format for each quantity
     // Signed quantities have the sign enconded in the left-most bit.
     unsigned int validBits() const { return validWord().to_uint(); }
-    unsigned int z0Bits() const { return z0Word().to_uint(); }
+    unsigned int z0Bits() const { return z0Word().range().to_uint(); }
     unsigned int multiplicityBits() const { return multiplicityWord().to_uint(); }
-    unsigned int ptBits() const { return ptWord().to_uint(); }
+    unsigned int ptBits() const { return ptWord().range().to_uint(); }
     unsigned int qualityBits() const { return qualityWord().to_uint(); }
     unsigned int inverseMultiplicityBits() const { return inverseMultiplicityWord().to_uint(); }
     unsigned int unassignedBits() const { return unassignedWord().to_uint(); }


### PR DESCRIPTION
#### PR description:

The methods ptBits() and z0Bits() of the TkJetWord.h and VertexWord.h classes attempt to return the bits for ap_(u)fixed datatypes, but the direct call to to_uint() truncated the float bits, leaving only the magnitude bits. These methods were not found to be in use anywhere in CMSSW, except now for adding GTT objects to L1Nano. This fix updates the methods, and they appropriately return all the magnitude + float bits, which enables full agreement in L1Nano for Vertices and TrackJets. scram build updateclassversion does not produce an updated class version/hash (nor direct usage of edmCheckClassVersion -g ...).

#### PR validation:

This PR passes
scram b
scram b code-checks
scram b code-format
scram b updateclassversion
Used to generate GTT objects in L1Nano format for ~3000 events

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR should have a port to master
