### PR TITLE
ntuplemaker fixes

### DIFF
--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -1819,14 +1819,14 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trkjetemExt_ntracks->clear();
       m_trkjetemExt_nxtracks->clear();
     }
-
-    m_pv_L1reco->clear();
-    m_pv_L1reco_sum->clear();
-    m_pv_L1reco_emu->clear();
-    m_pv_L1reco_sum_emu->clear();
-    m_pv_MC->clear();
-    m_MC_lep->clear();
   }
+
+  m_pv_L1reco->clear();
+  m_pv_L1reco_sum->clear();
+  m_pv_L1reco_emu->clear();
+  m_pv_L1reco_sum_emu->clear();
+  m_pv_MC->clear();
+  m_MC_lep->clear();
 
   // -----------------------------------------------------------------------------------------------
   // retrieve various containers

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -126,7 +126,6 @@ if runVtxNN:
     VertexAssociator = process.l1tTrackVertexNNAssociationProducer
     AssociationName = "l1tTrackVertexNNAssociationProducer"
 else:
-    process.l1tVertexFinderEmulator = process.l1tVertexProducer.clone()
     VertexAssociator = process.l1tTrackVertexAssociationProducer
     AssociationName = "l1tTrackVertexAssociationProducer"
     

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -128,7 +128,6 @@ if runVtxNN:
     AssociationName = "l1tTrackVertexNNAssociationProducer"
 else:
     process.l1tVertexFinderEmulator = process.l1tVertexProducer.clone()
-    process.l1tVertexFinderEmulator.VertexReconstruction.Algorithm = "FHEmulation"
     VertexAssociator = process.l1tTrackVertexAssociationProducer
     AssociationName = "l1tTrackVertexAssociationProducer"
     

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -13,7 +13,7 @@ L1TRK_INST ="MyL1TrackJets" ### if not in input DIGRAW then we make them in the 
 process = cms.Process(L1TRK_INST)
 
 #L1TRKALGO = 'HYBRID'  #baseline, 4par fit
-# L1TRKALGO = 'HYBRID_DISPLACED'  #extended, 5par fit
+#L1TRKALGO = 'HYBRID_DISPLACED'  #extended, 5par fit
 L1TRKALGO = 'HYBRID_PROMPTANDDISP'
 
 DISPLACED = ''
@@ -150,6 +150,7 @@ if (L1TRKALGO == 'HYBRID'):
     process.pTkMETEmu = cms.Path(process.l1tTrackerEmuEtMiss)
     process.pTkMHT = cms.Path(process.l1tTrackerHTMiss)
     process.pTkMHTEmulator = cms.Path(process.l1tTrackerEmuHTMiss)
+    process.pL1TrackTripletEmulator = cms.Path(process.l1tTrackTripletEmulation)
     DISPLACED = 'Prompt'
 
 # HYBRID: extended tracking

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -45,8 +45,7 @@ process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(0) # default: 0
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 
 readFiles = cms.untracked.vstring(
-                              'file:/eos/cms/store/cmst3/group/l1tr/gpetrucc/prod125X/WTo3Pion_pythia8_PU200/WTo3Pion_pythia8_PU200.batch3.job99.root'
-#                                  '/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/130X_mcRun4_realistic_v2_2026D95noPU-v1/00000/16f6615d-f98c-475f-ad33-0e89934b6c7f.root'
+    '/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/1cc5c14c-5bae-4e68-a369-04e230788660.root'
 )
 secFiles = cms.untracked.vstring()
 


### PR DESCRIPTION
#### PR description:

This PR will fix a couple of bugs to the ntuplemaker:
1. The vertex variables are not being cleared when SaveTrackJets is false because the clearing is in the wrong place. This is fixed by moving it outside of the boolean.
2. The vertexing algorithm name when not running the NN does not reference anything so it's default to the fasthisto algo. Theoretically it should be fasthisto so the hard coded name in the config was removed as fasthisto is already default.
3. The current default file is not available. It has been replaced with a TT file that is accessible.
4. The HYBRID method needs a process.pL1TrackTripletEmulator to run so it has now been set.


