### PR TITLE
OMTF configuration fix to use phase-2 values

### DIFF
--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -132,7 +132,8 @@ _phase2_siml1emulator.add(L1TCaloJetsTausTask)
 # ########################################################################
 from L1Trigger.L1TMuonOverlapPhase2.fakeOmtfParamsPhase2_cff import *
 from L1Trigger.L1TMuonOverlapPhase2.simOmtfPhase2Digis_extrapol_cfi import *
-_phase2_siml1emulator.add(omtfConfigurationPhase2)
+#_phase2_siml1emulator.add(omtfParamsSource)
+_phase2_siml1emulator.add(omtfParamsPhase2)
 _phase2_siml1emulator.add(simOmtfPhase2Digis)
 
 from L1Trigger.L1TMuonEndCapPhase2.simCscTriggerPrimitiveDigisForEMTF_cfi import *

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -130,7 +130,9 @@ _phase2_siml1emulator.add(L1TCaloJetsTausTask)
 
 # Overlap and EndCap Muon Track Finder
 # ########################################################################
-from L1Trigger.L1TMuonOverlapPhase2.simOmtfPhase2Digis_cfi import *
+from L1Trigger.L1TMuonOverlapPhase2.fakeOmtfParamsPhase2_cff import *
+from L1Trigger.L1TMuonOverlapPhase2.simOmtfPhase2Digis_extrapol_cfi import *
+_phase2_siml1emulator.add(omtfConfigurationPhase2)
 _phase2_siml1emulator.add(simOmtfPhase2Digis)
 
 from L1Trigger.L1TMuonEndCapPhase2.simCscTriggerPrimitiveDigisForEMTF_cfi import *

