### PR TITLE
Fix standalone calo barrel EGamma objects

### DIFF
--- a/DataFormats/L1TCalorimeterPhase2/interface/DigitizedClusterCorrelator.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/DigitizedClusterCorrelator.h
@@ -9,16 +9,26 @@ namespace l1tp2 {
   class DigitizedClusterCorrelator {
   private:
     // Data
-    ap_uint<64> clusterData;
+    unsigned long long int clusterData;
     unsigned int idxGCTCard;  // 0, 1, or 2
 
     // Constants
     static constexpr unsigned int n_towers_eta = 34;  // in GCT card unique region
     static constexpr unsigned int n_towers_phi = 24;  // in GCT card unique region
     static constexpr unsigned int n_crystals_in_tower = 5;
-    static constexpr float LSB_PT = 0.5;                     // 0.5 GeV
+    static constexpr float LSB_PT = 0.5;                 // 0.5 GeV
+    static constexpr float ETA_RANGE_ONE_SIDE = 1.4841;  // barrel goes from (-1.4841, +1.4841)
+    static constexpr float LSB_ETA = ((2 * ETA_RANGE_ONE_SIDE) / (n_towers_eta * n_crystals_in_tower));  // (2.8 / 170)
+    static constexpr float LSB_PHI = ((2 * M_PI) / (3 * n_towers_phi * n_crystals_in_tower));            // (2 pi * 360)
+
     static constexpr unsigned int n_bits_pt = 12;            // 12 bits allocated for pt
-    static constexpr unsigned int n_bits_unused_start = 49;  // unused bits start at bit 49
+    static constexpr unsigned int n_bits_unused_start = 63;  // unused bits start at bit 63
+
+    // "top" of the correlator card #0 in GCT coordinates is iPhi tower index 24
+    static constexpr int correlatorCard0_tower_iphi_offset = 24;
+    // same but for correlator cards #1 and 2 (cards wrap around phi = 180 degrees):
+    static constexpr int correlatorCard1_tower_iphi_offset = 48;
+    static constexpr int correlatorCard2_tower_iphi_offset = 0;
 
     // Private member functions to perform digitization
     ap_uint<12> digitizePt(float pt_f) {
@@ -31,33 +41,16 @@ namespace l1tp2 {
       return (ap_uint<12>)(pt_f / LSB_PT);
     }
 
-    //
-    ap_uint<6> digitizeIEta(unsigned int iEta) {
-      assert(iEta < n_towers_eta);
-      return (ap_uint<6>)iEta;
-    }
+    ap_uint<8> digitizeIEtaCr(unsigned int iEtaCr) { return (ap_uint<8>)iEtaCr; }
 
-    // This is tower iPhi in the unique region of the GCT card, so this only goes from 0-23
-    ap_uint<5> digitizeIPhi(unsigned int iPhi) {
-      assert(iPhi < n_towers_phi);
-      return (ap_uint<5>)iPhi;
-    }
-
-    ap_uint<3> digitizeIEtaCr(unsigned int iEtaCr) {
-      assert(iEtaCr < n_crystals_in_tower);
-      return (ap_uint<3>)iEtaCr;
-    }
-
-    ap_uint<3> digitizeIPhiCr(unsigned int iPhiCr) {
-      assert(iPhiCr < n_crystals_in_tower);
-      return (ap_uint<3>)iPhiCr;
-    }
+    ap_uint<7> digitizeIPhiCr(unsigned int iPhiCr) { return (ap_uint<7>)iPhiCr; }
 
     // To-do: HoE is not defined for clusters
     ap_uint<4> digitizeHoE(unsigned int hoe) { return (ap_uint<4>)hoe; }
+    ap_uint<2> digitizeHoeFlag(unsigned int hoeFlag) { return (ap_uint<2>)hoeFlag; }
 
-    //
-    ap_uint<3> digitizeIso(bool iso) { return (ap_uint<3>)iso; }
+    ap_uint<3> digitizeIso(unsigned int iso) { return (ap_uint<3>)iso; }
+    ap_uint<2> digitizeIsoFlag(unsigned int isoFlag) { return (ap_uint<2>)isoFlag; }
 
     // To-do: fb: no information yet
     ap_uint<6> digitizeFb(unsigned int fb) { return (ap_uint<6>)fb; }
@@ -66,10 +59,10 @@ namespace l1tp2 {
     ap_uint<5> digitizeTiming(unsigned int timing) { return (ap_uint<5>)timing; }
 
     // Shape: shower shape working point
-    ap_uint<1> digitizeShape(bool is_ss) { return (ap_uint<1>)is_ss; }
+    ap_uint<2> digitizeShapeFlag(unsigned int shapeFlag) { return (ap_uint<2>)shapeFlag; }
 
     // TO-DO: Brems: was brems applied (NOT STORED YET IN GCT)
-    ap_uint<1> digitizeBrems(bool brems_applied) { return (ap_uint<1>)brems_applied; }
+    ap_uint<2> digitizeBrems(unsigned int brems) { return (ap_uint<2>)brems; }
 
   public:
     DigitizedClusterCorrelator() { clusterData = 0x0; }
@@ -78,46 +71,45 @@ namespace l1tp2 {
 
     // Constructor from digitized inputs
     DigitizedClusterCorrelator(ap_uint<12> pt,
-                               ap_uint<6> eta,
-                               ap_uint<5> phi,
-                               ap_uint<3> etaCr,
-                               ap_uint<3> phiCr,
+                               ap_uint<8> etaCr,
+                               ap_uint<7> phiCr,
                                ap_uint<4> hoe,
+                               ap_uint<2> hoeFlag,
                                ap_uint<3> iso,
+                               ap_uint<2> isoFlag,
                                ap_uint<6> fb,
                                ap_uint<5> timing,
-                               ap_uint<1> shape,
-                               ap_uint<1> brems,
+                               ap_uint<2> shapeFlag,
+                               ap_uint<2> brems,
                                int iGCTCard,
                                bool fullydigitizedInputs) {
       (void)fullydigitizedInputs;
-
-      clusterData = ((ap_uint<64>)pt) | (((ap_uint<64>)eta) << 12) | (((ap_uint<64>)phi) << 18) |
-                    (((ap_uint<64>)etaCr) << 23) | (((ap_uint<64>)phiCr) << 26) | (((ap_uint<64>)hoe) << 29) |
-                    (((ap_uint<64>)iso << 33)) | (((ap_uint<64>)fb << 36)) | (((ap_uint<64>)timing << 42)) |
-                    (((ap_uint<64>)shape << 47)) | (((ap_uint<64>)brems << 48));
+      clusterData = ((ap_uint<64>)pt) | (((ap_uint<64>)etaCr) << 12) | (((ap_uint<64>)phiCr) << 20) |
+                    (((ap_uint<64>)hoe) << 27) | (((ap_uint<64>)hoeFlag) << 31) | (((ap_uint<64>)iso) << 36) |
+                    (((ap_uint<64>)isoFlag) << 38) | (((ap_uint<64>)fb) << 44) | (((ap_uint<64>)timing) << 49) |
+                    (((ap_uint<64>)shapeFlag << 51)) | (((ap_uint<64>)brems << 53));
       idxGCTCard = iGCTCard;
     }
 
     // Constructor from float inputs
     DigitizedClusterCorrelator(float pt_f,
-                               unsigned int iEta,
-                               unsigned int iPhi,
                                unsigned int iEtaCr,
                                unsigned int iPhiCr,
                                unsigned int hoe,
-                               bool iso,
+                               unsigned int hoeFlag,
+                               unsigned int iso,
+                               unsigned int isoFlag,
                                unsigned int fb,
                                unsigned int timing,
-                               bool shape,
+                               unsigned int shapeFlag,
                                unsigned int brems,
                                int iGCTCard) {
-      clusterData = (((ap_uint<64>)digitizePt(pt_f)) | ((ap_uint<64>)digitizeIEta(iEta) << 12) |
-                     ((ap_uint<64>)digitizeIPhi(iPhi) << 18) | ((ap_uint<64>)digitizeIEtaCr(iEtaCr) << 23) |
-                     ((ap_uint<64>)digitizeIPhiCr(iPhiCr) << 26) | ((ap_uint<64>)digitizeHoE(hoe) << 29) |
-                     ((ap_uint<64>)digitizeIso(iso) << 33) | ((ap_uint<64>)digitizeFb(fb) << 36) |
-                     ((ap_uint<64>)digitizeTiming(timing) << 42) | ((ap_uint<64>)digitizeShape(shape) << 47) |
-                     ((ap_uint<64>)digitizeBrems(brems) << 48));
+      clusterData = (((ap_uint<64>)digitizePt(pt_f)) | ((ap_uint<64>)digitizeIEtaCr(iEtaCr) << 12) |
+                     ((ap_uint<64>)digitizeIPhiCr(iPhiCr) << 20) | ((ap_uint<64>)digitizeHoE(hoe) << 27) |
+                     ((ap_uint<64>)digitizeHoeFlag(hoeFlag) << 31) | ((ap_uint<64>)digitizeIso(iso) << 36) |
+                     ((ap_uint<64>)digitizeIsoFlag(isoFlag) << 38) | ((ap_uint<64>)digitizeFb(fb) << 44) |
+                     ((ap_uint<64>)digitizeTiming(timing) << 49) | ((ap_uint<64>)digitizeShapeFlag(shapeFlag) << 51) |
+                     ((ap_uint<64>)digitizeBrems(brems) << 53));
       idxGCTCard = iGCTCard;
     }
 
@@ -126,22 +118,66 @@ namespace l1tp2 {
     // Other getters
     float ptLSB() const { return LSB_PT; }
     ap_uint<12> pt() const { return (clusterData & 0xFFF); }
-    ap_uint<6> eta() const { return ((clusterData >> 12) & 0x3F); }   // (six 1's) 0b111111 = 0x3F
-    ap_uint<5> phi() const { return ((clusterData >> 18) & 0x1F); }   // (five 1's) 0b11111 = 0x1F
-    ap_uint<3> etaCr() const { return ((clusterData >> 23) & 0x7); }  // (three 1's) 0b111 = 0x7
-    ap_uint<3> phiCr() const { return ((clusterData >> 26) & 0x7); }
-    ap_uint<4> hoe() const { return ((clusterData >> 29) & 0xF); }  // (four 1's) 0b1111 = 0xF
-    ap_uint<3> iso() const { return ((clusterData >> 33) & 0x7); }
-    ap_uint<6> fb() const { return ((clusterData >> 36) & 0x3F); }
-    ap_uint<5> timing() const { return ((clusterData >> 42) & 0x1F); }
-    ap_uint<1> shape() const { return ((clusterData >> 47) & 0x1); }
-    ap_uint<1> brems() const { return ((clusterData >> 48) & 0x1); }
-    unsigned int cardNumber() const { return idxGCTCard; }  // which GCT card (0, 1, or 2)
 
-    const int unusedBitsStart() const { return 49; }  // unused bits start at bit 49
+    // crystal eta in the correlator region (LSB: 2.8/170)
+    ap_uint<8> eta() const { return ((clusterData >> 12) & 0xFF); }  // (eight 1's) 0b11111111 = 0xFF
+
+    // crystal phi in the correlator region (LSB: 2pi/360)
+    ap_uint<7> phi() const { return ((clusterData >> 20) & 0x7F); }  // (seven 1's) 0b1111111 = 0x7F
+
+    // HoE value and flag: not defined yet in the emulator
+    ap_uint<4> hoe() const { return ((clusterData >> 27) & 0xF); }      // (four 1's) 0b1111 = 0xF
+    ap_uint<2> hoeFlag() const { return ((clusterData >> 31) & 0x3); }  // (two 1's) 0b11 = 0x3
+
+    // Raw isolation sum: not saved in the emulator
+    ap_uint<3> iso() const { return ((clusterData >> 36) & 0x7); }
+
+    // iso flag: two bits, least significant bit is the standalone WP (true or false), second bit is the looseTk WP (true or false)
+    // e.g. 0b01 : standalone iso flag passed, loose Tk iso flag did not pass
+    ap_uint<2> isoFlags() const { return ((clusterData >> 38) & 0x3); }  // (two 1's) 0b11 = 0x3
+    bool passes_iso() const { return (isoFlags() & 0x1); }               // standalone iso WP
+    bool passes_looseTkiso() const { return (isoFlags() & 0x2); }        // loose Tk iso WP
+
+    // fb and timing: not saved in the current emulator
+    ap_uint<6> fb() const { return ((clusterData >> 44) & 0x3F); }
+    ap_uint<5> timing() const { return ((clusterData >> 49) & 0x1F); }
+
+    // shower shape shape flag: two bits, least significant bit is the standalone WP, second bit is the looseTk WP
+    // e.g. 0b01 : standalone shower shape flag passed, loose Tk shower shape flag did not pass
+    ap_uint<2> shapeFlags() const { return ((clusterData >> 51) & 0x3); }
+
+    bool passes_ss() const { return (shapeFlags() & 0x1); }         // standalone shower shape WP
+    bool passes_looseTkss() const { return (shapeFlags() & 0x2); }  // loose Tk shower shape WP
+
+    // brems: not saved in the current emulator
+    ap_uint<2> brems() const { return ((clusterData >> 53) & 0x3); }
+
+    // which GCT card (0, 1, or 2)
+    unsigned int cardNumber() const { return idxGCTCard; }
+
+    const int unusedBitsStart() const { return n_bits_unused_start; }
 
     // Other checks
     bool passNullBitsCheck(void) const { return ((data() >> unusedBitsStart()) == 0x0); }
+
+    // Get real eta (does not depend on card number). crystal iEta = 0 starts at real eta -1.4841.
+    float realEta() const { return (float)((-1 * ETA_RANGE_ONE_SIDE) + (eta() * LSB_ETA)); }
+
+    // Get real phi (uses card number).
+    float realPhi() const {
+      // each card starts at a different real phi
+      int offset_tower = 0;
+      if (cardNumber() == 0) {
+        offset_tower = correlatorCard0_tower_iphi_offset;
+      } else if (cardNumber() == 1) {
+        offset_tower = correlatorCard1_tower_iphi_offset;
+      } else if (cardNumber() == 2) {
+        offset_tower = correlatorCard2_tower_iphi_offset;
+      }
+      int thisPhi = (phi() + (offset_tower * n_crystals_in_tower));
+      // crystal iPhi = 0 starts at real phi = -180 degrees
+      return (float)((-1 * M_PI) + (thisPhi * LSB_PHI));
+    }
   };
 
   // Collection typedef

--- a/DataFormats/L1TCalorimeterPhase2/interface/DigitizedClusterGT.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/DigitizedClusterGT.h
@@ -9,7 +9,7 @@ namespace l1tp2 {
   class DigitizedClusterGT {
   private:
     // Data
-    ap_uint<64> clusterData;
+    unsigned long long int clusterData;
 
     // Constants
     static constexpr float LSB_PT = 0.03125;                 // 0.03125 GeV

--- a/DataFormats/L1TCalorimeterPhase2/interface/DigitizedTowerCorrelator.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/DigitizedTowerCorrelator.h
@@ -9,7 +9,7 @@ namespace l1tp2 {
   class DigitizedTowerCorrelator {
   private:
     // Data
-    ap_uint<16> towerData;
+    unsigned int towerData;
     unsigned int idxCard;   // 0, 1, or 2 (there are three GCT cards)
     unsigned int idxFiber;  // 0 to 47 (there are 48 fibers in one GCT card)
     unsigned int idxTower;  // 0 to 16 (there are 17 towers in one fiber)

--- a/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
+++ b/DataFormats/L1TCalorimeterPhase2/src/classes_def.xml
@@ -25,19 +25,22 @@
   <class name="l1tp2::CaloJetsCollection" />
   <class name="edm::Wrapper<l1tp2::CaloJetsCollection>" />
 
-  <class name="l1tp2::DigitizedClusterCorrelator"  ClassVersion="3">
+  <class name="l1tp2::DigitizedClusterCorrelator"  ClassVersion="4">
+   <version ClassVersion="4" checksum="838642806"/>
      <version ClassVersion="3" checksum="1943292648"/>
   </class>
   <class name="l1tp2::DigitizedClusterCorrelatorCollection" />
   <class name="edm::Wrapper<l1tp2::DigitizedClusterCorrelatorCollection>" />
 
-  <class name="l1tp2::DigitizedTowerCorrelator"  ClassVersion="3">
+  <class name="l1tp2::DigitizedTowerCorrelator"  ClassVersion="4">
+   <version ClassVersion="4" checksum="1597735835"/>
        <version ClassVersion="3" checksum="3734711406"/>
   </class>
   <class name="l1tp2::DigitizedTowerCorrelatorCollection" />
   <class name="edm::Wrapper<l1tp2::DigitizedTowerCorrelatorCollection>" />
 
-  <class name="l1tp2::DigitizedClusterGT"  ClassVersion="3">
+  <class name="l1tp2::DigitizedClusterGT"  ClassVersion="4">
+   <version ClassVersion="4" checksum="2603854524"/>
        <version ClassVersion="3" checksum="3611926846"/>
   </class>
   <class name="l1tp2::DigitizedClusterGTCollection" />

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -1015,9 +1015,10 @@ namespace p2eg {
     bool is_iso;
     bool is_looseTkiso;
 
-    unsigned int hoe;     // not defined
-    unsigned int fb;      // not defined
-    unsigned int timing;  // not defined
+    unsigned int hoe;       // not defined
+    unsigned int hoe_flag;  // not defined
+    unsigned int fb;        // not defined
+    unsigned int timing;    // not defined
     ap_uint<2>
         brems;  // 0 if no brems applied, 1 or 2 if brems applied (one for + direction, one for - direction: check firmware)
 
@@ -1067,6 +1068,7 @@ namespace p2eg {
       is_iso = false;         // initialize: no info from RCT, so set it to false
       is_looseTkiso = false;  // initialize: no info from RCT, so set it to false
       hoe = 0;                // initialize: no info from RCT, so set it to null
+      hoe_flag = 0;           // initialize: no info from RCT, so set it to null
       fb = 0;                 // initialize: no info from RCT, so set it to null
       timing = 0;             // initialize: no info from RCT, so set it to null
       brems = rctCluster.brems;
@@ -1245,17 +1247,20 @@ namespace p2eg {
      * unique to each GCT card.
      */
     l1tp2::DigitizedClusterCorrelator createDigitizedClusterCorrelator(const int corrTowPhiOffset) const {
+      std::cout << " Creating digitized cluster correlator with towEta, crEta: " << towEta << ", " << crEta
+                << ", with global crystal iEta " << (towEta * CRYSTALS_IN_TOWER_ETA) + crEta << std::endl;
       return l1tp2::DigitizedClusterCorrelator(
           etFloat(),  // technically we are just multiplying and then dividing again by the LSB
-          towEta,
-          towPhi - corrTowPhiOffset,
-          crEta,
-          crPhi,
+          globalClusteriEta(),
+          ((towPhi - corrTowPhiOffset) * CRYSTALS_IN_TOWER_PHI) +
+              crPhi,  // cannot use globalClusteriPhi() helper function because correlator offset is different than GCT offset
           hoe,
-          is_iso,
+          hoe_flag,
+          iso,
+          (is_iso) | (is_looseTkiso << 1),  // 2 bits: e.g. 0b10 means is_looseTkiso was true, and is_iso was false
           fb,
           timing,
-          is_ss,
+          (is_ss) | (is_looseTkss << 1),  // 2 bits (same as iso flags) is_ss in lowest bit, is_looseTkss in higher bit
           brems,
           nGCTCard);
     }

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -1247,8 +1247,6 @@ namespace p2eg {
      * unique to each GCT card.
      */
     l1tp2::DigitizedClusterCorrelator createDigitizedClusterCorrelator(const int corrTowPhiOffset) const {
-      std::cout << " Creating digitized cluster correlator with towEta, crEta: " << towEta << ", " << crEta
-                << ", with global crystal iEta " << (towEta * CRYSTALS_IN_TOWER_ETA) + crEta << std::endl;
       return l1tp2::DigitizedClusterCorrelator(
           etFloat(),  // technically we are just multiplying and then dividing again by the LSB
           globalClusteriEta(),

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc
@@ -92,10 +92,10 @@ Phase2L1CaloEGammaEmulator::Phase2L1CaloEGammaEmulator(const edm::ParameterSet& 
       calib_(iConfig.getParameter<edm::ParameterSet>("calib")),
       caloGeometryTag_(esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag("", ""))),
       hbTopologyTag_(esConsumes<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag("", ""))) {
-  produces<l1tp2::CaloCrystalClusterCollection>("RCT");
-  produces<l1tp2::CaloCrystalClusterCollection>("GCT");
-  produces<l1tp2::CaloTowerCollection>("RCT");
-  produces<l1tp2::CaloTowerCollection>("GCT");
+  produces<l1tp2::CaloCrystalClusterCollection>("RCTClusters");
+  produces<l1tp2::CaloCrystalClusterCollection>("GCTClusters");
+  produces<l1tp2::CaloTowerCollection>("RCTTowers");
+  produces<l1tp2::CaloTowerCollection>("GCTTowers");
   produces<l1tp2::CaloTowerCollection>("GCTFullTowers");
   produces<BXVector<l1t::EGamma>>("GCTEGammas");
   produces<l1tp2::DigitizedClusterCorrelatorCollection>("GCTDigitizedClusterToCorrelator");
@@ -498,8 +498,8 @@ void Phase2L1CaloEGammaEmulator::produce(edm::Event& iEvent, const edm::EventSet
     }
   }  // end of loop over cards
 
-  iEvent.put(std::move(L1EGXtalClusters), "RCT");
-  iEvent.put(std::move(L1CaloTowers), "RCT");
+  iEvent.put(std::move(L1EGXtalClusters), "RCTClusters");
+  iEvent.put(std::move(L1CaloTowers), "RCTTowers");
 
   //*******************************************************************
   // Do GCT geometry for inputs
@@ -629,8 +629,8 @@ void Phase2L1CaloEGammaEmulator::produce(edm::Event& iEvent, const edm::EventSet
                    calib_);
   }
 
-  iEvent.put(std::move(L1GCTClusters), "GCT");
-  iEvent.put(std::move(L1GCTTowers), "GCT");
+  iEvent.put(std::move(L1GCTClusters), "GCTClusters");
+  iEvent.put(std::move(L1GCTTowers), "GCTTowers");
   iEvent.put(std::move(L1GCTFullTowers), "GCTFullTowers");
   iEvent.put(std::move(L1GCTEGammas), "GCTEGammas");
   iEvent.put(std::move(L1DigitizedClusterCorrelator), "GCTDigitizedClusterToCorrelator");


### PR DESCRIPTION
#### PR description:

This PR implements the following fixes and requests for the Phase-2 Calo standalone EGamma objects in the barrel emulator:

1. Using built-in unsigned integer types for the data member(s) of the digitized collections, instead of `ap_uint` types which was causing issues (see https://github.com/cms-sw/cmssw/pull/43872)
2. Changed label names of output objects to avoid duplicates: see [this commit diff](https://github.com/skkwan/cmssw/commit/a68ce53cd8912fa9b49fd442b481e232932107a3).
3. Updated the definitions of the `DigitizedClusterCorrelator` data format to match the latest specifications, including the working points for isolation and shower shape, with standalone and `looseTk` of each (four flags in total). For convenience, added methods to get these flags.
4. Also added methods in `DigitizedClusterCorrelator` to get the real eta and phi, `realEta()` and `realPhi()`.
5. Fixed a bug in the `DigitizedClusterCorrelator` initialization where the crystal `eta` convention was incorrect.

#### PR validation:

The following checks were performed:

1. Checked that digitizing error is gone, when `process.schedule = cms.Schedule(process.pL1EG, process.end)` and `keep *` are used in conjunction
2. Checked in an event that the `DigitizedClusterCorrelator` and `DigitizedClusterGT` give the same leading clusters (pT, eta, phi, working points in the case of the correlator clusters) as the `l1tp2::CaloTowerCollection` clusters.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)


