### PR TITLE
Implemented Quality Definition for EMTF++&GMT 

### DIFF
--- a/DataFormats/L1TMuonPhase2/interface/EMTFTrack.h
+++ b/DataFormats/L1TMuonPhase2/interface/EMTFTrack.h
@@ -41,6 +41,7 @@ namespace l1t::phase2 {
     void setEmtfBeta(int32_t aEmtfBeta) { emtf_beta_ = aEmtfBeta; }
     void setEmtfModeV1(int16_t aEmtfModeV1) { emtf_mode_v1_ = aEmtfModeV1; }
     void setEmtfModeV2(int16_t aEmtfModeV2) { emtf_mode_v2_ = aEmtfModeV2; }
+    void setEmtfQuality(int16_t aEmtfQuality) { emtf_quality_ = aEmtfQuality; }
 
     void setSiteHits(const site_hits_t& aSiteHits) { site_hits_ = aSiteHits; }
     void setSiteSegs(const site_segs_t& aSiteSegs) { site_segs_ = aSiteSegs; }
@@ -71,6 +72,7 @@ namespace l1t::phase2 {
     int32_t emtfBeta() const { return emtf_beta_; }
     int16_t emtfModeV1() const { return emtf_mode_v1_; }
     int16_t emtfModeV2() const { return emtf_mode_v2_; }
+    int16_t emtfQuality() const { return emtf_quality_; }
 
     const site_hits_t& siteHits() const { return site_hits_; }
     const site_segs_t& siteSegs() const { return site_segs_; }
@@ -101,6 +103,7 @@ namespace l1t::phase2 {
     int32_t emtf_beta_;
     int16_t emtf_mode_v1_;
     int16_t emtf_mode_v2_;
+    int16_t emtf_quality_;
 
     site_hits_t site_hits_;
     site_segs_t site_segs_;

--- a/DataFormats/L1TMuonPhase2/src/classes_def.xml
+++ b/DataFormats/L1TMuonPhase2/src/classes_def.xml
@@ -40,8 +40,9 @@
     </class>
     <class name="l1t::phase2::EMTFHitCollection"/>
     <class name="edm::Wrapper<l1t::phase2::EMTFHitCollection>"/>
-    <class name="l1t::phase2::EMTFTrack" ClassVersion="3">
+    <class name="l1t::phase2::EMTFTrack" ClassVersion="4">
       <version ClassVersion="3" checksum="972508279"/>
+      <version ClassVersion="4" checksum="3868553580"/>
     </class>
     <class name="l1t::phase2::EMTFTrackCollection"/>
     <class name="edm::Wrapper<l1t::phase2::EMTFTrackCollection>"/>

--- a/L1Trigger/L1TMuonEndCapPhase2/interface/Algo/OutputLayer.h
+++ b/L1Trigger/L1TMuonEndCapPhase2/interface/Algo/OutputLayer.h
@@ -34,6 +34,8 @@ namespace emtf::phase2::algo {
     int findEMTFModeV1(const track_t::site_mask_t&) const;
 
     int findEMTFModeV2(const track_t::site_mask_t&) const;
+
+    int findEMTFQuality(const track_t&, const int&, const int&) const;
   };
 
 }  // namespace emtf::phase2::algo

--- a/L1Trigger/L1TMuonEndCapPhase2/src/Algo/OutputLayer.cc
+++ b/L1Trigger/L1TMuonEndCapPhase2/src/Algo/OutputLayer.cc
@@ -69,6 +69,7 @@ void OutputLayer::apply(const int& endcap,
     // Find EMTF/GMT variables
     const int emtf_mode_v1 = findEMTFModeV1(track.site_mask);
     const int emtf_mode_v2 = findEMTFModeV2(track.site_mask);
+    const int emtf_quality = findEMTFQuality(track, emtf_mode_v1, emtf_mode_v2);
 
     // Init Parameters
     auto& out_trk = out_tracks.emplace_back();
@@ -96,6 +97,7 @@ void OutputLayer::apply(const int& endcap,
     out_trk.setEmtfBeta(0);  // not yet implemented
     out_trk.setEmtfModeV1(emtf_mode_v1);
     out_trk.setEmtfModeV2(emtf_mode_v2);
+    out_trk.setEmtfQuality(emtf_quality);
 
     out_trk.setSiteHits(site_hits);
     out_trk.setSiteSegs(site_segs);
@@ -221,3 +223,85 @@ int OutputLayer::findEMTFModeV2(const track_t::site_mask_t& x) const {
 
   return mode;
 }
+
+int OutputLayer::findEMTFQuality(const track_t& track, const int& mode_v1, const int& mode_v2) const {
+    // Short-Circuit: Invalid track
+    if (track.valid == 0) {
+        return 0;
+    }
+
+    // Short-Circuit: Single Station
+    bool is_single_station = (mode_v1 == 0);
+    is_single_station |= (mode_v1 == 1);
+    is_single_station |= (mode_v1 == 2);
+    is_single_station |= (mode_v1 == 4);
+    is_single_station |= (mode_v1 == 8);
+
+    if (is_single_station) {
+        return 0;
+    }
+
+    // Calculate Quality Based on ModeV2
+    if (mode_v2 == 0) {
+        // Single Hit
+        if ((0 <= track.quality) && (track.quality <= 3)) {
+            return 1;
+        } else if ((4 <= track.quality) && (track.quality <= 7)) {
+            return 2;
+        } else if (7 < track.quality) {
+            return 3;
+        }
+
+        return 0;
+    } else if (mode_v2 == 4) {
+        // Triple Muon Quality 
+        if ((8 <= track.quality) && (track.quality <= 11)) {
+            return 5;
+        } else if ((12 <= track.quality) && (track.quality <= 15)) {
+            return 6;
+        } else if (15 < track.quality) {
+            return 7;
+        }
+
+        return 4;
+    } else if (mode_v2 == 8) {
+        // Double Muon Quality 
+        bool valid_mode = (mode_v1 == 9);
+        valid_mode |= (mode_v1 == 10);
+        valid_mode |= (mode_v1 == 12);
+
+        if (valid_mode) {
+            if ((16 <= track.quality) && (track.quality <= 23)) {
+                return 9;
+            } else if ((24 <= track.quality) && (track.quality <= 31)) {
+                return 10;
+            } else if (31 < track.quality) {
+                return 11;
+            }
+        }
+
+        return 8;
+    } else if (mode_v2 == 12) {
+        // Single Muon Quality 
+        bool valid_mode = (mode_v1 == 11);
+        valid_mode |= (mode_v1 == 13);
+        valid_mode |= (mode_v1 == 14);
+        valid_mode |= (mode_v1 == 15);
+
+        if (valid_mode) {
+            if ((32 <= track.quality) && (track.quality <= 39)) {
+                return 13;
+            } else if ((40 <= track.quality) && (track.quality <= 51)) {
+                return 14;
+            } else if (51 < track.quality) {
+                return 15;
+            }
+        }
+
+        return 12;
+    }
+
+    // Invalid track
+    return 0;
+}
+

--- a/L1Trigger/L1TMuonEndCapPhase2/src/Algo/OutputLayer.cc
+++ b/L1Trigger/L1TMuonEndCapPhase2/src/Algo/OutputLayer.cc
@@ -225,83 +225,82 @@ int OutputLayer::findEMTFModeV2(const track_t::site_mask_t& x) const {
 }
 
 int OutputLayer::findEMTFQuality(const track_t& track, const int& mode_v1, const int& mode_v2) const {
-    // Short-Circuit: Invalid track
-    if (track.valid == 0) {
-        return 0;
-    }
-
-    // Short-Circuit: Single Station
-    bool is_single_station = (mode_v1 == 0);
-    is_single_station |= (mode_v1 == 1);
-    is_single_station |= (mode_v1 == 2);
-    is_single_station |= (mode_v1 == 4);
-    is_single_station |= (mode_v1 == 8);
-
-    if (is_single_station) {
-        return 0;
-    }
-
-    // Calculate Quality Based on ModeV2
-    if (mode_v2 == 0) {
-        // Single Hit
-        if ((0 <= track.quality) && (track.quality <= 3)) {
-            return 1;
-        } else if ((4 <= track.quality) && (track.quality <= 7)) {
-            return 2;
-        } else if (7 < track.quality) {
-            return 3;
-        }
-
-        return 0;
-    } else if (mode_v2 == 4) {
-        // Triple Muon Quality 
-        if ((8 <= track.quality) && (track.quality <= 11)) {
-            return 5;
-        } else if ((12 <= track.quality) && (track.quality <= 15)) {
-            return 6;
-        } else if (15 < track.quality) {
-            return 7;
-        }
-
-        return 4;
-    } else if (mode_v2 == 8) {
-        // Double Muon Quality 
-        bool valid_mode = (mode_v1 == 9);
-        valid_mode |= (mode_v1 == 10);
-        valid_mode |= (mode_v1 == 12);
-
-        if (valid_mode) {
-            if ((16 <= track.quality) && (track.quality <= 23)) {
-                return 9;
-            } else if ((24 <= track.quality) && (track.quality <= 31)) {
-                return 10;
-            } else if (31 < track.quality) {
-                return 11;
-            }
-        }
-
-        return 8;
-    } else if (mode_v2 == 12) {
-        // Single Muon Quality 
-        bool valid_mode = (mode_v1 == 11);
-        valid_mode |= (mode_v1 == 13);
-        valid_mode |= (mode_v1 == 14);
-        valid_mode |= (mode_v1 == 15);
-
-        if (valid_mode) {
-            if ((32 <= track.quality) && (track.quality <= 39)) {
-                return 13;
-            } else if ((40 <= track.quality) && (track.quality <= 51)) {
-                return 14;
-            } else if (51 < track.quality) {
-                return 15;
-            }
-        }
-
-        return 12;
-    }
-
-    // Invalid track
+  // Short-Circuit: Invalid track
+  if (track.valid == 0) {
     return 0;
-}
+  }
 
+  // Short-Circuit: Single Station
+  bool is_single_station = (mode_v1 == 0);
+  is_single_station |= (mode_v1 == 1);
+  is_single_station |= (mode_v1 == 2);
+  is_single_station |= (mode_v1 == 4);
+  is_single_station |= (mode_v1 == 8);
+
+  if (is_single_station) {
+    return 0;
+  }
+
+  // Calculate Quality Based on ModeV2
+  if (mode_v2 == 0) {
+    // Single Hit
+    if ((0 <= track.quality) && (track.quality <= 3)) {
+      return 1;
+    } else if ((4 <= track.quality) && (track.quality <= 7)) {
+      return 2;
+    } else if (7 < track.quality) {
+      return 3;
+    }
+
+    return 0;
+  } else if (mode_v2 == 4) {
+    // Triple Muon Quality
+    if ((8 <= track.quality) && (track.quality <= 11)) {
+      return 5;
+    } else if ((12 <= track.quality) && (track.quality <= 15)) {
+      return 6;
+    } else if (15 < track.quality) {
+      return 7;
+    }
+
+    return 4;
+  } else if (mode_v2 == 8) {
+    // Double Muon Quality
+    bool valid_mode = (mode_v1 == 9);
+    valid_mode |= (mode_v1 == 10);
+    valid_mode |= (mode_v1 == 12);
+
+    if (valid_mode) {
+      if ((16 <= track.quality) && (track.quality <= 23)) {
+        return 9;
+      } else if ((24 <= track.quality) && (track.quality <= 31)) {
+        return 10;
+      } else if (31 < track.quality) {
+        return 11;
+      }
+    }
+
+    return 8;
+  } else if (mode_v2 == 12) {
+    // Single Muon Quality
+    bool valid_mode = (mode_v1 == 11);
+    valid_mode |= (mode_v1 == 13);
+    valid_mode |= (mode_v1 == 14);
+    valid_mode |= (mode_v1 == 15);
+
+    if (valid_mode) {
+      if ((32 <= track.quality) && (track.quality <= 39)) {
+        return 13;
+      } else if ((40 <= track.quality) && (track.quality <= 51)) {
+        return 14;
+      } else if (51 < track.quality) {
+        return 15;
+      }
+    }
+
+    return 12;
+  }
+
+  // Invalid track
+  return 0;
+}

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -123,6 +123,10 @@ void Phase2L1TGMTFwdMuonTranslator::produce(edm::Event& iEvent, const edm::Event
       continue;
     }
 
+    if (track.emtfRels() != 127) {
+      continue;
+    }
+
     auto samuon = ConvertEMTFTrack(track, 0);
 
     // Skip qual == 0 EMTF tracks
@@ -235,7 +239,7 @@ void Phase2L1TGMTFwdMuonTranslator::associateStubs(l1t::SAMuon& mu, const l1t::M
 SAMuon Phase2L1TGMTFwdMuonTranslator::ConvertEMTFTrack(const l1t::phase2::EMTFTrack& track, const int bx_) {
   // Convert EMTF Phi and Theta to Global Phi and Eta
   float track_phi =
-      emtf::phase2::tp::calcPhiGlobRadFromLoc(track.sector(), emtf::phase2::tp::calcPhiLocDegFromInt(track.modelPhi()));
+      emtf::phase2::tp::calcPhiGlobRadFromLoc(track.sector(), emtf::phase2::tp::calcPhiLocRadFromInt(track.modelPhi()));
   float track_theta = emtf::phase2::tp::calcThetaRadFromInt(track.modelEta());
   float track_eta = -1 * std::log(std::tan(track_theta / 2));
 
@@ -247,7 +251,7 @@ SAMuon Phase2L1TGMTFwdMuonTranslator::ConvertEMTFTrack(const l1t::phase2::EMTFTr
   math::PtEtaPhiMLorentzVector p4(track.emtfPt() * LSBpt, track_eta, track_phi, 0.0);
 
   // Quantize Values
-  ap_uint<BITSSAQUAL> qual = track.emtfModeV2();  // Not sure how this should be handled; using mode for now
+  ap_uint<BITSSAQUAL> qual = track.emtfQuality();  // Quality provided by EMTF to GMT
   int charge = track.emtfQ();                     // EMTF uses the same convention
   ap_uint<BITSGTPT> pt = track.emtfPt();          // Quantized by EMTF in the same units
   ap_int<BITSGTPHI> phi = round(track_phi / LSBphi);

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -252,8 +252,8 @@ SAMuon Phase2L1TGMTFwdMuonTranslator::ConvertEMTFTrack(const l1t::phase2::EMTFTr
 
   // Quantize Values
   ap_uint<BITSSAQUAL> qual = track.emtfQuality();  // Quality provided by EMTF to GMT
-  int charge = track.emtfQ();                     // EMTF uses the same convention
-  ap_uint<BITSGTPT> pt = track.emtfPt();          // Quantized by EMTF in the same units
+  int charge = track.emtfQ();                      // EMTF uses the same convention
+  ap_uint<BITSGTPT> pt = track.emtfPt();           // Quantized by EMTF in the same units
   ap_int<BITSGTPHI> phi = round(track_phi / LSBphi);
   ap_int<BITSGTETA> eta = round(track_eta / LSBeta);
   ap_int<BITSSAZ0> z0 = track.emtfZ0();  // Quantized by EMTF in the same units

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTFwdMuonTranslator.cc
@@ -119,19 +119,22 @@ void Phase2L1TGMTFwdMuonTranslator::produce(edm::Event& iEvent, const edm::Event
   for (unsigned int track_id = 0; track_id < emtf_tracks->size(); ++track_id) {
     const auto& track = emtf_tracks->at(track_id);
 
+    // Short-Circuit: Only keep valid tracks that are in BX=0
     if ((track.valid() == 0) || (track.bx() != 0)) {
       continue;
     }
 
+    // Short-Circuit: Only keep tracks with quality above 3 to avoid single hit tracks
+    if (track.emtfQuality() <= 3) {
+      continue;
+    }
+
+    // Short-Circuit: Only keep tracks with the max relevance score (127)
     if (track.emtfRels() != 127) {
       continue;
     }
 
     auto samuon = ConvertEMTFTrack(track, 0);
-
-    // Skip qual == 0 EMTF tracks
-    if (samuon.hwQual() == 0)
-      continue;
 
     //now associate the stubs
     associateStubs(samuon, stubs);


### PR DESCRIPTION
This PR implements the following features:
- GMT Quality definition for EMTF++
- Bug fix for incorrect phi values found by Zhenbin
- Uses the EMTF Relevance Score to mitigate rate @ 200 PU.

I believe this bit of code is urgent for the trigger annual review.