### PR TITLE
L1TrackVertexAssociationProducer bug fix to stop accessing data after move

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -563,6 +563,13 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
     }      //end if (processEmulatedTracks_)
   }        //end loop over input converted tracks
 
+  if (processSimulatedTracks_ && processEmulatedTracks_ && debug_ >= 2) {
+    printDebugInfo(l1SelectedTracksHandle,
+                   l1SelectedTracksEmulationHandle,
+                   vTTTrackAssociatedOutput,
+                   vTTTrackAssociatedEmulationOutput);
+  }
+
   if (processSimulatedTracks_) {
     iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
   }
@@ -573,12 +580,6 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
       linkLimitSelEmu.log();
   }
 
-  if (processSimulatedTracks_ && processEmulatedTracks_ && debug_ >= 2) {
-    printDebugInfo(l1SelectedTracksHandle,
-                   l1SelectedTracksEmulationHandle,
-                   vTTTrackAssociatedOutput,
-                   vTTTrackAssociatedEmulationOutput);
-  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -579,7 +579,6 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
     if (debug_ >= 2)
       linkLimitSelEmu.log();
   }
-
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------


### PR DESCRIPTION
#### PR description:

Currently when running `L1TrackVertexAssociationProducer` with a debug level of 2 or more the code will crash with a segfault as it is trying to access data in `vTTTrackAssociatedOutput` and `vTTTrackAssociatedEmulationOutput` which had just been moved in the preceding lines.

#### PR validation:

After moving the printDebugInfo command to before the move commands the module will run without crashing.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will need to be made to master too.