### PR TITLE
Produce and use custom HGCal towers for baseline GCT calo jets and taus.

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -175,6 +175,8 @@ def _appendPhase2Digis(obj):
         'keep *_l1tHGCalBackEndLayer2Producer_*_*',
         'keep *_l1tHGCalTowerMapProducer_*_*',
         'keep *_l1tHGCalTowerProducer_*_*',
+        'keep *_l1tHGCalEnergySplitTowerMapProducer_*_*',
+        'keep *_l1tHGCalEnergySplitTowerProducer_*_*',
         'keep *_l1tEGammaClusterEmuProducer_*_*',
         'keep *_l1tVertexFinder_*_*',
         'keep *_l1tVertexFinderEmulator_*_*',

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -121,12 +121,12 @@ from L1Trigger.L1CaloTrigger.l1tNNCaloTauEmulator_cfi import *
 _phase2_siml1emulator.add(l1tNNCaloTauEmulator)
 
 # ---- Produce the emulated CaloJets and Taus
-from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cff import *
 
 _phase2_siml1emulator.add(l1tTowerCalibration)
 _phase2_siml1emulator.add(l1tCaloJet)
 _phase2_siml1emulator.add(l1tCaloJetHTT)
-_phase2_siml1emulator.add(l1tPhase2CaloJetEmulator)
+_phase2_siml1emulator.add(L1TCaloJetsTausTask)
 
 # Overlap and EndCap Muon Track Finder
 # ########################################################################

--- a/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
@@ -13,7 +13,7 @@ l1tHGCalEnergySplitTowerProducer = l1tHGCalTowerProducer.clone( InputTowerMaps =
 L1THGCalEnergySplitTowersTask = cms.Task(l1tHGCalEnergySplitTowerMapProducer, l1tHGCalEnergySplitTowerProducer)
 
 # Use energy split towers in calo jet/tau emulator
-l1tPhase2CaloJetEmulator.hgcalTowers.hgcalTowers = ("l1tHGCalEnergySplitTowerProducer","HGCalTowerProcessor")
+l1tPhase2CaloJetEmulator.hgcalTowers = ("l1tHGCalEnergySplitTowerProducer","HGCalTowerProcessor")
 
 L1TCaloJetsTausTask = cms.Task(
     L1THGCalEnergySplitTowersTask,

--- a/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
@@ -1,0 +1,21 @@
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
+
+from L1Trigger.L1THGCal.l1tHGCalTowerMapProducer_cfi import *
+from L1Trigger.L1THGCal.l1tHGCalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
+from L1Trigger.L1THGCal.l1tHGCalTowerProducer_cfi import *
+
+# Add HGCal tower producers for energy split towers
+# Based on custom_towers_energySplit in L1Trigger/L1THGCal/python/customTowers.py
+parameters_towers_2d = L1TTriggerTowerConfig_energySplit.clone()
+l1tHGCalEnergySplitTowerMapProducer = l1tHGCalTowerMapProducer.clone()
+l1tHGCalEnergySplitTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
+l1tHGCalEnergySplitTowerProducer = l1tHGCalTowerProducer.clone( InputTowerMaps = ("l1tHGCalEnergySplitTowerMapProducer","HGCalTowerMapProcessor") )
+L1THGCalEnergySplitTowersTask = cms.Task(l1tHGCalEnergySplitTowerMapProducer, l1tHGCalEnergySplitTowerProducer)
+
+# Use energy split towers in calo jet/tau emulator
+l1tPhase2CaloJetEmulator.hgcalTowers.hgcalTowers = ("l1tHGCalEnergySplitTowerProducer","HGCalTowerProcessor")
+
+L1TCaloJetsTausTask = cms.Task(
+    L1THGCalEnergySplitTowersTask,
+    l1tPhase2CaloJetEmulator
+)


### PR DESCRIPTION
#### PR description:

This PR adds the production of the non-default energy split HGCal towers for use by the baseline GCT jets and taus.  The GCT NN Calo Tau algorithm still uses the default towers.

I've marked it as draft as I still need to check the performance of the GCT objects look as expected with this change.  However I wanted to start the review of the code (i.e. check what I have done is acceptable) in parallel to the physics validation given the urgency.

#### PR validation:

Ran the L1 sequence for the v5 recipe.  Performance validation ongoing.

@pallabidas can you and Victor also check this PR?  Perhaps we can merge this PR with the update of the GCT calibrations when going to master?
