### PR TITLE
Phase 2 GTT fix null options for loading from buffers in F/W workflow

### DIFF
--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -53,10 +53,10 @@ for filePath in options.inputFiles:
         filePath = filePath.replace("/", ".")
         inputFilesImport = getattr(__import__(filePath.strip(".py"),fromlist=["readFiles"]),"readFiles")
         inputFiles.extend( inputFilesImport )
-        if options.vertices:
+        if options.vertices in ['load', 'overwrite']:
             inputBuffersImport = getattr(__import__(filePath.strip(".py"),fromlist=["correlator_source"]),"correlator_source").fileNames
             inputBuffers.extend( inputBuffersImport )
-        if options.tracks:
+        if options.tracks in ['load', 'overwrite']:
             inputTrackBuffersImport = getattr(__import__(filePath.strip(".py"),fromlist=["track_source"]),"track_source").fileNames
             inputTrackBuffers.extend( inputTrackBuffersImport )
     else:


### PR DESCRIPTION
#### PR description:
This PR fixes cases when no options to load tracks or vertices from buffers is specified in the GTT F/W workflow and the input file does not contain lists of buffers to load from 

This does not affect nominal workflows pertaining to AR; but this is also not time-sensitive and can be deferred in review as needed.

#### PR validation:

scram b {code-checks, code-format, ""}
~trivial change, no compiled code is affected
cmsRun createFirmwareInputFiles_cfg.py maxEvents=200 format=APx inputFiles=... works without specifying (tracks|vertices)=X where X is load, donotload, overwrite 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This will require a forward-port to master as well