--- a/L1Trigger/L1TMuonOverlapPhase2/python/fakeOmtfParamsPhase2_cff.py
+++ b/L1Trigger/L1TMuonOverlapPhase2/python/fakeOmtfParamsPhase2_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+omtfParamsSource = cms.ESSource(
+    "EmptyESSource",
+    recordName = cms.string('L1TMuonOverlapParamsRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+###OMTF ESProducer. Fills CondFormats from XML files.
+omtfParamsPhase2 = cms.ESProducer(
+    "L1TMuonOverlapPhase1ParamsESProducer",
+    patternsXMLFiles = cms.VPSet(
+        cms.PSet(patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_ExtraplMB1nadMB2DTQualAndEtaFixedP_ValueP1Scale_t20_v1_SingleMu_iPt_and_OneOverPt_classProb17_recalib2_minDP0.xml")),
+    ),
+    configXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer_0x0209.xml"),
+)
+
+
+omtfConfigurationPhase2=cms.Task(omtfParamsSource, omtfParamsPhase2)

--- a/L1Trigger/L1TMuonOverlapPhase2/python/fakeOmtfParamsPhase2_cff.py
+++ b/L1Trigger/L1TMuonOverlapPhase2/python/fakeOmtfParamsPhase2_cff.py
@@ -15,6 +15,3 @@ omtfParamsPhase2 = cms.ESProducer(
     ),
     configXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer_0x0209.xml"),
 )
-
-
-omtfConfigurationPhase2=cms.Task(omtfParamsSource, omtfParamsPhase2)

--- a/L1Trigger/L1TMuonOverlapPhase2/python/simOmtfPhase2Digis_extrapol_cfi.py
+++ b/L1Trigger/L1TMuonOverlapPhase2/python/simOmtfPhase2Digis_extrapol_cfi.py
@@ -45,6 +45,9 @@ simOmtfPhase2Digis = cms.EDProducer("L1TMuonOverlapPhase2TrackProducer",
   useStubQualInExtr  = cms.bool(True),
   useEndcapStubsRInExtr  = cms.bool(True),
   useFloatingPointExtrapolation  = cms.bool(False),
+
+  ##  XML / PATTERNS file:
+  patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_ExtraplMB1nadMB2DTQualAndEtaFixedP_ValueP1Scale_t20_v1_SingleMu_iPt_and_OneOverPt_classProb17_recalib2_minDP0.xml"),
   extrapolFactorsFilename = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/ExtrapolationFactors_ExtraplMB1nadMB2DTQual_ValueP1Scale_t20.xml"),
   
   sorterType = cms.string("byLLH"),

--- a/L1Trigger/L1TMuonOverlapPhase2/python/simOmtfPhase2Digis_extrapol_cfi.py
+++ b/L1Trigger/L1TMuonOverlapPhase2/python/simOmtfPhase2Digis_extrapol_cfi.py
@@ -8,7 +8,8 @@ simOmtfPhase2Digis = cms.EDProducer("L1TMuonOverlapPhase2TrackProducer",
   srcCSC = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
   srcRPC = cms.InputTag('simMuonRPCDigis'), 
   srcDTPhPhase2 = cms.InputTag('dtTriggerPhase2PrimitiveDigis'),
-  
+  srcDTThPhase2 = cms.InputTag('dtTriggerPhase2PrimitiveDigis'),
+
   dumpResultToXML = cms.bool(False),
   dumpDetailedResultToXML = cms.bool(False),
   XMLDumpFileName = cms.string("TestEvents.xml"),                                     

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -161,14 +161,14 @@ SAMuon Phase2L1TGMTFwdMuonTranslator::Convertl1tMuon(const l1t::RegionalMuonCand
   if (isDisplaced && mu.hwPtUnconstrained() > 0)
     pt = round(mu.hwPtUnconstrained() * 1.0 / LSBpt);  // Phase-1 LSB 1.0GeV!!
 
-  // BEWARE: THIS CONVERSION IS ONLY VALID FOR OMTF  
+  // BEWARE: THIS CONVERSION IS ONLY VALID FOR OMTF
   constexpr double p1phiLSB = 2 * M_PI / 576;
   // From the uGMTConfiguration of OMTF. OMTF send in local phi!!
   // all others correspond to 120 degree sectors = 192 in int-scale
-  int globPhi = mu.processor() *192 + mu.hwPhi(); 
+  int globPhi = mu.processor() * 192 + mu.hwPhi();
   // first processor starts at CMS phi = 15 degrees (24 in int)... Handle wrap-around with %. Add 576 to make sure the number is positive
   globPhi = (globPhi + 600) % 576;
-  ap_int<BITSGTPHI> phi = round(globPhi* p1phiLSB / LSBphi);  // Phase-1 LSB (2*pi/576)
+  ap_int<BITSGTPHI> phi = round(globPhi * p1phiLSB / LSBphi);  // Phase-1 LSB (2*pi/576)
 
   ap_int<BITSGTETA> eta = round(mu.hwEta() * 0.010875 / LSBeta);  // Phase-1 LSB 0.010875
 

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -161,10 +161,11 @@ SAMuon Phase2L1TGMTFwdMuonTranslator::Convertl1tMuon(const l1t::RegionalMuonCand
   if (isDisplaced && mu.hwPtUnconstrained() > 0)
     pt = round(mu.hwPtUnconstrained() * 1.0 / LSBpt);  // Phase-1 LSB 1.0GeV!!
 
+  // BEWARE: THIS CONVERSION IS ONLY VALID FOR OMTF  
   constexpr double p1phiLSB = 2 * M_PI / 576;
   // From the uGMTConfiguration of OMTF. OMTF send in local phi!!
-  // all others correspond to 60 degree sectors = 96 in int-scale
-  int globPhi = mu.processor() *96 + mu.hwPhi();
+  // all others correspond to 120 degree sectors = 192 in int-scale
+  int globPhi = mu.processor() *192 + mu.hwPhi(); 
   // first processor starts at CMS phi = 15 degrees (24 in int)... Handle wrap-around with %. Add 576 to make sure the number is positive
   globPhi = (globPhi + 600) % 576;
   ap_int<BITSGTPHI> phi = round(globPhi* p1phiLSB / LSBphi);  // Phase-1 LSB (2*pi/576)

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -100,19 +100,19 @@ void Phase2L1TGMTFwdMuonTranslator::produce(edm::Event& iEvent, const edm::Event
     // Since OMTF is using Phase-1 LSB, will convert to SAMuon locally
     // We should move to passing words in future
     l1t::SAMuon samuon;
-    if (mu.hwPt() > 0)
+    if (mu.hwPt() > 0) {
       samuon = Convertl1tMuon(mu, 0);
-    else if (mu.hwPtUnconstrained() > 0)  //Assume exculsive, need double check
-      samuon = Convertl1tMuon(mu, 0, true);
-
-    //now associate the stubs
-    associateStubs(samuon, stubs);
-
-    // Add To Collections
-    if (mu.hwPt() > 0)
+      //now associate the stubs
+      associateStubs(samuon, stubs);
       prompt.push_back(samuon);
-    else if (mu.hwPtUnconstrained() > 0)
+    }
+    if (mu.hwPtUnconstrained() > 0)  //Assume exculsive, need double check
+    {
+      samuon = Convertl1tMuon(mu, 0, true);
+      //now associate the stubs
+      associateStubs(samuon, stubs);
       displaced.push_back(samuon);
+    }
   }
 
   // Convert EMTF++ Tracks to SAMuons

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -106,7 +106,7 @@ void Phase2L1TGMTFwdMuonTranslator::produce(edm::Event& iEvent, const edm::Event
       associateStubs(samuon, stubs);
       prompt.push_back(samuon);
     }
-    if (mu.hwPtUnconstrained() > 0)  //Assume exculsive, need double check
+    if (mu.hwPtUnconstrained() > 0)  
     {
       samuon = Convertl1tMuon(mu, 0, true);
       //now associate the stubs


### PR DESCRIPTION
#### PR description:

This contains the required config files to load the correct OMTF configuration for Phase-2. This is built on top of #1241 and it requires https://github.com/cms-data/L1Trigger-L1TMuon/pull/27 to be merged and downloaded inside L1Trigger/L1TMuon/data/omtf_data 

#### PR validation:

First quick look at efficiencies look OK: https://folguera.web.cern.ch/L1T/2024_04_AR_Tests/V36nano_muons_test/object_performance/turnons/MuonTFsMatching_Eta_Pt15toInf_-999_V36nano_muons.png

