### PR TITLE
Set track word before running TQ MVA

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -739,7 +739,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     aTrack.setStubPtConsistency(
         StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
 
-    // set TTTrack word
+    // set track word before TQ MVA calculated which uses track word variables
     aTrack.setTrackWordBits();
 
     if (trackQuality_) {
@@ -751,6 +751,8 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     //      trackQualityModel_->setBonusFeatures(hph.bonusFeatures());
     //    }
 
+    // set track word again to set MVA variable from TTTrack into track word
+    aTrack.setTrackWordBits();
     // test track word
     //aTrack.testTrackWordBits();
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -739,6 +739,9 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     aTrack.setStubPtConsistency(
         StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
 
+    // set TTTrack word
+    aTrack.setTrackWordBits();
+
     if (trackQuality_) {
       trackQualityModel_->setL1TrackQuality(aTrack);
     }
@@ -748,8 +751,6 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     //      trackQualityModel_->setBonusFeatures(hph.bonusFeatures());
     //    }
 
-    // set TTTrack word
-    aTrack.setTrackWordBits();
     // test track word
     //aTrack.testTrackWordBits();
 


### PR DESCRIPTION
#### PR description:

The TQ MVA variable is currently outputting useless information starting in CMSSW 14X because the inputs to the MVA take in some of the track word information which has been changed to be set after the MVA is calculated. Therefore, the MVA is getting inputs of 0 for the track word variables. The fix simply moves the setting of the track word to before the TQ MVA calculation again, while also having a setting after the MVA calculation to set the MVA variable in the track word.

This fix will also need to be made in central CMSSW as the bug can also be found there.

Note: It is perhaps not the most elegant solution to set the track word both before and after the MVA calculation. This current fix should be implemented ASAP as many GTT objects rely on the MVA and so they currently are getting a wrong value and it's probably hurting performance. I am chatting with the L1Tk group to discuss having a separate setter for the MVA variables in the TTTrack and track word classes and will implement that solution when we have decided what is best.

#### PR validation:

All code checks have been run and the fix gives the desired behavior.
